### PR TITLE
Fix fresh-install build failure (TS2688 'Cannot find type definition file for bun') — 0.10.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to Collie are recorded here. The format follows
 `version` in `herdr-plugin.toml`, `package.json`, and `web/package.json` (enforced by
 `scripts/check-version.sh`). See [`CLAUDE.md`](./CLAUDE.md) → *Versioning* for the bump policy.
 
+## [0.10.3] - 2026-07-12
+
+### Fixed
+- `collie-ctl.sh build` installs the root dependency tree (not just `web/`) before typechecking, so a fresh Herdr install no longer fails with TS2688 "Cannot find type definition file for 'bun'" (03f409f, #9)
+
 ## [0.10.2] - 2026-07-12
 
 ### Fixed

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,6 +1,6 @@
 id = "herdr.collie"
 name = "Collie"
-version = "0.10.2"
+version = "0.10.3"
 min_herdr_version = "0.7.0"
 description = "Mobile web UI to monitor and reply to your agent herd, served over Tailscale"
 platforms = ["linux", "macos"]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "collie",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "private": true,
   "license": "MIT",
   "description": "Collie — a mobile web UI to monitor and reply to your Herdr agent herd over Tailscale",

--- a/scripts/collie-ctl.sh
+++ b/scripts/collie-ctl.sh
@@ -55,6 +55,12 @@ cmd_build() {
   if [ "${SKIP_VERSION_CHECK:-}" != "1" ]; then
     bash "${PLUGIN_ROOT}/scripts/check-version.sh"
   fi
+  # Install BOTH dependency trees before typechecking. The root typecheck (tsconfig `types: ["bun"]`)
+  # resolves @types/bun from the ROOT node_modules; a fresh Herdr checkout ships neither tree, so
+  # without a root install the very first build dies with TS2688 "Cannot find type definition file
+  # for 'bun'" and Herdr rolls the install back (issue #9). It works on the dev host only because a
+  # manual `bun install` left root node_modules behind.
+  ( cd "${PLUGIN_ROOT}" && "$BUN" install )
   ( cd "${PLUGIN_ROOT}/web" && "$BUN" install )
   # Typecheck BOTH sides before building — the Vite build itself does not typecheck, so a type
   # error would otherwise ship silently. Skip with SKIP_TYPECHECK=1 (same hatch as the pre-push hook).

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "collie-web",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "private": true,
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Problem

A fresh `herdr plugin install AltanS/collie` fails at the build step (reported in #9):

\`\`\`
$ bunx tsc --noEmit
error TS2688: Cannot find type definition file for 'bun'.
\`\`\`

Herdr then rolls the install back → `plugin_not_found`.

## Root cause

`cmd_build` in `scripts/collie-ctl.sh` ran `bun install` **only in `web/`**, then ran the **root** typecheck whose `tsconfig.json` declares `"types": ["bun"]`. A fresh checkout has no root `node_modules`, so `@types/bun` can't be resolved → `TS2688`. It only built on the dev host because a manual `bun install` had left root `node_modules` behind.

## Fix

Install the root dependency tree before typechecking (03f409f):

\`\`\`bash
( cd "${PLUGIN_ROOT}" && "$BUN" install )
( cd "${PLUGIN_ROOT}/web" && "$BUN" install )
\`\`\`

## Verification

Reproduced and verified in an isolated **detached git worktree** (clean checkout, no root `node_modules`), never touching the running instance:

- **Before:** `TS2688`, exit 1 — identical to the issue.
- **After:** root install pulls `@types/bun@1.3.14`, both typechecks pass, Vite builds, exit 0, `web/dist` present.
- Re-verified the full shippable 0.10.3 state builds from scratch.

Full test suite green (168 backend + 566 web).

Version bumped 0.10.2 → 0.10.3 across the three manifests + CHANGELOG; `check-version.sh` ✓.

Fixes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)