### PR TITLE
feat: add COLLIE_SKIP_SERVE to bypass tailscale serve

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,10 @@ COLLIE_HOST=127.0.0.1
 # (plain HTTP on :$COLLIE_PORT — for Headscale / `.internal` domains without HTTPS certs; then set
 # COLLIE_PUBLIC_HOSTS below, and note PWA install + Web Push need a secure context).
 # COLLIE_SERVE_MODE=https
+# Skip tailscale serve entirely (set to 1 when using a reverse proxy like Caddy/Nginx).
+# The bridge stays on 127.0.0.1 only — your proxy handles TLS, auth, and public access.
+# With this enabled, set COLLIE_ALLOWED_ORIGINS and COLLIE_PUBLIC_HOSTS to match your proxy's hostname.
+# COLLIE_SKIP_SERVE=1
 
 # --- Herdr connection ---
 # Usually injected by the systemd unit; override only if your socket is elsewhere.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to Collie are recorded here. The format follows
 `version` in `herdr-plugin.toml`, `package.json`, and `web/package.json` (enforced by
 `scripts/check-version.sh`). See [`CLAUDE.md`](./CLAUDE.md) → *Versioning* for the bump policy.
 
+## [0.12.0] - 2026-07-17
+
+### Added
+- `COLLIE_SKIP_SERVE=1` env var to disable tailscale serve entirely — bridge stays on loopback only, ideal for deployments behind a reverse proxy (Caddy, Nginx, etc.)
+
 ## [0.11.0] - 2026-07-15
 
 ### Added

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,6 +1,6 @@
 id = "herdr.collie"
 name = "Collie"
-version = "0.11.0"
+version = "0.12.0"
 min_herdr_version = "0.7.0"
 description = "Mobile web UI to monitor and reply to your agent herd, served over Tailscale"
 platforms = ["linux", "macos"]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "collie",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "private": true,
   "license": "MIT",
   "description": "Collie — a mobile web UI to monitor and reply to your Herdr agent herd over Tailscale",

--- a/scripts/collie-ctl.sh
+++ b/scripts/collie-ctl.sh
@@ -149,7 +149,11 @@ print_status_banner() {
   fi
   echo "    service   ${svc}"
   echo "    local     http://127.0.0.1:${PORT}"
-  echo "    tailnet   $(bridge_url)"
+  if [ "${COLLIE_SKIP_SERVE:-}" = "1" ]; then
+    echo "    proxy     (COLLIE_SKIP_SERVE=1 — use your reverse proxy)"
+  else
+    echo "    tailnet   $(bridge_url)"
+  fi
   echo
 }
 
@@ -270,6 +274,10 @@ cmd_apply_update() {
 }
 
 cmd_serve() {
+  if [ "${COLLIE_SKIP_SERVE:-}" = "1" ]; then
+    echo "tailscale serve skipped (COLLIE_SKIP_SERVE=1) — bridge is on 127.0.0.1:${PORT} only"
+    return
+  fi
   command -v tailscale >/dev/null || { echo "note: tailscale not found; bridge is on 127.0.0.1:${PORT} only"; return; }
   local out="${CONFIG_DIR}/serve.out"
   if [ "$SERVE_MODE" = "http" ]; then
@@ -293,6 +301,10 @@ cmd_serve() {
 # https:443 by default, or http:$PORT in http mode. Best-effort (|| true) so teardown is idempotent
 # when the mapping is already gone.
 cmd_unserve() {
+  if [ "${COLLIE_SKIP_SERVE:-}" = "1" ]; then
+    echo "tailscale serve skipped (COLLIE_SKIP_SERVE=1) — nothing to unserve"
+    return
+  fi
   command -v tailscale >/dev/null || { echo "note: tailscale not found; no serve mapping to remove"; return; }
   if [ "$SERVE_MODE" = "http" ]; then
     tailscale serve --http="$PORT" off >/dev/null 2>&1 || true
@@ -305,7 +317,11 @@ cmd_unserve() {
 
 cmd_status() {
   print_status_banner
-  echo "  serve config:"; tailscale serve status 2>/dev/null | sed 's/^/    /' || true
+  if [ "${COLLIE_SKIP_SERVE:-}" = "1" ]; then
+    echo "  serve config: skipped (COLLIE_SKIP_SERVE=1)"
+  else
+    echo "  serve config:"; tailscale serve status 2>/dev/null | sed 's/^/    /' || true
+  fi
 }
 
 cmd_logs() {

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "collie-web",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "private": true,
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Summary

Adds `COLLIE_SKIP_SERVE=1` env var to skip `tailscale serve` entirely. The bridge stays on loopback only (or `0.0.0.0` if `COLLIE_HOST` is set), ideal for deployments behind a reverse proxy (Caddy, Nginx, etc.) or direct port access via MagicDNS.

## Changes

- `scripts/collie-ctl.sh`: `cmd_serve()`, `cmd_unserve()`, `cmd_status()`, and `print_status_banner()` all respect `COLLIE_SKIP_SERVE=1`
- `.env.example`: documents the new variable
- Version bumped to 0.12.0 (minor)

## Use case

When running Collie behind Caddy/Nginx or accessing directly via `http://host:port`, there's no need for `tailscale serve` — your proxy handles TLS, auth, and public access. This avoids the bridge fighting over the tailscale serve mapping.