### PR TITLE
feat: long-press pane actions (rename/close) + busy bar on slow polls

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -107,6 +107,10 @@ Product details that shaped the loop:
   races.
 - **Close the trust loop.** A "Sent" state on the `POST`'s HTTP response, then the visible
   blocked→working transition. Without it, latency makes users double-tap.
+- **Manage a pane in place.** Long-pressing a pane pill in the tab's pane switcher opens a small
+  actions sheet — rename it (the label then leads its cards/headers) or close it. Both are the same
+  `pane.rename` / `pane.close` writes the security posture already covers
+  (`web/src/components/pane-actions-sheet.tsx`).
 
 **Known gap — the notification body doesn't carry the question.** The design called for putting the
 agent's question *in* the notification, so a tap is actionable even before the app loads (§7 explains

--- a/HERDR_API.md
+++ b/HERDR_API.md
@@ -104,9 +104,14 @@ Three sibling RPCs set a display label on a workspace, tab, or pane. Live-verifi
   `event` field is snake_case on the stream, as everywhere).
 - **Errors:** an unknown id → `{code:"pane_not_found" | "tab_not_found" | "workspace_not_found",
   message:"<kind> <id> not found"}`.
-- **No length limit; empty string accepted** (stored as-is on tab/workspace). Collie itself maps a
-  blank pane label to `null` before sending, so an empty "Save" clears — a Collie choice, not a Herdr
-  rule; see `bridge/server.ts`.
+- **No length limit; empty string accepted** (stored as-is on tab/workspace). Re-verified on
+  `tab.rename` 2026-07-19: `label:""` is stored **literally** (the tab's label becomes empty — it does
+  **not** reset to the default number), and `label:null` is rejected with
+  ``{code:"invalid_request", message:"invalid request: invalid type: null, expected a string"}`` —
+  confirming tabs/workspaces have **no "clear"** (only `pane.rename` clears, via `null`). Collie makes
+  its own opposite choices per object: a blank pane "Save" clears (blank → `null`), while a blank tab
+  "Save" is refused client- and bridge-side, since a literal-empty tab chip is useless. See
+  `bridge/server.ts` (`normalizeTabLabel`).
 - **Undocumented field:** once set, a pane's label rides along as **`label?: string`** in `pane.list`,
   `pane.get`, `pane.current`, and `session.snapshot` panes (omitted when unset — so it's absent from
   the base pane shape below). Workspaces already expose `label`; tabs likewise.

--- a/HERDR_API.md
+++ b/HERDR_API.md
@@ -86,6 +86,34 @@ against a real pane). Empirically enumerated against Herdr 0.7.0 — it is **NOT
   e.g. `{keys:["Down","Enter"]}`.
 - Re-checked against 0.7.2's bundled schema: unchanged.
 
+## Rename methods — set an object's label (verified)
+
+Three sibling RPCs set a display label on a workspace, tab, or pane. Live-verified 2026-07-18.
+
+| Method | Params | `label` | Returns (`result.type`) | Event |
+|---|---|---|---|---|
+| `pane.rename` | `{pane_id, label}` | `string \| null` — **null clears** | `pane_info` → `{pane}` | **none** |
+| `tab.rename` | `{tab_id, label}` | `string` (non-null) | `tab_info` → `{tab}` | `tab_renamed` |
+| `workspace.rename` | `{workspace_id, label}` | `string` (non-null) | `workspace_info` → `{workspace}` | `workspace_renamed` |
+
+- **`pane.rename` is the odd one out, twice over.** Its `label` accepts `null`, which **clears** the
+  label (the `label` key then disappears from the pane record); the sibling two take a non-null
+  string. And it emits **NO event** — a renamed pane surfaces only on the next `session.snapshot` /
+  `pane.list` poll. `tab.rename` / `workspace.rename` DO emit: `tab_renamed` →
+  `{type, tab_id, workspace_id, label}`, `workspace_renamed` → `{type, workspace_id, label}` (the
+  `event` field is snake_case on the stream, as everywhere).
+- **Errors:** an unknown id → `{code:"pane_not_found" | "tab_not_found" | "workspace_not_found",
+  message:"<kind> <id> not found"}`.
+- **No length limit; empty string accepted** (stored as-is on tab/workspace). Collie itself maps a
+  blank pane label to `null` before sending, so an empty "Save" clears — a Collie choice, not a Herdr
+  rule; see `bridge/server.ts`.
+- **Undocumented field:** once set, a pane's label rides along as **`label?: string`** in `pane.list`,
+  `pane.get`, `pane.current`, and `session.snapshot` panes (omitted when unset — so it's absent from
+  the base pane shape below). Workspaces already expose `label`; tabs likewise.
+- **`agent.rename` `{target, name}`** also exists in the schema, but it is a DIFFERENT operation
+  (renames an agent session, not a pane/tab/workspace) — **unverified and unwired by Collie**. Listed
+  only so it isn't mistaken for the label renames above.
+
 ## Object shapes (observed)
 
 ```jsonc

--- a/HERDR_API.md
+++ b/HERDR_API.md
@@ -119,6 +119,25 @@ Three sibling RPCs set a display label on a workspace, tab, or pane. Live-verifi
   (renames an agent session, not a pane/tab/workspace) — **unverified and unwired by Collie**. Listed
   only so it isn't mistaken for the label renames above.
 
+## Close methods — kill a pane or a whole tab (verified)
+
+Two sibling structural ops remove panes. `tab.close` live-verified 2026-07-19 on the sandbox session.
+
+| Method | Params | Returns (`result.type`) | Event | Error (unknown id) |
+|---|---|---|---|---|
+| `pane.close` | `{pane_id}` | `ok` | `pane.closed` | `pane_not_found` |
+| `tab.close` | `{tab_id}` (schema: `TabTarget`) | `ok` | `tab.closed` | `tab_not_found` |
+
+- **`tab.close` is a BULK pane-close: closing a tab terminates EVERY pane inside it.** Verified by
+  creating a throwaway tab holding a plain shell pane, then `tab.close {tab_id}` — the next
+  `session.snapshot` no longer lists the tab **or** its inner pane. So it's no more privileged than
+  closing those panes one-by-one (which `pane.close` already allows) — same remote-shell threat model.
+- **Success is a bare `{"result":{"type":"ok"}}`** (same shape as `pane.close`), not a record reply
+  like the renames — there's nothing left to describe. The closure surfaces on the next snapshot poll;
+  `tab.close` also emits a `tab_closed` event (which Collie doesn't consume).
+- **Errors:** unknown id → `{code:"tab_not_found", message:"tab <id> not found"}`; a missing `tab_id`
+  → ``{code:"invalid_request", message:"invalid request: missing field `tab_id` …"}``.
+
 ## Object shapes (observed)
 
 ```jsonc

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ serving a Vite + React + shadcn PWA.
 https://github.com/user-attachments/assets/6334eab2-d503-4cfe-b770-80c4517e9482
 
 A run through the herd from a phone: the dashboard floats the agent that **needs you** to the top,
-you drill into a space's tabs and panes (long-press a pane pill to rename or close it, or a tab chip
-to rename it — and a Claude pane shows the name you gave it with `/rename`), switch between herds, and pick up a push
+you drill into a space's tabs and panes (long-press a pane pill or a tab chip to rename or close it —
+and a Claude pane shows the name you gave it with `/rename`), switch between herds, and pick up a push
 notification the moment an agent is waiting on input.
 
 <table>

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ serving a Vite + React + shadcn PWA.
 https://github.com/user-attachments/assets/6334eab2-d503-4cfe-b770-80c4517e9482
 
 A run through the herd from a phone: the dashboard floats the agent that **needs you** to the top,
-you drill into a space's tabs and panes (long-press a pane pill to rename or close it — and a Claude
-pane shows the name you gave it with `/rename`), switch between herds, and pick up a push
+you drill into a space's tabs and panes (long-press a pane pill to rename or close it, or a tab chip
+to rename it — and a Claude pane shows the name you gave it with `/rename`), switch between herds, and pick up a push
 notification the moment an agent is waiting on input.
 
 <table>

--- a/README.md
+++ b/README.md
@@ -35,8 +35,9 @@ serving a Vite + React + shadcn PWA.
 https://github.com/user-attachments/assets/6334eab2-d503-4cfe-b770-80c4517e9482
 
 A run through the herd from a phone: the dashboard floats the agent that **needs you** to the top,
-you drill into a space's tabs and panes (long-press a pane pill to rename or close it), switch
-between herds, and pick up a push notification the moment an agent is waiting on input.
+you drill into a space's tabs and panes (long-press a pane pill to rename or close it — and a Claude
+pane shows the name you gave it with `/rename`), switch between herds, and pick up a push
+notification the moment an agent is waiting on input.
 
 <table>
   <tr>

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ serving a Vite + React + shadcn PWA.
 https://github.com/user-attachments/assets/6334eab2-d503-4cfe-b770-80c4517e9482
 
 A run through the herd from a phone: the dashboard floats the agent that **needs you** to the top,
-you drill into a space's tabs and panes, switch between herds, and pick up a push notification the
-moment an agent is waiting on input.
+you drill into a space's tabs and panes (long-press a pane pill to rename or close it), switch
+between herds, and pick up a push notification the moment an agent is waiting on input.
 
 <table>
   <tr>

--- a/bridge/herdr-client.ts
+++ b/bridge/herdr-client.ts
@@ -397,6 +397,16 @@ export class HerdrClient {
     return this.request<void>("tab.rename", { tab_id: tabId, label });
   }
 
+  /**
+   * Close a tab, terminating EVERY pane inside it (live-verified 2026-07-19: the tab's shell/agent
+   * panes all disappear with it — closing a tab is a bulk pane-close). Resolves on herdr's
+   * `{type:"ok"}` reply; the closure surfaces on the next `session.snapshot` poll (tab.close also
+   * emits a `tab_closed` event, which Collie doesn't consume). Bad id → `tab_not_found`.
+   */
+  closeTab(tabId: string): Promise<void> {
+    return this.request<void>("tab.close", { tab_id: tabId });
+  }
+
   /** Reachability check for the connected/disconnected banner. */
   async ping(): Promise<boolean> {
     try {

--- a/bridge/herdr-client.ts
+++ b/bridge/herdr-client.ts
@@ -386,6 +386,17 @@ export class HerdrClient {
     return this.request<void>("pane.rename", { pane_id: paneId, label });
   }
 
+  /**
+   * Set a tab's label. Unlike {@link renamePane}, `label` is a NON-null string: herdr's `tab.rename`
+   * rejects `null` (`invalid type: null, expected a string`) and stores an empty string literally
+   * rather than clearing to the default number — both live-verified 2026-07-19 — so a tab has no
+   * "clear". Resolves on herdr's `tab_info` reply; the new label surfaces on the next snapshot poll
+   * (tab.rename also emits a `tab_renamed` event, which Collie doesn't consume). Bad id → `tab_not_found`.
+   */
+  renameTab(tabId: string, label: string): Promise<void> {
+    return this.request<void>("tab.rename", { tab_id: tabId, label });
+  }
+
   /** Reachability check for the connected/disconnected banner. */
   async ping(): Promise<boolean> {
     try {

--- a/bridge/herdr-client.ts
+++ b/bridge/herdr-client.ts
@@ -44,6 +44,9 @@ interface WirePane {
   foreground_cwd?: string;
   agent?: string | null;
   agent_status: AgentStatus;
+  /** User-set pane label (herdr `pane.rename`). Present only once set — the key disappears when
+   *  cleared with `label: null`, so absent/null both read as "no label". */
+  label?: string | null;
   revision: number;
   /** Scroll position (herdr ≥ 0.7.2); optional so older servers that omit it still typecheck. Unused for now. */
   scroll?: {
@@ -372,6 +375,15 @@ export class HerdrClient {
   /** Close a pane, terminating its agent ("kill"). Resolves on Herdr's `{type:"ok"}` reply. */
   closePane(paneId: string): Promise<void> {
     return this.request<void>("pane.close", { pane_id: paneId });
+  }
+
+  /**
+   * Set or clear a pane's label. `label: null` clears it (the key then disappears from pane
+   * records). Resolves on Herdr's `pane_info` reply — the returned pane isn't consumed here, the
+   * next snapshot poll carries the new label (pane.rename emits no event). Bad id → `pane_not_found`.
+   */
+  renamePane(paneId: string, label: string | null): Promise<void> {
+    return this.request<void>("pane.rename", { pane_id: paneId, label });
   }
 
   /** Reachability check for the connected/disconnected banner. */

--- a/bridge/server.test.ts
+++ b/bridge/server.test.ts
@@ -4,6 +4,7 @@ import {
   checkAccess,
   deviceAuth,
   isHostAllowed,
+  normalizeTabLabel,
   paneReadResponse,
   resolveStaticPath,
   sendReplySteps,
@@ -428,5 +429,25 @@ describe("startupWarnings — security-posture nags", () => {
   test("populated publicHosts: no Host-validation warning", () => {
     const ws = startupWarnings(cfg({ publicHosts: ["collie.example.ts.net"] }));
     expect(has(ws, "COLLIE_PUBLIC_HOSTS")).toBe(false);
+  });
+});
+
+// A tab's label is a non-null, non-empty string (herdr rejects null and stores "" literally — no
+// "clear" for a tab, unlike a pane). normalizeTabLabel is the gate that enforces that before the RPC.
+describe("normalizeTabLabel", () => {
+  test("accepts a non-empty string, trimming surrounding whitespace", () => {
+    expect(normalizeTabLabel("deploy")).toEqual({ ok: true, label: "deploy" });
+    expect(normalizeTabLabel("  deploy  ")).toEqual({ ok: true, label: "deploy" });
+  });
+
+  test("rejects a blank label (empty or whitespace-only) — a tab has no clear", () => {
+    expect(normalizeTabLabel("")).toEqual({ ok: false, error: "label required" });
+    expect(normalizeTabLabel("   ")).toEqual({ ok: false, error: "label required" });
+  });
+
+  test("rejects a non-string label (null / number / missing)", () => {
+    expect(normalizeTabLabel(null)).toEqual({ ok: false, error: "bad label" });
+    expect(normalizeTabLabel(42)).toEqual({ ok: false, error: "bad label" });
+    expect(normalizeTabLabel(undefined)).toEqual({ ok: false, error: "bad label" });
   });
 });

--- a/bridge/server.ts
+++ b/bridge/server.ts
@@ -76,7 +76,7 @@ const SECURITY_HEADERS: Record<string, string> = {
 // (or a co-located proxy) can reach the bridge's port, so a loopback caller is the on-host operator.
 const LOOPBACK_HOST = /^(localhost|127\.0\.0\.1|\[::1\])(:\d+)?$/;
 
-const PANE_ROUTE = /^\/api\/pane\/([^/]+)(?:\/(reply|keys|upload|close))?$/;
+const PANE_ROUTE = /^\/api\/pane\/([^/]+)(?:\/(reply|keys|upload|close|rename))?$/;
 
 export function startServer(opts: {
   cfg: Config;
@@ -169,6 +169,7 @@ export function startServer(opts: {
         if (action === "keys" && req.method === "POST") return keysPane(herdr, paneId, req, audit, device, session);
         if (action === "upload" && req.method === "POST") return uploadPane(cfg, paneId, req, audit, device, session);
         if (action === "close" && req.method === "POST") return closePane(herdr, paneId, req, audit, device, session);
+        if (action === "rename" && req.method === "POST") return renamePane(herdr, paneId, req, audit, device, session);
         return text("method not allowed", 405);
       }
 
@@ -487,6 +488,37 @@ async function closePane(
   try {
     await herdr.closePane(paneId);
     audit.record({ action: "pane.close", paneId, session, device, detail: {} });
+    return json({ ok: true } satisfies ActionResponse, ae);
+  } catch (err) {
+    return json({ ok: false, error: (err as Error).message } satisfies ActionResponse, ae);
+  }
+}
+
+// Set or clear a pane's label. Structural metadata op — strictly less powerful than the text/keys
+// injection the bridge already allows, so it stays within the existing remote-shell threat model.
+// The body's `label` must be a string or null; a blank string clears (so a user can wipe a label by
+// saving an empty field), which we send to Herdr as `label: null`.
+async function renamePane(
+  herdr: HerdrClient,
+  paneId: string,
+  req: Request,
+  audit: AuditLog,
+  device: string | null,
+  session: string,
+): Promise<Response> {
+  const ae = req.headers.get("accept-encoding");
+  let body: { label?: unknown };
+  try {
+    body = (await req.json()) as typeof body;
+  } catch {
+    return text("bad body", 400);
+  }
+  if (body.label !== null && typeof body.label !== "string") return text("bad label", 400);
+  const trimmed = typeof body.label === "string" ? body.label.trim() : "";
+  const label = trimmed.length > 0 ? trimmed : null;
+  try {
+    await herdr.renamePane(paneId, label);
+    audit.record({ action: "pane.rename", paneId, session, device, detail: { label } });
     return json({ ok: true } satisfies ActionResponse, ae);
   } catch (err) {
     return json({ ok: false, error: (err as Error).message } satisfies ActionResponse, ae);

--- a/bridge/server.ts
+++ b/bridge/server.ts
@@ -77,6 +77,10 @@ const SECURITY_HEADERS: Record<string, string> = {
 const LOOPBACK_HOST = /^(localhost|127\.0\.0\.1|\[::1\])(:\d+)?$/;
 
 const PANE_ROUTE = /^\/api\/pane\/([^/]+)(?:\/(reply|keys|upload|close|rename))?$/;
+// A tab currently supports only rename (no close), so a lean single-action route rather than the
+// pane route's action group. The `/api/tab` POST above (create) is an exact match, so it never
+// collides with this `/api/tab/<id>/rename`.
+const TAB_RENAME_ROUTE = /^\/api\/tab\/([^/]+)\/rename$/;
 
 export function startServer(opts: {
   cfg: Config;
@@ -147,6 +151,17 @@ export function startServer(opts: {
         const rt = registry.get(sessionName);
         if (!rt) return unknownSession();
         return createWorkspace(rt.herdr, req, audit, deviceAuth(req, cfg).device, rt.name);
+      }
+
+      // ── Rename a tab (set its label) ─────────────────────────────────────
+      const tabMatch = pathname.match(TAB_RENAME_ROUTE);
+      if (tabMatch && req.method === "POST") {
+        const denied = guard(req, cfg, "write");
+        if (denied) return denied;
+        const rt = registry.get(sessionName);
+        if (!rt) return unknownSession();
+        const tabId = decodeURIComponent(tabMatch[1]!);
+        return renameTab(rt.herdr, tabId, req, audit, deviceAuth(req, cfg).device, rt.name);
       }
 
       // ── Per-pane read / send ─────────────────────────────────────────────
@@ -519,6 +534,51 @@ async function renamePane(
   try {
     await herdr.renamePane(paneId, label);
     audit.record({ action: "pane.rename", paneId, session, device, detail: { label } });
+    return json({ ok: true } satisfies ActionResponse, ae);
+  } catch (err) {
+    return json({ ok: false, error: (err as Error).message } satisfies ActionResponse, ae);
+  }
+}
+
+/**
+ * Validate an untrusted tab-rename body's `label`. A tab label is a NON-null, NON-empty string:
+ * herdr's `tab.rename` rejects `null`, and an empty string is stored literally (a blank tab chip)
+ * rather than clearing to the default number — both live-verified 2026-07-19. So, unlike a pane label
+ * (where a blank field clears to `null`), Collie has no "clear" for a tab and rejects a blank label.
+ * Pure + exported so the rule is unit-testable without standing up Bun.serve.
+ */
+export function normalizeTabLabel(
+  v: unknown,
+): { ok: true; label: string } | { ok: false; error: string } {
+  if (typeof v !== "string") return { ok: false, error: "bad label" };
+  const label = v.trim();
+  if (!label) return { ok: false, error: "label required" };
+  return { ok: true, label };
+}
+
+// Set a tab's label. Structural metadata op — strictly less powerful than the text/keys injection the
+// bridge already allows, so it stays within the existing remote-shell threat model. A tab has no
+// "clear" (see normalizeTabLabel): a blank label is a 400, not a reset to the tab number.
+async function renameTab(
+  herdr: HerdrClient,
+  tabId: string,
+  req: Request,
+  audit: AuditLog,
+  device: string | null,
+  session: string,
+): Promise<Response> {
+  const ae = req.headers.get("accept-encoding");
+  let body: { label?: unknown };
+  try {
+    body = (await req.json()) as typeof body;
+  } catch {
+    return text("bad body", 400);
+  }
+  const parsed = normalizeTabLabel(body.label);
+  if (!parsed.ok) return text(parsed.error, 400);
+  try {
+    await herdr.renameTab(tabId, parsed.label);
+    audit.record({ action: "tab.rename", session, device, detail: { tabId, label: parsed.label } });
     return json({ ok: true } satisfies ActionResponse, ae);
   } catch (err) {
     return json({ ok: false, error: (err as Error).message } satisfies ActionResponse, ae);

--- a/bridge/server.ts
+++ b/bridge/server.ts
@@ -77,10 +77,9 @@ const SECURITY_HEADERS: Record<string, string> = {
 const LOOPBACK_HOST = /^(localhost|127\.0\.0\.1|\[::1\])(:\d+)?$/;
 
 const PANE_ROUTE = /^\/api\/pane\/([^/]+)(?:\/(reply|keys|upload|close|rename))?$/;
-// A tab currently supports only rename (no close), so a lean single-action route rather than the
-// pane route's action group. The `/api/tab` POST above (create) is an exact match, so it never
-// collides with this `/api/tab/<id>/rename`.
-const TAB_RENAME_ROUTE = /^\/api\/tab\/([^/]+)\/rename$/;
+// A tab supports rename + close — an action group like the pane route. The `/api/tab` POST above
+// (create) is an exact match on `/api/tab`, so it never collides with this `/api/tab/<id>/<action>`.
+const TAB_ACTION_ROUTE = /^\/api\/tab\/([^/]+)\/(rename|close)$/;
 
 export function startServer(opts: {
   cfg: Config;
@@ -153,15 +152,18 @@ export function startServer(opts: {
         return createWorkspace(rt.herdr, req, audit, deviceAuth(req, cfg).device, rt.name);
       }
 
-      // ── Rename a tab (set its label) ─────────────────────────────────────
-      const tabMatch = pathname.match(TAB_RENAME_ROUTE);
+      // ── Tab actions: rename (set its label) / close (kill it + every pane in it) ──
+      const tabMatch = pathname.match(TAB_ACTION_ROUTE);
       if (tabMatch && req.method === "POST") {
         const denied = guard(req, cfg, "write");
         if (denied) return denied;
         const rt = registry.get(sessionName);
         if (!rt) return unknownSession();
         const tabId = decodeURIComponent(tabMatch[1]!);
-        return renameTab(rt.herdr, tabId, req, audit, deviceAuth(req, cfg).device, rt.name);
+        const action = tabMatch[2];
+        const device = deviceAuth(req, cfg).device;
+        if (action === "close") return closeTab(rt.herdr, tabId, req, audit, device, rt.name);
+        return renameTab(rt.herdr, tabId, req, audit, device, rt.name);
       }
 
       // ── Per-pane read / send ─────────────────────────────────────────────
@@ -579,6 +581,28 @@ async function renameTab(
   try {
     await herdr.renameTab(tabId, parsed.label);
     audit.record({ action: "tab.rename", session, device, detail: { tabId, label: parsed.label } });
+    return json({ ok: true } satisfies ActionResponse, ae);
+  } catch (err) {
+    return json({ ok: false, error: (err as Error).message } satisfies ActionResponse, ae);
+  }
+}
+
+// Close a tab, killing every pane inside it (live-verified 2026-07-19: the tab's panes disappear with
+// it — see HERDR_API.md). Structural op — no more powerful than closing those panes one-by-one, which
+// the bridge already allows via pane.close — so it stays within the existing remote-shell threat
+// model. No body: the tab id is in the path.
+async function closeTab(
+  herdr: HerdrClient,
+  tabId: string,
+  req: Request,
+  audit: AuditLog,
+  device: string | null,
+  session: string,
+): Promise<Response> {
+  const ae = req.headers.get("accept-encoding");
+  try {
+    await herdr.closeTab(tabId);
+    audit.record({ action: "tab.close", session, device, detail: { tabId } });
     return json({ ok: true } satisfies ActionResponse, ae);
   } catch (err) {
     return json({ ok: false, error: (err as Error).message } satisfies ActionResponse, ae);

--- a/bridge/session-name.test.ts
+++ b/bridge/session-name.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { extractClaudeSessionName } from "./state-engine.ts";
+
+// `extractClaudeSessionName` pulls Claude's own `/rename` session name out of a pane's rendered text.
+// It must match the name embedded in the horizontal rule above the ❯ prompt, and — critically — never
+// false-positive on an unnamed session (plain rule), a pane without an input box (a dialog), or a
+// decorative rule elsewhere in the output. We exercise it against the real pane fixtures the web tests
+// use, ANSI-stripped to mirror the plain "text" read the bridge actually performs.
+
+const FIXTURES = join(import.meta.dir, "..", "web", "src", "fixtures", "panes");
+const stripAnsi = (s: string) => s.replace(/\x1b\[[0-9;]*m/g, "");
+const fixture = (name: string) => stripAnsi(readFileSync(join(FIXTURES, `${name}.txt`), "utf8"));
+
+describe("extractClaudeSessionName — named sessions", () => {
+  test("reads the name embedded in the rule above the ❯ prompt (fixture)", () => {
+    // claude--working.txt was captured with a renamed session ("collie upgrades").
+    expect(extractClaudeSessionName(fixture("claude--working"))).toBe("collie upgrades");
+  });
+
+  test("reads a hyphenated name from the live 'text' render (CRLF-agnostic, varied width)", () => {
+    const live = [
+      "❯ /rename",
+      "  ⎿  Session renamed to: ping-pong-response",
+      "",
+      "──────────────────────────── ping-pong-response ──",
+      "❯ ",
+      "───────────────────────────────────────────────────",
+      "  [Opus 4.8 (1M context)] ~/playground/demo…",
+    ].join("\r\n"); // CRLF, as some captures carry
+    expect(extractClaudeSessionName(live)).toBe("ping-pong-response");
+  });
+
+  test("trims trailing rule decoration and surrounding whitespace", () => {
+    const text = ["────── my-session ──────   ", "❯ some queued draft"].join("\n");
+    expect(extractClaudeSessionName(text)).toBe("my-session");
+  });
+
+  test("accepts a single-word and a spaced multi-word name alike", () => {
+    expect(extractClaudeSessionName(["──── solo ──", "❯"].join("\n"))).toBe("solo");
+    expect(extractClaudeSessionName(["──── two words here ──", "❯"].join("\n"))).toBe(
+      "two words here",
+    );
+  });
+});
+
+describe("extractClaudeSessionName — no name / no false positives", () => {
+  test("returns undefined for an unnamed session (plain rule above the prompt)", () => {
+    expect(extractClaudeSessionName(fixture("claude--fresh-idle"))).toBeUndefined();
+    expect(extractClaudeSessionName(fixture("claude--done"))).toBeUndefined();
+  });
+
+  test("returns undefined when the pane shows a dialog, not the input box", () => {
+    expect(extractClaudeSessionName(fixture("claude--permission-bash"))).toBeUndefined();
+  });
+
+  test("does not mistake a decorative in-menu rule for a name (select menu)", () => {
+    // claude--select-menu.txt has a full-width rule mid-menu — not above a ❯ prompt.
+    expect(extractClaudeSessionName(fixture("claude--select-menu"))).toBeUndefined();
+  });
+
+  test("ignores a named-looking rule that is NOT directly above the ❯ prompt", () => {
+    const decoy = ["──────── not a prompt ────────", "just output", "more output"].join("\n");
+    expect(extractClaudeSessionName(decoy)).toBeUndefined();
+  });
+
+  test("ignores the ' ❯' menu cursor (leading space) — only the column-0 prompt anchors", () => {
+    // A selected menu row renders as " ❯ 1. Yes"; a rule above it must not be read as a name.
+    const menu = ["──────── looks named ────────", " ❯ 1. Yes", "   2. No"].join("\n");
+    expect(extractClaudeSessionName(menu)).toBeUndefined();
+  });
+
+  test("returns undefined for empty text", () => {
+    expect(extractClaudeSessionName("")).toBeUndefined();
+  });
+});

--- a/bridge/state-engine.test.ts
+++ b/bridge/state-engine.test.ts
@@ -16,10 +16,17 @@ interface FakePane {
   cwd: string;
   agent?: string | null;
   agent_status: AgentStatus;
+  label?: string | null;
   revision: number;
 }
 
-function pane(id: string, ws: string, status: AgentStatus, agent: string | null): FakePane {
+function pane(
+  id: string,
+  ws: string,
+  status: AgentStatus,
+  agent: string | null,
+  label?: string | null,
+): FakePane {
   return {
     pane_id: id,
     terminal_id: "term",
@@ -29,6 +36,7 @@ function pane(id: string, ws: string, status: AgentStatus, agent: string | null)
     cwd: "/home/you/demo",
     agent,
     agent_status: status,
+    ...(label !== undefined ? { label } : {}),
     revision: 0,
   };
 }
@@ -190,6 +198,32 @@ describe("StateEngine — snapshot shaping", () => {
     expect(snap.shellPanes.map((a) => a.paneId)).toEqual(["w1:p2"]);
     expect(snap.shellPanes[0]!.agent).toBe("shell");
     expect(snap.bridge).toBe("connected");
+  });
+
+  test("threads a pane label through to the view when set, on agents and shells alike", async () => {
+    const { herdr, engine, poll } = makeEngine();
+    herdr.panes = [
+      pane("w1:p1", "w1", "idle", "claude", "deploy"),
+      pane("w1:p2", "w1", "unknown", null, "logs"),
+    ];
+    await poll();
+    const snap = engine.current();
+    expect(snap.agents[0]!.paneLabel).toBe("deploy");
+    expect(snap.shellPanes[0]!.paneLabel).toBe("logs");
+  });
+
+  test("leaves paneLabel absent when the pane has no label (or a null/empty one)", async () => {
+    const { herdr, engine, poll } = makeEngine();
+    herdr.panes = [
+      pane("w1:p1", "w1", "idle", "claude"), // no label field at all
+      pane("w1:p2", "w1", "idle", "codex", null), // explicitly null
+      pane("w1:p3", "w1", "idle", "codex", ""), // empty string → treated as unset
+    ];
+    await poll();
+    for (const a of engine.current().agents) {
+      expect(a.paneLabel).toBeUndefined();
+      expect("paneLabel" in a).toBe(false);
+    }
   });
 
   test("sorts agents by urgency (blocked first), then workspace number", async () => {

--- a/bridge/state-engine.test.ts
+++ b/bridge/state-engine.test.ts
@@ -327,6 +327,88 @@ describe("StateEngine — snapshot vs legacy path", () => {
   });
 });
 
+describe("StateEngine — session name enrichment", () => {
+  // A named claude input box: the rule above the ❯ prompt carries the /rename session name.
+  const named = (name: string) => [`──────── ${name} ──`, "❯ "].join("\n");
+  // An unnamed input box (plain rule) — no session name to extract.
+  const plainBox = ["────────────────", "❯ "].join("\n");
+
+  // A fake herdr that also serves per-pane text, so enrichSessionNames has something to read. The
+  // production StateEngine short-circuits when `readPane` is absent (the other fakes here omit it),
+  // which is exactly why those tests are unaffected by the enrichment step.
+  class NameHerdr {
+    panes: FakePane[] = [];
+    texts = new Map<string, string>();
+    sessionSnapshot() {
+      return Promise.resolve({ version: "0.7.2", protocol: 16, workspaces: [ws("w1", 1)], tabs: [], panes: this.panes });
+    }
+    readPane(paneId: string) {
+      return Promise.resolve({ pane_id: paneId, text: this.texts.get(paneId) ?? "", truncated: false, revision: 0 });
+    }
+  }
+
+  function makeNameEngine() {
+    const herdr = new NameHerdr();
+    const engine = new StateEngine(herdr as unknown as HerdrClient, 1500);
+    const poll = () => (engine as unknown as { poll(): Promise<void> }).poll();
+    const agent = (id: string) => engine.current().agents.find((a) => a.paneId === id)!;
+    return { herdr, engine, poll, agent };
+  }
+
+  test("threads a claude pane's /rename session name onto the view — claude-only", async () => {
+    const { herdr, poll, agent } = makeNameEngine();
+    herdr.panes = [pane("w1:p1", "w1", "idle", "claude"), pane("w1:p2", "w1", "idle", "codex")];
+    herdr.texts.set("w1:p1", named("my-feature"));
+    herdr.texts.set("w1:p2", named("ignored")); // codex is never read, so never named
+    await poll();
+    expect(agent("w1:p1").sessionName).toBe("my-feature");
+    expect(agent("w1:p2").sessionName).toBeUndefined();
+  });
+
+  test("leaves sessionName absent for an unnamed claude session (plain rule)", async () => {
+    const { herdr, poll, agent } = makeNameEngine();
+    herdr.panes = [pane("w1:p1", "w1", "idle", "claude")];
+    herdr.texts.set("w1:p1", plainBox);
+    await poll();
+    expect(agent("w1:p1").sessionName).toBeUndefined();
+    expect("sessionName" in agent("w1:p1")).toBe(false);
+  });
+
+  test("keeps the last-known name when a later poll can't see the input box (sticky)", async () => {
+    const { herdr, poll, agent } = makeNameEngine();
+    herdr.panes = [pane("w1:p1", "w1", "idle", "claude")];
+    herdr.texts.set("w1:p1", named("kept"));
+    await poll(); // learns it
+    herdr.texts.set("w1:p1", "● Working…\n  ⎿  no input box in view"); // extractor → undefined
+    await poll();
+    expect(agent("w1:p1").sessionName).toBe("kept");
+  });
+
+  test("drops the cached name when the pane vanishes, so a reused id starts clean", async () => {
+    const { herdr, poll, agent } = makeNameEngine();
+    herdr.panes = [pane("w1:p1", "w1", "idle", "claude")];
+    herdr.texts.set("w1:p1", named("old"));
+    await poll(); // cached
+    herdr.panes = [];
+    await poll(); // pane gone → cache pruned
+    herdr.panes = [pane("w1:p1", "w1", "idle", "claude")];
+    herdr.texts.set("w1:p1", plainBox); // reappears, now unnamed
+    await poll();
+    expect(agent("w1:p1").sessionName).toBeUndefined();
+  });
+
+  test("a failing pane read never blanks the name or fails the poll", async () => {
+    const { herdr, engine, poll, agent } = makeNameEngine();
+    herdr.panes = [pane("w1:p1", "w1", "idle", "claude")];
+    herdr.texts.set("w1:p1", named("safe"));
+    await poll();
+    herdr.readPane = () => Promise.reject(new Error("read down"));
+    await poll();
+    expect(agent("w1:p1").sessionName).toBe("safe"); // last-known kept
+    expect(engine.current().bridge).toBe("connected"); // the poll itself still succeeded
+  });
+});
+
 describe("StateEngine — poke / cadence / onUpdate", () => {
   test("onUpdate fires with the fresh snapshot after a successful poll, but not after a failed one", async () => {
     const { herdr, engine, poll } = makeEngine();

--- a/bridge/state-engine.ts
+++ b/bridge/state-engine.ts
@@ -12,6 +12,45 @@ import {
 // transition events. Polling (vs the per-pane event subscription) keeps this resync-free: a failed
 // poll just retries next tick, and reconnection needs no special handling. See HERDR_API.md.
 
+// How many recent lines to read per claude pane when sniffing its `/rename` session name. Claude's
+// input box (and the named rule above it) sits at the very tail, so a small window is plenty and
+// keeps the extra per-poll reads cheap.
+const SESSION_NAME_READ_LINES = 40;
+
+// Claude renders its input box as a horizontal rule, the ❯ prompt line, then a closing rule. After
+// `/rename <name>` the TOP rule carries the session name inside it: "────────── my-name ──". This
+// matches that named rule. `\S` also matches box-drawing chars, but a *plain* rule has no embedded
+// space-delimited text, so it can't match — and the ❯-prompt anchor (below) rules out any decorative
+// rule elsewhere in the output. Rule chars: ─ (U+2500, light) and ━ (U+2501, heavy).
+const NAMED_RULE = /^[─━]{2,}[ \t]+(\S.*?\S|\S)[ \t]+[─━]+[ \t]*$/;
+// Claude's input prompt marker, anchored at column 0. Its menu/selection cursors render as " ❯"
+// (leading space), so the column-0 anchor discriminates the real input prompt from a selected row.
+const PROMPT_LINE = /^❯/;
+
+/**
+ * Pull Claude's own session name (set via `/rename`) out of a pane's recent text, or `undefined` when
+ * the session is unnamed (a plain rule) or the pane isn't showing its input box (a dialog, a working
+ * spinner). Claude draws the name INTO the horizontal rule directly above the ❯ prompt, e.g.
+ * `────────── my-name ──`; we accept that rule ONLY when the very next line is the ❯ prompt, so a
+ * decorative rule anywhere else in the output can never be mistaken for it (no false positives).
+ * Derived from Claude's UI grammar — claude-only; other harnesses never call this. Pure + exported so
+ * it's unit-tested against the pane fixtures without standing up the socket client.
+ */
+export function extractClaudeSessionName(text: string): string | undefined {
+  if (!text) return undefined;
+  const lines = text.split(/\r?\n/);
+  // Scan bottom-up: the input box's top rule is the lowest named-rule-above-❯ in the buffer.
+  for (let i = lines.length - 2; i >= 0; i--) {
+    const below = lines[i + 1];
+    if (below === undefined || !PROMPT_LINE.test(below)) continue;
+    const m = NAMED_RULE.exec(lines[i]!);
+    if (!m) continue;
+    const name = m[1]!.trim();
+    if (name) return name;
+  }
+  return undefined;
+}
+
 export interface EngineSnapshot {
   agents: AgentView[];
   shellPanes: AgentView[];
@@ -31,6 +70,10 @@ export class StateEngine {
   private tabs: TabView[] = [];
   private bridge: BridgeStatus = "disconnected";
   private readonly prevStatus = new Map<string, AgentStatus>();
+  // Last-known claude `/rename` session name per pane. Kept sticky so the name doesn't flicker away
+  // when a pane momentarily hides its input box (a dialog / working spinner) — only cleared when the
+  // pane itself vanishes (see the removal loop). Enriched from pane text each poll (see enrichSessionNames).
+  private readonly sessionNames = new Map<string, string>();
   private readonly transitionListeners = new Set<TransitionListener>();
   private readonly removeListeners = new Set<RemoveListener>();
   private readonly updateListeners = new Set<UpdateListener>();
@@ -229,8 +272,13 @@ export class StateEngine {
       for (const id of [...this.prevStatus.keys()]) {
         if (live.has(id)) continue;
         this.prevStatus.delete(id);
+        this.sessionNames.delete(id); // drop the cached name so a reused pane id starts clean
         for (const fn of this.removeListeners) fn(id);
       }
+
+      // Enrich claude panes with their own `/rename` session name (read from pane text). Best-effort:
+      // a failed read keeps the last-known name and never fails the poll.
+      await this.enrichSessionNames(agents);
 
       this.agents = agents;
       this.shellPanes = shellPanes;
@@ -253,6 +301,36 @@ export class StateEngine {
         this.queuedPoll = false;
         if (this.started) void this.poll();
       }
+    }
+  }
+
+  /**
+   * Read each claude pane's recent text and attach its `/rename` session name (see
+   * {@link extractClaudeSessionName}) to the view, exactly parallel to `paneLabel`. The name lives
+   * only in the pane's rendered text — Herdr's pane metadata doesn't carry it — so this is the one
+   * place all panes can pick it up (the web app only holds text for the open pane). Reads run in
+   * parallel and are individually best-effort: a read that fails or times out keeps the last-known
+   * name (sticky cache) and never fails the poll. Claude-only; other harnesses never set it. A
+   * herdr client without `readPane` (the unit-test fake) short-circuits, so it's a no-op there.
+   */
+  private async enrichSessionNames(agents: AgentView[]): Promise<void> {
+    if (typeof this.herdr.readPane !== "function") return;
+    const claude = agents.filter((a) => a.agent === "claude");
+    if (claude.length === 0) return;
+    await Promise.all(
+      claude.map(async (a) => {
+        try {
+          const read = await this.herdr.readPane(a.paneId, "recent", SESSION_NAME_READ_LINES, "text");
+          const name = extractClaudeSessionName(read.text);
+          if (name) this.sessionNames.set(a.paneId, name);
+        } catch {
+          // Keep whatever's cached (if anything) — a transient read failure must not blank the name.
+        }
+      }),
+    );
+    for (const a of agents) {
+      const name = this.sessionNames.get(a.paneId);
+      if (name) a.sessionName = name;
     }
   }
 }

--- a/bridge/state-engine.ts
+++ b/bridge/state-engine.ts
@@ -167,6 +167,8 @@ export class StateEngine {
           cwd: p.cwd,
           focused: p.focused,
           kind,
+          // A user-set pane label (herdr pane.rename); omitted when unset so "absent stays absent".
+          ...(typeof p.label === "string" && p.label.length > 0 ? { paneLabel: p.label } : {}),
         };
       };
 

--- a/bridge/types.ts
+++ b/bridge/types.ts
@@ -22,6 +22,12 @@ export interface AgentView {
   kind?: "agent" | "shell";
   /** User-set pane label (herdr `pane.rename`), when one is set; absent when the pane is unlabelled. */
   paneLabel?: string;
+  /**
+   * Claude's OWN session name, set in-agent via `/rename` and read out of the pane's rendered text
+   * (see `extractClaudeSessionName` in state-engine.ts). Claude-only and derived, not a wire field —
+   * absent for unnamed sessions and every non-claude pane. Display priority is `paneLabel` first.
+   */
+  sessionName?: string;
 }
 
 /** A Herdr workspace ("space") — a project-scoped container of tabs. From `workspace.list`. */

--- a/bridge/types.ts
+++ b/bridge/types.ts
@@ -20,6 +20,8 @@ export interface AgentView {
   focused: boolean;
   /** "agent" for an agent-bearing pane, "shell" for a bare shell. Defaults to "agent" when absent. */
   kind?: "agent" | "shell";
+  /** User-set pane label (herdr `pane.rename`), when one is set; absent when the pane is unlabelled. */
+  paneLabel?: string;
 }
 
 /** A Herdr workspace ("space") — a project-scoped container of tabs. From `workspace.list`. */

--- a/web/src/components/action-sheet-rows.tsx
+++ b/web/src/components/action-sheet-rows.tsx
@@ -1,0 +1,135 @@
+import type { KeyboardEvent as ReactKeyboardEvent, ReactNode, RefObject } from "react";
+import { ChevronLeft, Loader2 } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+// Shared building blocks for the long-press action sheets — pane AND tab — so the two stay visually
+// and behaviourally identical (the user's ask: "they should be the same"). The plain action row, the
+// two-tap destructive row, and the rename view are authored ONCE here; each sheet owns its own
+// state/handlers and just composes these, differing only in domain semantics (which RPC, whether a
+// blank clears, the blast-radius wording). A label rendered here is user text going only into an
+// <input> value / text node — never markup — so it stays within the pane-output XSS boundary.
+
+/** A plain (non-destructive) action row: leading icon + label. Used for "Rename". */
+export function ActionRow({
+  icon,
+  label,
+  onClick,
+}: {
+  icon: ReactNode;
+  label: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left text-sm font-medium transition-colors hover:bg-accent active:bg-muted"
+    >
+      {icon}
+      {label}
+    </button>
+  );
+}
+
+/**
+ * The destructive close row: destructive-styled from the very first render (not just once armed) and
+ * two-tap confirmed — the first tap arms (row flips to `confirmLabel`), the second fires `onClick`.
+ * The `armed` / `closing` flags + the three labels are owned by the caller (its usePendingConfirm +
+ * closing state), so the arm→confirm→spinner choreography looks and behaves the same on both sheets.
+ */
+export function DestructiveActionRow({
+  icon,
+  label,
+  confirmLabel,
+  closingLabel,
+  armed,
+  closing,
+  onClick,
+}: {
+  icon: ReactNode;
+  label: string;
+  confirmLabel: string;
+  closingLabel: string;
+  armed: boolean;
+  closing: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={closing}
+      className={cn(
+        "flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left text-sm font-medium transition-colors disabled:opacity-60",
+        armed
+          ? "bg-destructive text-destructive-foreground"
+          : "text-destructive hover:bg-destructive/10 active:bg-destructive/15",
+      )}
+    >
+      {closing ? <Loader2 className="size-4 shrink-0 animate-spin" /> : icon}
+      {closing ? closingLabel : armed ? confirmLabel : label}
+    </button>
+  );
+}
+
+/**
+ * The rename view behind the "Rename" tap: a Back row, a prefilled label input (autofocused by the
+ * caller via `inputRef`), and Save. `canSave` lets a sheet refuse a blank field — tabs have no
+ * "clear" so they pass `canSave = trimmed.length > 0`, while a pane passes `true` always so saving a
+ * blank field clears its label. Enter in the input saves.
+ */
+export function RenameView({
+  inputRef,
+  label,
+  onLabelChange,
+  onSave,
+  onBack,
+  saving,
+  canSave,
+  placeholder,
+}: {
+  inputRef: RefObject<HTMLInputElement | null>;
+  label: string;
+  onLabelChange: (value: string) => void;
+  onSave: () => void;
+  onBack: () => void;
+  saving: boolean;
+  canSave: boolean;
+  placeholder: string;
+}) {
+  function onInputKeyDown(e: ReactKeyboardEvent<HTMLInputElement>) {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      onSave();
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      <button
+        type="button"
+        onClick={onBack}
+        className="flex items-center gap-1 self-start rounded-md py-1 pr-2 text-xs font-medium text-muted-foreground transition-colors active:bg-muted"
+      >
+        <ChevronLeft className="size-3.5" />
+        Back
+      </button>
+      <label className="flex flex-col gap-1">
+        <span className="text-xs font-medium text-muted-foreground">Label</span>
+        <input
+          ref={inputRef}
+          value={label}
+          onChange={(e) => onLabelChange(e.target.value)}
+          onKeyDown={onInputKeyDown}
+          placeholder={placeholder}
+          className="h-11 rounded-lg border border-border bg-background px-3 text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+        />
+      </label>
+      <Button onClick={onSave} disabled={saving || !canSave} className="h-11">
+        {saving ? <Loader2 className="size-4 animate-spin" /> : "Save"}
+      </Button>
+    </div>
+  );
+}

--- a/web/src/components/agent-card.tsx
+++ b/web/src/components/agent-card.tsx
@@ -33,7 +33,10 @@ export function AgentCard({ agent, onClick }: { agent: AgentView; onClick: () =>
         )}
         <div className="min-w-0 flex-1">
           <div className="flex items-center gap-1.5">
-            <span className="truncate font-medium">{isShell ? "shell" : agent.agent}</span>
+            {/* A user-set pane label takes the name slot (the icon still shows which agent it is). */}
+            <span className="truncate font-medium">
+              {agent.paneLabel ?? (isShell ? "shell" : agent.agent)}
+            </span>
             <span className="truncate text-xs text-muted-foreground">· {agent.workspaceLabel}</span>
           </div>
           <div className="truncate font-mono text-xs text-muted-foreground">

--- a/web/src/components/agent-card.tsx
+++ b/web/src/components/agent-card.tsx
@@ -5,6 +5,7 @@ import { Card } from "@/components/ui/card";
 import { ShellBadge, StatusBadge } from "@/components/status-badge";
 import { AgentIcon } from "@/components/agent-icon";
 import { shortCwd } from "@/lib/format";
+import { paneDisplayName } from "@/lib/types";
 import type { AgentView } from "@/lib/types";
 
 // A pane row, used by the triage home and the space view. Usually an agent; for a bare shell pane
@@ -33,10 +34,9 @@ export function AgentCard({ agent, onClick }: { agent: AgentView; onClick: () =>
         )}
         <div className="min-w-0 flex-1">
           <div className="flex items-center gap-1.5">
-            {/* A user-set pane label takes the name slot (the icon still shows which agent it is). */}
-            <span className="truncate font-medium">
-              {agent.paneLabel ?? (isShell ? "shell" : agent.agent)}
-            </span>
+            {/* Name slot: a user label, else Claude's /rename session name, else the agent name — the
+                icon still shows which agent it is (see paneDisplayName). */}
+            <span className="truncate font-medium">{paneDisplayName(agent)}</span>
             <span className="truncate text-xs text-muted-foreground">· {agent.workspaceLabel}</span>
           </div>
           <div className="truncate font-mono text-xs text-muted-foreground">

--- a/web/src/components/agent-chat.tsx
+++ b/web/src/components/agent-chat.tsx
@@ -564,6 +564,9 @@ export function AgentChat({
             session={session}
             readOnly={readOnly}
             onRenamed={() => revalidator.revalidate()}
+            // Closing the tab this pane lives in kills the pane too — leave for Home the same way a
+            // pane-close does (onBack); closing any other tab just revalidates so it drops out.
+            onClosed={(tabId) => (agent?.tabId === tabId ? onBack() : revalidator.revalidate())}
           />
         )}
 

--- a/web/src/components/agent-chat.tsx
+++ b/web/src/components/agent-chat.tsx
@@ -561,6 +561,9 @@ export function AgentChat({
             onSelect={(id) => id && goToTab(id)}
             onNewTab={newTab}
             allowAll={false}
+            session={session}
+            readOnly={readOnly}
+            onRenamed={() => revalidator.revalidate()}
           />
         )}
 

--- a/web/src/components/agent-chat.tsx
+++ b/web/src/components/agent-chat.tsx
@@ -514,10 +514,13 @@ export function AgentChat({
                   <AgentIcon agent={agent.agent} className="size-6" />
                 )}
                 <div className="min-w-0 flex-1">
-                  {/* A user-set pane label leads when present (the identifier they chose); otherwise
-                      the default space › tab. The cwd subline keeps context either way. */}
+                  {/* A user-set pane label leads when present (the identifier they chose), then
+                      Claude's own /rename session name, otherwise the default space › tab. The cwd
+                      subline keeps context either way. */}
                   <div className="truncate font-semibold leading-tight">
-                    {agent.paneLabel ?? `${agent.workspaceLabel}${tabLabel ? ` › ${tabLabel}` : ""}`}
+                    {agent.paneLabel ??
+                      agent.sessionName ??
+                      `${agent.workspaceLabel}${tabLabel ? ` › ${tabLabel}` : ""}`}
                   </div>
                   <div className="truncate font-mono text-xs leading-tight text-muted-foreground">
                     {shortCwd(agent.cwd)}

--- a/web/src/components/agent-chat.tsx
+++ b/web/src/components/agent-chat.tsx
@@ -22,7 +22,6 @@ import { PaneStrip } from "@/components/pane-strip";
 import { ReadOnlyBanner } from "@/components/read-only-banner";
 import { StatusArea } from "@/components/status-area";
 import { ShellBadge, StatusBadge } from "@/components/status-badge";
-import * as api from "@/lib/api";
 import { submitPromptOption } from "@/lib/prompt-action";
 import { submitWizardKeys } from "@/lib/wizard-action";
 import { submitPreviewKeys, submitPreviewNote, submitPreviewOption } from "@/lib/preview-action";
@@ -110,7 +109,6 @@ export function AgentChat({
   // composer drops to read-only (and shows a banner). The mirror still polls (reading is fine).
   const readOnly = isReadOnly(device);
 
-  const [closingId, setClosingId] = useState<string | null>(null);
   // Drawers/sheets are mutually exclusive — at most one open. A single value makes that invariant
   // unrepresentable to violate.
   const [drawer, setDrawer] = useState<Drawer>(null);
@@ -448,31 +446,6 @@ export function AgentChat({
     composerRef.current?.focusInput();
   }
 
-  // Close a pane from the switcher's per-row ✕. Closing the pane you're viewing returns Home (the
-  // return is the confirmation, no toast); closing any other just revalidates so it drops out of the
-  // list. One close at a time (closingId gates re-entry and drives the row spinner).
-  async function closePane(id: string) {
-    if (closingId) return;
-    if (readOnly) {
-      setStatus("Read-only — device not authorised", "error");
-      return;
-    }
-    setClosingId(id);
-    try {
-      const res = await api.closePane(id, session);
-      if (res.ok) {
-        if (id === paneId) onBack();
-        else revalidator.revalidate();
-      } else {
-        setStatus(res.error ?? "Close failed", "error");
-      }
-    } catch (e) {
-      setStatus(e instanceof Error ? e.message : String(e), "error");
-    } finally {
-      setClosingId(null);
-    }
-  }
-
   return (
     <div className="flex h-[100dvh] min-w-0 w-full max-w-[100dvw] flex-col overflow-x-hidden">
       {/* Header — while find is open, the find bar takes over this row (one-handed, thumb-reachable). */}
@@ -692,15 +665,14 @@ export function AgentChat({
         </div>
       </div>
 
-      {/* Swipe-up quick switcher — just the panes (agents + shells), reached by the thumb gesture */}
+      {/* Swipe-up quick switcher — just the panes (agents + shells), reached by the thumb gesture.
+          Switch-only: pane closing lives in the pane pill's long-press sheet, not here. */}
       <BottomSheet open={drawer === "switcher"} onClose={closeDrawer} title="Switch pane">
         <ThreadSidebar
           agents={agents}
           shellPanes={shellPanes}
           currentPaneId={paneId}
           onSelect={switchTo}
-          onClose={closePane}
-          closingId={closingId ?? undefined}
           className="px-0 py-1"
         />
       </BottomSheet>

--- a/web/src/components/agent-chat.tsx
+++ b/web/src/components/agent-chat.tsx
@@ -514,9 +514,10 @@ export function AgentChat({
                   <AgentIcon agent={agent.agent} className="size-6" />
                 )}
                 <div className="min-w-0 flex-1">
+                  {/* A user-set pane label leads when present (the identifier they chose); otherwise
+                      the default space › tab. The cwd subline keeps context either way. */}
                   <div className="truncate font-semibold leading-tight">
-                    {agent.workspaceLabel}
-                    {tabLabel ? ` › ${tabLabel}` : ""}
+                    {agent.paneLabel ?? `${agent.workspaceLabel}${tabLabel ? ` › ${tabLabel}` : ""}`}
                   </div>
                   <div className="truncate font-mono text-xs leading-tight text-muted-foreground">
                     {shortCwd(agent.cwd)}
@@ -569,6 +570,11 @@ export function AgentChat({
               .sort((a, b) => a.paneId.localeCompare(b.paneId))}
             currentPaneId={paneId}
             onSelect={switchTo}
+            session={session}
+            readOnly={readOnly}
+            onRenamed={() => revalidator.revalidate()}
+            // Mirror closePane's success branch: closing the open pane returns Home, else revalidate.
+            onClosed={(id) => (id === paneId ? onBack() : revalidator.revalidate())}
           />
         )}
 

--- a/web/src/components/agent-sidebar.test.tsx
+++ b/web/src/components/agent-sidebar.test.tsx
@@ -97,34 +97,23 @@ describe("ThreadSidebar", () => {
     expect(screen.getByText("Shells")).toBeInTheDocument();
   });
 
-  it("shows no ✕ close control unless onClose is provided", () => {
+  it("is switch-only — no close control on any row", () => {
     render(<ThreadSidebar agents={[fixtureAgents[0]!]} currentPaneId="" onSelect={vi.fn()} />);
-    expect(screen.queryByRole("button", { name: /^Close / })).toBeNull();
+    expect(screen.queryByRole("button", { name: /close/i })).toBeNull();
   });
 
-  it("closes a pane only after a two-tap confirm on its ✕", async () => {
-    const user = userEvent.setup();
-    const onClose = vi.fn();
-    // fixtureAgents[0] is the blocked claude agent (paneId w1:p1).
-    render(
-      <ThreadSidebar agents={[fixtureAgents[0]!]} currentPaneId="" onSelect={vi.fn()} onClose={onClose} />,
-    );
-    await user.click(screen.getByRole("button", { name: "Close claude" }));
-    expect(onClose).not.toHaveBeenCalled(); // first tap only arms the confirm
-    await user.click(screen.getByRole("button", { name: "Confirm closing claude" }));
-    expect(onClose).toHaveBeenCalledExactlyOnceWith("w1:p1");
-  });
-
-  it("disables a row's ✕ while that pane is being closed", () => {
-    render(
+  it("gives each section a status-colored bullet from the shared group palette", () => {
+    const { container } = render(
       <ThreadSidebar
-        agents={[fixtureAgents[0]!]}
+        agents={[...fixtureAgents, idleAgent]}
+        shellPanes={[shellPane]}
         currentPaneId=""
         onSelect={vi.fn()}
-        onClose={vi.fn()}
-        closingId="w1:p1"
       />,
     );
-    expect(screen.getByRole("button", { name: "Close claude" })).toBeDisabled();
+    // One dot per section, colored by the same status palette the badges use.
+    for (const cls of ["bg-status-blocked", "bg-status-working", "bg-status-idle", "bg-status-unknown"]) {
+      expect(container.getElementsByClassName(cls).length).toBeGreaterThan(0);
+    }
   });
 });

--- a/web/src/components/agent-sidebar.tsx
+++ b/web/src/components/agent-sidebar.tsx
@@ -5,6 +5,7 @@ import { AgentIcon } from "@/components/agent-icon";
 import { usePendingConfirm } from "@/hooks/use-pending-confirm";
 import { AGENT_GROUPS } from "@/lib/agent-groups";
 import { shortCwd } from "@/lib/format";
+import { paneDisplayName } from "@/lib/types";
 import type { AgentView } from "@/lib/types";
 
 interface ThreadSidebarProps {
@@ -130,8 +131,9 @@ function PaneRow({
   closing?: boolean;
 }) {
   const isShell = pane.kind === "shell";
-  // A user-set pane label leads (the icon still conveys the agent); falls back to the agent/shell name.
-  const name = pane.paneLabel ?? (isShell ? "shell" : pane.agent);
+  // A user label leads, then Claude's /rename session name, then the agent/shell name (the icon still
+  // conveys the agent). See paneDisplayName.
+  const name = paneDisplayName(pane);
   // A row is a container, not one big button: the select tap and the ✕ are separate controls, so they
   // can't be nested <button>s. The active/hover highlight lives on the container; the inner button is
   // transparent and carries aria-current.

--- a/web/src/components/agent-sidebar.tsx
+++ b/web/src/components/agent-sidebar.tsx
@@ -1,8 +1,7 @@
-import { Loader2, TerminalSquare, X } from "lucide-react";
+import { TerminalSquare } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 import { AgentIcon } from "@/components/agent-icon";
-import { usePendingConfirm } from "@/hooks/use-pending-confirm";
 import { AGENT_GROUPS } from "@/lib/agent-groups";
 import { shortCwd } from "@/lib/format";
 import { paneDisplayName } from "@/lib/types";
@@ -14,34 +13,22 @@ interface ThreadSidebarProps {
   shellPanes?: AgentView[];
   currentPaneId: string;
   onSelect: (paneId: string) => void;
-  /** When set, each row gets a ✕ that closes that pane (two-tap confirm). Omit to hide it. */
-  onClose?: (paneId: string) => void;
-  /** The pane currently being closed — shows a spinner on its row. */
-  closingId?: string;
   /** Override the list container padding (e.g. flush inside a bottom sheet). */
   className?: string;
 }
 
 // The pane switcher reused by both the side drawer's PANES section and the swipe-up bottom sheet:
 // every agent pane grouped/sorted like the home triage, then any bare shell panes under a "Shells"
-// group, scrollable, with the open one highlighted. Mirrors the Herdr TUI's pane list. When onClose
-// is given, each row carries its own close affordance so it's always unambiguous which pane you end.
+// group, scrollable, with the open one highlighted. Mirrors the Herdr TUI's pane list. Switching is
+// the ONLY action here — closing a pane lives in the pane pill's long-press sheet (with its own
+// confirm), so a fat-thumbed switch can never destroy a pane.
 export function ThreadSidebar({
   agents,
   shellPanes = [],
   currentPaneId,
   onSelect,
-  onClose,
-  closingId,
   className,
 }: ThreadSidebarProps) {
-  // Two-tap confirm, keyed by paneId, so arming one row's ✕ doesn't arm the others.
-  const { pending, confirm } = usePendingConfirm();
-  const requestClose = onClose
-    ? (paneId: string) => {
-        if (confirm(paneId)) onClose(paneId);
-      }
-    : undefined;
   if (agents.length === 0 && shellPanes.length === 0) {
     return (
       <div className="px-4 py-12 text-center text-sm text-muted-foreground">No agents running.</div>
@@ -54,16 +41,13 @@ export function ThreadSidebar({
         const members = agents.filter((a) => g.match(a.status));
         if (members.length === 0) return null;
         return (
-          <Section key={g.key} label={g.label} count={members.length} accent={g.accent}>
+          <Section key={g.key} label={g.label} count={members.length} accent={g.accent} dot={g.dot}>
             {members.map((a) => (
               <PaneRow
                 key={a.paneId}
                 pane={a}
                 active={a.paneId === currentPaneId}
                 onSelect={onSelect}
-                onClose={requestClose}
-                confirming={pending === a.paneId}
-                closing={closingId === a.paneId}
               />
             ))}
           </Section>
@@ -71,16 +55,13 @@ export function ThreadSidebar({
       })}
 
       {shellPanes.length > 0 && (
-        <Section label="Shells" count={shellPanes.length}>
+        <Section label="Shells" count={shellPanes.length} dot="bg-status-unknown">
           {shellPanes.map((p) => (
             <PaneRow
               key={p.paneId}
               pane={p}
               active={p.paneId === currentPaneId}
               onSelect={onSelect}
-              onClose={requestClose}
-              confirming={pending === p.paneId}
-              closing={closingId === p.paneId}
             />
           ))}
         </Section>
@@ -93,21 +74,26 @@ function Section({
   label,
   count,
   accent,
+  dot,
   children,
 }: {
   label: string;
   count: number;
   accent?: boolean;
+  /** Status-palette bullet beside the header — the same colors the status badges use, so each
+   *  section carries its at-a-glance color key. */
+  dot: string;
   children: React.ReactNode;
 }) {
   return (
     <section className="flex flex-col gap-0.5">
       <h3
         className={cn(
-          "px-2 pb-1 text-[11px] font-semibold uppercase tracking-wide",
+          "flex items-center gap-1.5 px-2 pb-1 text-[11px] font-semibold uppercase tracking-wide",
           accent ? "text-status-blocked" : "text-muted-foreground",
         )}
       >
+        <span aria-hidden="true" className={cn("size-1.5 shrink-0 rounded-full", dot)} />
         {label} <span className="opacity-60">({count})</span>
       </h3>
       {children}
@@ -119,75 +105,40 @@ function PaneRow({
   pane,
   active,
   onSelect,
-  onClose,
-  confirming,
-  closing,
 }: {
   pane: AgentView;
   active: boolean;
   onSelect: (paneId: string) => void;
-  onClose?: (paneId: string) => void;
-  confirming?: boolean;
-  closing?: boolean;
 }) {
   const isShell = pane.kind === "shell";
   // A user label leads, then Claude's /rename session name, then the agent/shell name (the icon still
   // conveys the agent). See paneDisplayName.
   const name = paneDisplayName(pane);
-  // A row is a container, not one big button: the select tap and the ✕ are separate controls, so they
-  // can't be nested <button>s. The active/hover highlight lives on the container; the inner button is
-  // transparent and carries aria-current.
   return (
-    <div
+    <button
+      type="button"
+      onClick={() => onSelect(pane.paneId)}
+      aria-current={active ? "page" : undefined}
       className={cn(
-        "flex w-full items-center gap-1 rounded-lg pr-1 transition-colors",
+        "flex w-full min-w-0 items-center gap-2.5 rounded-lg px-2.5 py-2 text-left transition-colors",
         active ? "bg-accent text-accent-foreground" : "hover:bg-muted/60 active:bg-muted",
       )}
     >
-      <button
-        type="button"
-        onClick={() => onSelect(pane.paneId)}
-        aria-current={active ? "page" : undefined}
-        className="flex min-w-0 flex-1 items-center gap-2.5 rounded-lg px-2.5 py-2 text-left"
-      >
-        {isShell ? (
-          <TerminalSquare className="size-3.5 shrink-0 text-muted-foreground" />
-        ) : (
-          // Status is conveyed by the section grouping; the row leads with the agent's logo.
-          <AgentIcon agent={pane.agent} className="size-5" />
-        )}
-        <div className="min-w-0 flex-1">
-          <div className="flex items-center gap-1.5">
-            <span className="truncate text-sm font-medium">{name}</span>
-            <span className="truncate text-[11px] text-muted-foreground">· {pane.workspaceLabel}</span>
-          </div>
-          <div className="truncate font-mono text-[11px] text-muted-foreground">
-            {shortCwd(pane.cwd)}
-          </div>
-        </div>
-      </button>
-      {onClose && (
-        <button
-          type="button"
-          onClick={() => onClose(pane.paneId)}
-          disabled={closing}
-          aria-label={confirming ? `Confirm closing ${name}` : `Close ${name}`}
-          className={cn(
-            "shrink-0 rounded-md text-[11px] font-medium transition-colors disabled:opacity-60",
-            confirming
-              ? "bg-destructive px-2 py-1.5 text-destructive-foreground"
-              : "flex size-8 items-center justify-center text-muted-foreground/50 hover:bg-muted hover:text-destructive",
-          )}
-        >
-          {closing ? (
-            <Loader2 className="size-3.5 animate-spin" />
-          ) : confirming ? (
-            "Close?"
-          ) : (
-            <X className="size-4" />
-          )}
-        </button>
+      {isShell ? (
+        <TerminalSquare className="size-3.5 shrink-0 text-muted-foreground" />
+      ) : (
+        // Status is conveyed by the section grouping; the row leads with the agent's logo.
+        <AgentIcon agent={pane.agent} className="size-5" />
       )}
-    </div>
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-1.5">
+          <span className="truncate text-sm font-medium">{name}</span>
+          <span className="truncate text-[11px] text-muted-foreground">· {pane.workspaceLabel}</span>
+        </div>
+        <div className="truncate font-mono text-[11px] text-muted-foreground">
+          {shortCwd(pane.cwd)}
+        </div>
+      </div>
+    </button>
   );
 }

--- a/web/src/components/agent-sidebar.tsx
+++ b/web/src/components/agent-sidebar.tsx
@@ -130,7 +130,8 @@ function PaneRow({
   closing?: boolean;
 }) {
   const isShell = pane.kind === "shell";
-  const name = isShell ? "shell" : pane.agent;
+  // A user-set pane label leads (the icon still conveys the agent); falls back to the agent/shell name.
+  const name = pane.paneLabel ?? (isShell ? "shell" : pane.agent);
   // A row is a container, not one big button: the select tap and the ✕ are separate controls, so they
   // can't be nested <button>s. The active/hover highlight lives on the container; the inner button is
   // transparent and carries aria-current.

--- a/web/src/components/pane-actions-sheet.test.tsx
+++ b/web/src/components/pane-actions-sheet.test.tsx
@@ -7,9 +7,10 @@ import { clearStatus } from "@/lib/status";
 import type { AgentView } from "@/lib/types";
 import { PaneActionsSheet } from "./pane-actions-sheet";
 
-// The long-press pane actions sheet: rename (set/clear the label) and close (two-tap kill). Both are
-// wired straight to the bridge via lib/api (exercised through MSW here); the parent gets onRenamed /
-// onClosed callbacks for the revalidate/navigate side-effects.
+// The long-press pane actions sheet: an action-list first view (Rename / Close pane), with rename
+// tucked behind its own tap so opening the sheet never shoves a keyboard-triggering input at you.
+// Both actions are wired straight to the bridge via lib/api (exercised through MSW here); the parent
+// gets onRenamed / onClosed callbacks for the revalidate/navigate side-effects.
 
 beforeEach(() => clearStatus());
 
@@ -38,10 +39,45 @@ function renderSheet(overrides: Partial<React.ComponentProps<typeof PaneActionsS
   return props;
 }
 
+describe("PaneActionsSheet — action list", () => {
+  it("opens on the action list, not the rename input", () => {
+    renderSheet();
+    expect(screen.getByRole("button", { name: "Rename" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Close pane" })).toBeInTheDocument();
+    expect(screen.queryByPlaceholderText("name this pane")).toBeNull();
+  });
+
+  it("color-codes the Close pane row as destructive from the first tap, not just once armed", () => {
+    renderSheet();
+    expect(screen.getByRole("button", { name: "Close pane" })).toHaveClass("text-destructive");
+  });
+});
+
 describe("PaneActionsSheet — rename", () => {
-  it("prefills the input from the pane's current label", () => {
+  it("stays on the action list until Rename is tapped, then shows the prefilled input", async () => {
+    const user = userEvent.setup();
     renderSheet({ pane: { ...agent, paneLabel: "deploy" } });
+    expect(screen.queryByPlaceholderText("name this pane")).toBeNull();
+
+    await user.click(screen.getByRole("button", { name: "Rename" }));
     expect(screen.getByPlaceholderText("name this pane")).toHaveValue("deploy");
+  });
+
+  it("autofocuses the input once rename mode opens", async () => {
+    const user = userEvent.setup();
+    renderSheet();
+    await user.click(screen.getByRole("button", { name: "Rename" }));
+    await waitFor(() => expect(screen.getByPlaceholderText("name this pane")).toHaveFocus());
+  });
+
+  it("Back returns to the action list without saving", async () => {
+    const user = userEvent.setup();
+    renderSheet();
+    await user.click(screen.getByRole("button", { name: "Rename" }));
+    await user.click(screen.getByRole("button", { name: "Back" }));
+
+    expect(screen.queryByPlaceholderText("name this pane")).toBeNull();
+    expect(screen.getByRole("button", { name: "Rename" })).toBeInTheDocument();
   });
 
   it("posts the trimmed label, then calls onRenamed and closes", async () => {
@@ -54,6 +90,7 @@ describe("PaneActionsSheet — rename", () => {
       }),
     );
     const props = renderSheet();
+    await user.click(screen.getByRole("button", { name: "Rename" }));
     const input = screen.getByPlaceholderText("name this pane");
     await user.type(input, "  deploy  ");
     await user.click(screen.getByRole("button", { name: "Save" }));
@@ -73,6 +110,7 @@ describe("PaneActionsSheet — rename", () => {
       }),
     );
     const props = renderSheet({ pane: { ...agent, paneLabel: "deploy" } });
+    await user.click(screen.getByRole("button", { name: "Rename" }));
     await user.clear(screen.getByPlaceholderText("name this pane"));
     await user.click(screen.getByRole("button", { name: "Save" }));
 
@@ -86,6 +124,7 @@ describe("PaneActionsSheet — rename", () => {
       http.post(/\/api\/pane\/[^/]+\/rename$/, () => HttpResponse.json({ ok: false, error: "pane not found" })),
     );
     const props = renderSheet();
+    await user.click(screen.getByRole("button", { name: "Rename" }));
     await user.type(screen.getByPlaceholderText("name this pane"), "x");
     await user.click(screen.getByRole("button", { name: "Save" }));
 
@@ -93,6 +132,32 @@ describe("PaneActionsSheet — rename", () => {
     await waitFor(() => expect(screen.getByRole("button", { name: "Save" })).not.toBeDisabled());
     expect(props.onRenamed).not.toHaveBeenCalled();
     expect(props.onClose).not.toHaveBeenCalled();
+  });
+
+  it("resets back to the action list when the sheet reopens, even mid-rename", async () => {
+    const user = userEvent.setup();
+    const { rerender } = render(<PaneActionsSheet open={true} onClose={vi.fn()} pane={agent} onRenamed={vi.fn()} onClosed={vi.fn()} />);
+    await user.click(screen.getByRole("button", { name: "Rename" }));
+    expect(screen.getByPlaceholderText("name this pane")).toBeInTheDocument();
+
+    rerender(<PaneActionsSheet open={false} onClose={vi.fn()} pane={agent} onRenamed={vi.fn()} onClosed={vi.fn()} />);
+    rerender(<PaneActionsSheet open={true} onClose={vi.fn()} pane={agent} onRenamed={vi.fn()} onClosed={vi.fn()} />);
+
+    expect(screen.queryByPlaceholderText("name this pane")).toBeNull();
+    expect(screen.getByRole("button", { name: "Rename" })).toBeInTheDocument();
+  });
+
+  it("resets back to the action list when the target pane changes, even mid-rename", async () => {
+    const user = userEvent.setup();
+    const other: AgentView = { ...agent, paneId: "w1:p2" };
+    const { rerender } = render(<PaneActionsSheet open={true} onClose={vi.fn()} pane={agent} onRenamed={vi.fn()} onClosed={vi.fn()} />);
+    await user.click(screen.getByRole("button", { name: "Rename" }));
+    expect(screen.getByPlaceholderText("name this pane")).toBeInTheDocument();
+
+    rerender(<PaneActionsSheet open={true} onClose={vi.fn()} pane={other} onRenamed={vi.fn()} onClosed={vi.fn()} />);
+
+    expect(screen.queryByPlaceholderText("name this pane")).toBeNull();
+    expect(screen.getByRole("button", { name: "Rename" })).toBeInTheDocument();
   });
 });
 
@@ -114,6 +179,7 @@ describe("PaneActionsSheet — read-only", () => {
   it("shows a note and no write actions when the device isn't authorised", () => {
     renderSheet({ readOnly: true });
     expect(screen.getByText(/read-only/i)).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Rename" })).toBeNull();
     expect(screen.queryByPlaceholderText("name this pane")).toBeNull();
     expect(screen.queryByRole("button", { name: "Save" })).toBeNull();
     expect(screen.queryByRole("button", { name: "Close pane" })).toBeNull();

--- a/web/src/components/pane-actions-sheet.test.tsx
+++ b/web/src/components/pane-actions-sheet.test.tsx
@@ -1,0 +1,121 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+
+import { server } from "@/test/setup";
+import { clearStatus } from "@/lib/status";
+import type { AgentView } from "@/lib/types";
+import { PaneActionsSheet } from "./pane-actions-sheet";
+
+// The long-press pane actions sheet: rename (set/clear the label) and close (two-tap kill). Both are
+// wired straight to the bridge via lib/api (exercised through MSW here); the parent gets onRenamed /
+// onClosed callbacks for the revalidate/navigate side-effects.
+
+beforeEach(() => clearStatus());
+
+const agent: AgentView = {
+  paneId: "w1:p1",
+  workspaceId: "w1",
+  workspaceLabel: "webapp",
+  workspaceNumber: 1,
+  tabId: "w1:t1",
+  agent: "claude",
+  status: "idle",
+  cwd: "/home/you/webapp",
+  focused: false,
+};
+
+function renderSheet(overrides: Partial<React.ComponentProps<typeof PaneActionsSheet>> = {}) {
+  const props: React.ComponentProps<typeof PaneActionsSheet> = {
+    open: true,
+    onClose: vi.fn(),
+    pane: agent,
+    onRenamed: vi.fn(),
+    onClosed: vi.fn(),
+    ...overrides,
+  };
+  render(<PaneActionsSheet {...props} />);
+  return props;
+}
+
+describe("PaneActionsSheet — rename", () => {
+  it("prefills the input from the pane's current label", () => {
+    renderSheet({ pane: { ...agent, paneLabel: "deploy" } });
+    expect(screen.getByPlaceholderText("name this pane")).toHaveValue("deploy");
+  });
+
+  it("posts the trimmed label, then calls onRenamed and closes", async () => {
+    const user = userEvent.setup();
+    let body: unknown;
+    server.use(
+      http.post(/\/api\/pane\/[^/]+\/rename$/, async ({ request }) => {
+        body = await request.json();
+        return HttpResponse.json({ ok: true });
+      }),
+    );
+    const props = renderSheet();
+    const input = screen.getByPlaceholderText("name this pane");
+    await user.type(input, "  deploy  ");
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(props.onRenamed).toHaveBeenCalledTimes(1));
+    expect(body).toEqual({ label: "deploy" });
+    expect(props.onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("clears the label by saving an empty field (sends an empty label)", async () => {
+    const user = userEvent.setup();
+    let body: unknown;
+    server.use(
+      http.post(/\/api\/pane\/[^/]+\/rename$/, async ({ request }) => {
+        body = await request.json();
+        return HttpResponse.json({ ok: true });
+      }),
+    );
+    const props = renderSheet({ pane: { ...agent, paneLabel: "deploy" } });
+    await user.clear(screen.getByPlaceholderText("name this pane"));
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(props.onRenamed).toHaveBeenCalledTimes(1));
+    expect(body).toEqual({ label: "" });
+  });
+
+  it("does NOT revalidate or close when the rename fails (error goes to the status channel)", async () => {
+    const user = userEvent.setup();
+    server.use(
+      http.post(/\/api\/pane\/[^/]+\/rename$/, () => HttpResponse.json({ ok: false, error: "pane not found" })),
+    );
+    const props = renderSheet();
+    await user.type(screen.getByPlaceholderText("name this pane"), "x");
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    // The sheet stays open (Save still enabled) and neither side-effect fires.
+    await waitFor(() => expect(screen.getByRole("button", { name: "Save" })).not.toBeDisabled());
+    expect(props.onRenamed).not.toHaveBeenCalled();
+    expect(props.onClose).not.toHaveBeenCalled();
+  });
+});
+
+describe("PaneActionsSheet — close", () => {
+  it("closes only after a two-tap confirm, then calls onClosed and closes the sheet", async () => {
+    const user = userEvent.setup();
+    const props = renderSheet();
+
+    await user.click(screen.getByRole("button", { name: "Close pane" }));
+    expect(props.onClosed).not.toHaveBeenCalled(); // first tap only arms
+
+    await user.click(screen.getByRole("button", { name: "Tap again to close" }));
+    await waitFor(() => expect(props.onClosed).toHaveBeenCalledExactlyOnceWith("w1:p1"));
+    expect(props.onClose).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("PaneActionsSheet — read-only", () => {
+  it("shows a note and no write actions when the device isn't authorised", () => {
+    renderSheet({ readOnly: true });
+    expect(screen.getByText(/read-only/i)).toBeInTheDocument();
+    expect(screen.queryByPlaceholderText("name this pane")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Save" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Close pane" })).toBeNull();
+  });
+});

--- a/web/src/components/pane-actions-sheet.tsx
+++ b/web/src/components/pane-actions-sheet.tsx
@@ -1,9 +1,10 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { KeyboardEvent as ReactKeyboardEvent } from "react";
-import { Loader2 } from "lucide-react";
+import { ChevronLeft, Loader2, Pencil, XCircle } from "lucide-react";
 
 import { BottomSheet } from "@/components/ui/sheet";
 import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 import { usePendingConfirm } from "@/hooks/use-pending-confirm";
 import * as api from "@/lib/api";
 import { setStatus } from "@/lib/status";
@@ -26,10 +27,15 @@ interface PaneActionsSheetProps {
   onClosed: (paneId: string) => void;
 }
 
+type Mode = "actions" | "rename";
+
 // Long-press actions for a single pane: rename (set/clear its label) and close (kill). Reached by
-// long-pressing a pane pill. The label is user text rendered only into an <input> value / text node
-// — never markup — so it stays within the pane-output XSS boundary. Both actions are writes, so under
-// read-only they're replaced by a note. Close reuses the app's two-tap arm-then-confirm.
+// long-pressing a pane pill. Opens on an action-list view (Rename / Close pane); rename is a second
+// tap away so the sheet doesn't shove a keyboard-triggering input at you just to close a pane. The
+// label is user text rendered only into an <input> value / text node — never markup — so it stays
+// within the pane-output XSS boundary. Both actions are writes, so under read-only they're replaced
+// by a note. Close reuses the app's two-tap arm-then-confirm and is destructive-styled from the very
+// first tap, not just once armed.
 export function PaneActionsSheet({
   open,
   onClose,
@@ -39,19 +45,28 @@ export function PaneActionsSheet({
   onRenamed,
   onClosed,
 }: PaneActionsSheetProps) {
+  const [mode, setMode] = useState<Mode>("actions");
   const [label, setLabel] = useState("");
   const [saving, setSaving] = useState(false);
   const [closing, setClosing] = useState(false);
   const { pending, confirm, reset } = usePendingConfirm();
+  const inputRef = useRef<HTMLInputElement>(null);
 
-  // Prefill the input from the current label whenever the sheet opens on a (new) pane. Intentionally
-  // NOT keyed on the live label, so a background poll landing while you type can't clobber your edit.
+  // Reset to the action list — and reprefill the label — whenever the sheet opens on a (new) pane,
+  // AND whenever it closes, so reopening never lands you mid-rename. Intentionally NOT keyed on the
+  // live label, so a background poll landing while you type can't clobber your edit.
   useEffect(() => {
+    setMode("actions");
     if (!open) return;
     setLabel(pane?.paneLabel ?? "");
     reset();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open, pane?.paneId]);
+
+  // Autofocus the label input when rename mode opens, so the phone keyboard pops without a second tap.
+  useEffect(() => {
+    if (mode === "rename") inputRef.current?.focus();
+  }, [mode]);
 
   async function save() {
     if (!pane || saving) return;
@@ -73,7 +88,7 @@ export function PaneActionsSheet({
     }
   }
 
-  // Two-tap: the first tap arms (button flips to "Tap again to close"), the second closes.
+  // Two-tap: the first tap arms (row flips to "Tap again to close"), the second closes.
   async function requestClose() {
     if (!pane || closing) return;
     if (!confirm(pane.paneId)) return;
@@ -108,11 +123,51 @@ export function PaneActionsSheet({
         <p className="py-2 text-sm text-muted-foreground">
           Read-only — this device isn't authorised to rename or close panes.
         </p>
+      ) : mode === "actions" ? (
+        <div className="flex flex-col gap-1">
+          <button
+            type="button"
+            onClick={() => setMode("rename")}
+            className="flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left text-sm font-medium transition-colors hover:bg-accent active:bg-muted"
+          >
+            <Pencil className="size-4 shrink-0 text-muted-foreground" />
+            Rename
+          </button>
+
+          {/* Close (kill) — destructive-styled from the first tap, not just once armed; two-tap confirmed. */}
+          <button
+            type="button"
+            onClick={() => void requestClose()}
+            disabled={closing}
+            className={cn(
+              "flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left text-sm font-medium transition-colors disabled:opacity-60",
+              confirming
+                ? "bg-destructive text-destructive-foreground"
+                : "text-destructive hover:bg-destructive/10 active:bg-destructive/15",
+            )}
+          >
+            {closing ? (
+              <Loader2 className="size-4 shrink-0 animate-spin" />
+            ) : (
+              <XCircle className="size-4 shrink-0" />
+            )}
+            {closing ? "Closing…" : confirming ? "Tap again to close" : "Close pane"}
+          </button>
+        </div>
       ) : (
         <div className="flex flex-col gap-3">
+          <button
+            type="button"
+            onClick={() => setMode("actions")}
+            className="flex items-center gap-1 self-start rounded-md py-1 pr-2 text-xs font-medium text-muted-foreground transition-colors active:bg-muted"
+          >
+            <ChevronLeft className="size-3.5" />
+            Back
+          </button>
           <label className="flex flex-col gap-1">
             <span className="text-xs font-medium text-muted-foreground">Label</span>
             <input
+              ref={inputRef}
               value={label}
               onChange={(e) => setLabel(e.target.value)}
               onKeyDown={onInputKeyDown}
@@ -123,24 +178,6 @@ export function PaneActionsSheet({
           <Button onClick={() => void save()} disabled={saving} className="h-11">
             {saving ? <Loader2 className="size-4 animate-spin" /> : "Save"}
           </Button>
-
-          {/* Close (kill) — separated so it doesn't sit flush against Save, and two-tap confirmed. */}
-          <div className="mt-1 border-t border-border/60 pt-3">
-            <Button
-              variant={confirming ? "destructive" : "outline"}
-              onClick={() => void requestClose()}
-              disabled={closing}
-              className="h-11 w-full"
-            >
-              {closing ? (
-                <Loader2 className="size-4 animate-spin" />
-              ) : confirming ? (
-                "Tap again to close"
-              ) : (
-                "Close pane"
-              )}
-            </Button>
-          </div>
         </div>
       )}
     </BottomSheet>

--- a/web/src/components/pane-actions-sheet.tsx
+++ b/web/src/components/pane-actions-sheet.tsx
@@ -1,0 +1,152 @@
+import { useEffect, useState } from "react";
+import type { KeyboardEvent as ReactKeyboardEvent } from "react";
+import { Loader2 } from "lucide-react";
+
+import { BottomSheet } from "@/components/ui/sheet";
+import { Button } from "@/components/ui/button";
+import { usePendingConfirm } from "@/hooks/use-pending-confirm";
+import * as api from "@/lib/api";
+import { setStatus } from "@/lib/status";
+import type { AgentView } from "@/lib/types";
+
+interface PaneActionsSheetProps {
+  open: boolean;
+  onClose: () => void;
+  /** The pane these actions target. Null while nothing is selected (sheet closed). */
+  pane: AgentView | null;
+  /** Session scope for the rename/close writes (undefined = primary). */
+  session?: string;
+  /** This device isn't authorised to write — show a read-only note instead of the actions. */
+  readOnly?: boolean;
+  /** Fired after a successful rename so the parent can revalidate (the label lands on the next poll). */
+  onRenamed: () => void;
+  /** Fired after a successful close, with the closed pane id — the parent navigates Home if it's the
+   *  pane currently open, or revalidates so it drops out of the list. */
+  onClosed: (paneId: string) => void;
+}
+
+/** The display name of a pane: its user label if set, else the agent name (or "shell"). */
+function paneName(pane: AgentView): string {
+  return pane.paneLabel ?? (pane.kind === "shell" ? "shell" : pane.agent);
+}
+
+// Long-press actions for a single pane: rename (set/clear its label) and close (kill). Reached by
+// long-pressing a pane pill. The label is user text rendered only into an <input> value / text node
+// — never markup — so it stays within the pane-output XSS boundary. Both actions are writes, so under
+// read-only they're replaced by a note. Close reuses the app's two-tap arm-then-confirm.
+export function PaneActionsSheet({
+  open,
+  onClose,
+  pane,
+  session,
+  readOnly = false,
+  onRenamed,
+  onClosed,
+}: PaneActionsSheetProps) {
+  const [label, setLabel] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [closing, setClosing] = useState(false);
+  const { pending, confirm, reset } = usePendingConfirm();
+
+  // Prefill the input from the current label whenever the sheet opens on a (new) pane. Intentionally
+  // NOT keyed on the live label, so a background poll landing while you type can't clobber your edit.
+  useEffect(() => {
+    if (!open) return;
+    setLabel(pane?.paneLabel ?? "");
+    reset();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, pane?.paneId]);
+
+  async function save() {
+    if (!pane || saving) return;
+    const next = label.trim();
+    setSaving(true);
+    try {
+      const res = await api.renamePane(pane.paneId, next, session);
+      if (res.ok) {
+        setStatus(next ? "Renamed" : "Label cleared", "success");
+        onRenamed();
+        onClose();
+      } else {
+        setStatus(res.error ?? "Rename failed", "error");
+      }
+    } catch (e) {
+      setStatus(e instanceof Error ? e.message : String(e), "error");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  // Two-tap: the first tap arms (button flips to "Tap again to close"), the second closes.
+  async function requestClose() {
+    if (!pane || closing) return;
+    if (!confirm(pane.paneId)) return;
+    setClosing(true);
+    try {
+      const res = await api.closePane(pane.paneId, session);
+      if (res.ok) {
+        onClose();
+        onClosed(pane.paneId);
+      } else {
+        setStatus(res.error ?? "Close failed", "error");
+      }
+    } catch (e) {
+      setStatus(e instanceof Error ? e.message : String(e), "error");
+    } finally {
+      setClosing(false);
+    }
+  }
+
+  function onInputKeyDown(e: ReactKeyboardEvent<HTMLInputElement>) {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      void save();
+    }
+  }
+
+  const confirming = !!pane && pending === pane.paneId;
+
+  return (
+    <BottomSheet open={open} onClose={onClose} title={pane ? paneName(pane) : "Pane"}>
+      {readOnly ? (
+        <p className="py-2 text-sm text-muted-foreground">
+          Read-only — this device isn't authorised to rename or close panes.
+        </p>
+      ) : (
+        <div className="flex flex-col gap-3">
+          <label className="flex flex-col gap-1">
+            <span className="text-xs font-medium text-muted-foreground">Label</span>
+            <input
+              value={label}
+              onChange={(e) => setLabel(e.target.value)}
+              onKeyDown={onInputKeyDown}
+              placeholder="name this pane"
+              className="h-11 rounded-lg border border-border bg-background px-3 text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+            />
+          </label>
+          <Button onClick={() => void save()} disabled={saving} className="h-11">
+            {saving ? <Loader2 className="size-4 animate-spin" /> : "Save"}
+          </Button>
+
+          {/* Close (kill) — separated so it doesn't sit flush against Save, and two-tap confirmed. */}
+          <div className="mt-1 border-t border-border/60 pt-3">
+            <Button
+              variant={confirming ? "destructive" : "outline"}
+              onClick={() => void requestClose()}
+              disabled={closing}
+              className="h-11 w-full"
+            >
+              {closing ? (
+                <Loader2 className="size-4 animate-spin" />
+              ) : confirming ? (
+                "Tap again to close"
+              ) : (
+                "Close pane"
+              )}
+            </Button>
+          </div>
+        </div>
+      )}
+    </BottomSheet>
+  );
+}

--- a/web/src/components/pane-actions-sheet.tsx
+++ b/web/src/components/pane-actions-sheet.tsx
@@ -1,10 +1,8 @@
 import { useEffect, useRef, useState } from "react";
-import type { KeyboardEvent as ReactKeyboardEvent } from "react";
-import { ChevronLeft, Loader2, Pencil, XCircle } from "lucide-react";
+import { Pencil, XCircle } from "lucide-react";
 
 import { BottomSheet } from "@/components/ui/sheet";
-import { Button } from "@/components/ui/button";
-import { cn } from "@/lib/utils";
+import { ActionRow, DestructiveActionRow, RenameView } from "@/components/action-sheet-rows";
 import { usePendingConfirm } from "@/hooks/use-pending-confirm";
 import * as api from "@/lib/api";
 import { setStatus } from "@/lib/status";
@@ -32,10 +30,10 @@ type Mode = "actions" | "rename";
 // Long-press actions for a single pane: rename (set/clear its label) and close (kill). Reached by
 // long-pressing a pane pill. Opens on an action-list view (Rename / Close pane); rename is a second
 // tap away so the sheet doesn't shove a keyboard-triggering input at you just to close a pane. The
-// label is user text rendered only into an <input> value / text node — never markup — so it stays
-// within the pane-output XSS boundary. Both actions are writes, so under read-only they're replaced
-// by a note. Close reuses the app's two-tap arm-then-confirm and is destructive-styled from the very
-// first tap, not just once armed.
+// action rows + rename view are the SHARED pieces (action-sheet-rows) the tab sheet also uses, so the
+// two stay identical. The label is user text rendered only into an <input> value / text node — never
+// markup — so it stays within the pane-output XSS boundary. Both actions are writes, so under
+// read-only they're replaced by a note.
 export function PaneActionsSheet({
   open,
   onClose,
@@ -108,13 +106,6 @@ export function PaneActionsSheet({
     }
   }
 
-  function onInputKeyDown(e: ReactKeyboardEvent<HTMLInputElement>) {
-    if (e.key === "Enter") {
-      e.preventDefault();
-      void save();
-    }
-  }
-
   const confirming = !!pane && pending === pane.paneId;
 
   return (
@@ -125,60 +116,33 @@ export function PaneActionsSheet({
         </p>
       ) : mode === "actions" ? (
         <div className="flex flex-col gap-1">
-          <button
-            type="button"
+          <ActionRow
+            icon={<Pencil className="size-4 shrink-0 text-muted-foreground" />}
+            label="Rename"
             onClick={() => setMode("rename")}
-            className="flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left text-sm font-medium transition-colors hover:bg-accent active:bg-muted"
-          >
-            <Pencil className="size-4 shrink-0 text-muted-foreground" />
-            Rename
-          </button>
-
-          {/* Close (kill) — destructive-styled from the first tap, not just once armed; two-tap confirmed. */}
-          <button
-            type="button"
+          />
+          <DestructiveActionRow
+            icon={<XCircle className="size-4 shrink-0" />}
+            label="Close pane"
+            confirmLabel="Tap again to close"
+            closingLabel="Closing…"
+            armed={confirming}
+            closing={closing}
             onClick={() => void requestClose()}
-            disabled={closing}
-            className={cn(
-              "flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left text-sm font-medium transition-colors disabled:opacity-60",
-              confirming
-                ? "bg-destructive text-destructive-foreground"
-                : "text-destructive hover:bg-destructive/10 active:bg-destructive/15",
-            )}
-          >
-            {closing ? (
-              <Loader2 className="size-4 shrink-0 animate-spin" />
-            ) : (
-              <XCircle className="size-4 shrink-0" />
-            )}
-            {closing ? "Closing…" : confirming ? "Tap again to close" : "Close pane"}
-          </button>
+          />
         </div>
       ) : (
-        <div className="flex flex-col gap-3">
-          <button
-            type="button"
-            onClick={() => setMode("actions")}
-            className="flex items-center gap-1 self-start rounded-md py-1 pr-2 text-xs font-medium text-muted-foreground transition-colors active:bg-muted"
-          >
-            <ChevronLeft className="size-3.5" />
-            Back
-          </button>
-          <label className="flex flex-col gap-1">
-            <span className="text-xs font-medium text-muted-foreground">Label</span>
-            <input
-              ref={inputRef}
-              value={label}
-              onChange={(e) => setLabel(e.target.value)}
-              onKeyDown={onInputKeyDown}
-              placeholder="name this pane"
-              className="h-11 rounded-lg border border-border bg-background px-3 text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
-            />
-          </label>
-          <Button onClick={() => void save()} disabled={saving} className="h-11">
-            {saving ? <Loader2 className="size-4 animate-spin" /> : "Save"}
-          </Button>
-        </div>
+        <RenameView
+          inputRef={inputRef}
+          label={label}
+          onLabelChange={setLabel}
+          onSave={() => void save()}
+          onBack={() => setMode("actions")}
+          saving={saving}
+          // A blank pane field clears the label (blank → null on the bridge), so Save stays enabled.
+          canSave={true}
+          placeholder="name this pane"
+        />
       )}
     </BottomSheet>
   );

--- a/web/src/components/pane-actions-sheet.tsx
+++ b/web/src/components/pane-actions-sheet.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/components/ui/button";
 import { usePendingConfirm } from "@/hooks/use-pending-confirm";
 import * as api from "@/lib/api";
 import { setStatus } from "@/lib/status";
+import { paneDisplayName } from "@/lib/types";
 import type { AgentView } from "@/lib/types";
 
 interface PaneActionsSheetProps {
@@ -23,11 +24,6 @@ interface PaneActionsSheetProps {
   /** Fired after a successful close, with the closed pane id — the parent navigates Home if it's the
    *  pane currently open, or revalidates so it drops out of the list. */
   onClosed: (paneId: string) => void;
-}
-
-/** The display name of a pane: its user label if set, else the agent name (or "shell"). */
-function paneName(pane: AgentView): string {
-  return pane.paneLabel ?? (pane.kind === "shell" ? "shell" : pane.agent);
 }
 
 // Long-press actions for a single pane: rename (set/clear its label) and close (kill). Reached by
@@ -107,7 +103,7 @@ export function PaneActionsSheet({
   const confirming = !!pane && pending === pane.paneId;
 
   return (
-    <BottomSheet open={open} onClose={onClose} title={pane ? paneName(pane) : "Pane"}>
+    <BottomSheet open={open} onClose={onClose} title={pane ? paneDisplayName(pane) : "Pane"}>
       {readOnly ? (
         <p className="py-2 text-sm text-muted-foreground">
           Read-only — this device isn't authorised to rename or close panes.

--- a/web/src/components/pane-strip.test.tsx
+++ b/web/src/components/pane-strip.test.tsx
@@ -92,9 +92,9 @@ describe("PaneStrip", () => {
         onClosed={vi.fn()}
       />,
     );
-    expect(screen.queryByPlaceholderText("name this pane")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Rename" })).toBeNull();
     fireEvent.contextMenu(screen.getByRole("button", { name: /codex/ }));
-    expect(screen.getByPlaceholderText("name this pane")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Rename" })).toBeInTheDocument();
   });
 
   it("stays inert on contextmenu when the write actions are not wired", () => {
@@ -106,7 +106,7 @@ describe("PaneStrip", () => {
       />,
     );
     fireEvent.contextMenu(screen.getByRole("button", { name: /codex/ }));
-    expect(screen.queryByPlaceholderText("name this pane")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Rename" })).toBeNull();
   });
 
   // Tapping the already-active pill used to be a dead re-navigate (onSelect with the same id it's
@@ -124,9 +124,9 @@ describe("PaneStrip", () => {
         onClosed={vi.fn()}
       />,
     );
-    expect(screen.queryByPlaceholderText("name this pane")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Rename" })).toBeNull();
     await user.click(screen.getByRole("button", { name: /claude/ }));
-    expect(screen.getByPlaceholderText("name this pane")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Rename" })).toBeInTheDocument();
     expect(onSelect).not.toHaveBeenCalled();
   });
 
@@ -144,7 +144,7 @@ describe("PaneStrip", () => {
     );
     await user.click(screen.getByRole("button", { name: /codex/ }));
     expect(onSelect).toHaveBeenCalledExactlyOnceWith("w1:p2");
-    expect(screen.queryByPlaceholderText("name this pane")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Rename" })).toBeNull();
   });
 
   it("a tap of the ACTIVE pill still just re-selects (no-op) when actions are NOT wired", async () => {

--- a/web/src/components/pane-strip.test.tsx
+++ b/web/src/components/pane-strip.test.tsx
@@ -4,7 +4,12 @@ import userEvent from "@testing-library/user-event";
 import { PaneStrip } from "./pane-strip";
 import type { AgentView } from "@/lib/types";
 
-function pane(paneId: string, agent: string, kind: "agent" | "shell" = "agent"): AgentView {
+function pane(
+  paneId: string,
+  agent: string,
+  kind: "agent" | "shell" = "agent",
+  extra: Partial<AgentView> = {},
+): AgentView {
   return {
     paneId,
     workspaceId: "w1",
@@ -16,6 +21,7 @@ function pane(paneId: string, agent: string, kind: "agent" | "shell" = "agent"):
     cwd: "/home/proj",
     focused: false,
     kind,
+    ...extra,
   };
 }
 
@@ -41,6 +47,23 @@ describe("PaneStrip", () => {
     // The current pane (codex / w1:p2) is the one marked active.
     expect(screen.getByRole("button", { name: /codex/ })).toHaveAttribute("aria-current", "true");
     expect(screen.getByRole("button", { name: /claude/ })).not.toHaveAttribute("aria-current");
+  });
+
+  it("shows Claude's /rename session name on a pill when no user label is set", () => {
+    render(
+      <PaneStrip
+        panes={[
+          pane("w1:p1", "claude", "agent", { sessionName: "auth-refactor" }),
+          // A user label still wins over the session name.
+          pane("w1:p2", "claude", "agent", { sessionName: "ignored", paneLabel: "deploy" }),
+        ]}
+        currentPaneId="w1:p1"
+        onSelect={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("auth-refactor")).toBeInTheDocument();
+    expect(screen.getByText("deploy")).toBeInTheDocument();
+    expect(screen.queryByText("ignored")).toBeNull();
   });
 
   it("fires onSelect with the pane id when a pane is tapped", async () => {

--- a/web/src/components/pane-strip.test.tsx
+++ b/web/src/components/pane-strip.test.tsx
@@ -108,4 +108,56 @@ describe("PaneStrip", () => {
     fireEvent.contextMenu(screen.getByRole("button", { name: /codex/ }));
     expect(screen.queryByPlaceholderText("name this pane")).toBeNull();
   });
+
+  // Tapping the already-active pill used to be a dead re-navigate (onSelect with the same id it's
+  // already on). With actions wired, that tap now opens the same sheet a long-press would — so the
+  // pill is never a dead tap.
+  it("opens the actions sheet on a plain tap of the ACTIVE pill when actions are wired", async () => {
+    const user = userEvent.setup();
+    const onSelect = vi.fn();
+    render(
+      <PaneStrip
+        panes={[pane("w1:p1", "claude"), pane("w1:p2", "codex")]}
+        currentPaneId="w1:p1"
+        onSelect={onSelect}
+        onRenamed={vi.fn()}
+        onClosed={vi.fn()}
+      />,
+    );
+    expect(screen.queryByPlaceholderText("name this pane")).toBeNull();
+    await user.click(screen.getByRole("button", { name: /claude/ }));
+    expect(screen.getByPlaceholderText("name this pane")).toBeInTheDocument();
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it("still navigates on a tap of an INACTIVE pill even when actions are wired", async () => {
+    const user = userEvent.setup();
+    const onSelect = vi.fn();
+    render(
+      <PaneStrip
+        panes={[pane("w1:p1", "claude"), pane("w1:p2", "codex")]}
+        currentPaneId="w1:p1"
+        onSelect={onSelect}
+        onRenamed={vi.fn()}
+        onClosed={vi.fn()}
+      />,
+    );
+    await user.click(screen.getByRole("button", { name: /codex/ }));
+    expect(onSelect).toHaveBeenCalledExactlyOnceWith("w1:p2");
+    expect(screen.queryByPlaceholderText("name this pane")).toBeNull();
+  });
+
+  it("a tap of the ACTIVE pill still just re-selects (no-op) when actions are NOT wired", async () => {
+    const user = userEvent.setup();
+    const onSelect = vi.fn();
+    render(
+      <PaneStrip
+        panes={[pane("w1:p1", "claude"), pane("w1:p2", "codex")]}
+        currentPaneId="w1:p1"
+        onSelect={onSelect}
+      />,
+    );
+    await user.click(screen.getByRole("button", { name: /claude/ }));
+    expect(onSelect).toHaveBeenCalledExactlyOnceWith("w1:p1");
+  });
 });

--- a/web/src/components/pane-strip.test.tsx
+++ b/web/src/components/pane-strip.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import { PaneStrip } from "./pane-strip";
@@ -55,5 +55,34 @@ describe("PaneStrip", () => {
     );
     await user.click(screen.getByRole("button", { name: /codex/ }));
     expect(onSelect).toHaveBeenCalledExactlyOnceWith("w1:p2");
+  });
+
+  // A long-press on a pill reaches the DOM as a `contextmenu` event (Android Chrome / right-click);
+  // with the write actions wired it opens the actions sheet. This is the path the on-device bug broke.
+  it("opens the actions sheet on a long-press (contextmenu) when actions are wired", () => {
+    render(
+      <PaneStrip
+        panes={[pane("w1:p1", "claude"), pane("w1:p2", "codex")]}
+        currentPaneId="w1:p1"
+        onSelect={vi.fn()}
+        onRenamed={vi.fn()}
+        onClosed={vi.fn()}
+      />,
+    );
+    expect(screen.queryByPlaceholderText("name this pane")).toBeNull();
+    fireEvent.contextMenu(screen.getByRole("button", { name: /codex/ }));
+    expect(screen.getByPlaceholderText("name this pane")).toBeInTheDocument();
+  });
+
+  it("stays inert on contextmenu when the write actions are not wired", () => {
+    render(
+      <PaneStrip
+        panes={[pane("w1:p1", "claude"), pane("w1:p2", "codex")]}
+        currentPaneId="w1:p1"
+        onSelect={vi.fn()}
+      />,
+    );
+    fireEvent.contextMenu(screen.getByRole("button", { name: /codex/ }));
+    expect(screen.queryByPlaceholderText("name this pane")).toBeNull();
   });
 });

--- a/web/src/components/pane-strip.tsx
+++ b/web/src/components/pane-strip.tsx
@@ -1,8 +1,11 @@
+import { useState } from "react";
 import { TerminalSquare } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 import { SectionLabel } from "@/components/ui/section-label";
 import { StatusDot } from "@/components/status-badge";
+import { PaneActionsSheet } from "@/components/pane-actions-sheet";
+import { useLongPress } from "@/hooks/use-long-press";
 import type { AgentView } from "@/lib/types";
 
 interface PaneStripProps {
@@ -10,53 +13,112 @@ interface PaneStripProps {
   panes: AgentView[];
   currentPaneId: string;
   onSelect: (paneId: string) => void;
+  /** Session scope for the long-press pane actions (rename/close); undefined = primary. */
+  session?: string;
+  /** Drop the long-press write actions when the device isn't authorised. */
+  readOnly?: boolean;
+  /** Revalidate after a rename. Long-press pane actions turn on only when this AND onClosed are set. */
+  onRenamed?: () => void;
+  /** Navigate/refresh after a close (Home if it's the open pane). Enables long-press with onRenamed. */
+  onClosed?: (paneId: string) => void;
 }
 
 // The panes within the current tab, as a horizontal switcher one level below the tab bar
 // (space › tab › pane). Mobile deliberately doesn't replicate the desktop's pane tiling — a tab can
 // hold several panes, and this is just a quick way to flip between them. Rendered only when the tab
 // actually holds more than one pane (a lone pane needs no switcher), so it's an optional extra row.
-export function PaneStrip({ panes, currentPaneId, onSelect }: PaneStripProps) {
+// A long-press on a pill opens its actions sheet (rename / close) when the parent wires the actions.
+export function PaneStrip({
+  panes,
+  currentPaneId,
+  onSelect,
+  session,
+  readOnly,
+  onRenamed,
+  onClosed,
+}: PaneStripProps) {
+  const [sheetPane, setSheetPane] = useState<AgentView | null>(null);
+  // Actions need both callbacks wired (revalidate on rename, navigate on close); without them the
+  // pills stay plain tap-to-switch — long-press is inert.
+  const actionsEnabled = !!onRenamed && !!onClosed;
+
   if (panes.length < 2) return null;
 
   return (
-    <div className="flex items-center gap-2 overflow-x-auto border-t border-border/40 bg-muted/20 px-3 py-1.5 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
-      <SectionLabel>Panes</SectionLabel>
-      {panes.map((p) => {
-        const active = p.paneId === currentPaneId;
-        const isShell = p.kind === "shell";
-        // The "pN" suffix of the pane id disambiguates same-named panes (two claudes in one tab).
-        const tag = p.paneId.split(":").pop();
-        return (
-          <button
+    <>
+      <div className="flex items-center gap-2 overflow-x-auto border-t border-border/40 bg-muted/20 px-3 py-1.5 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+        <SectionLabel>Panes</SectionLabel>
+        {panes.map((p) => (
+          <PanePill
             key={p.paneId}
-            type="button"
-            onClick={() => onSelect(p.paneId)}
-            aria-current={active ? "true" : undefined}
-            className={cn(
-              "flex shrink-0 items-center gap-1.5 whitespace-nowrap rounded-full px-2.5 py-1 text-sm font-medium transition-colors active:scale-95",
-              active
-                ? "bg-primary text-primary-foreground"
-                : "bg-muted text-muted-foreground hover:bg-muted/70",
-            )}
-          >
-            {isShell ? (
-              <TerminalSquare className="size-3.5 shrink-0" />
-            ) : (
-              <StatusDot status={p.status} />
-            )}
-            <span>{isShell ? "shell" : p.agent}</span>
-            <span
-              className={cn(
-                "font-mono text-[10px]",
-                active ? "text-primary-foreground/70" : "text-muted-foreground/60",
-              )}
-            >
-              {tag}
-            </span>
-          </button>
-        );
-      })}
-    </div>
+            pane={p}
+            active={p.paneId === currentPaneId}
+            onSelect={onSelect}
+            onLongPress={actionsEnabled ? () => setSheetPane(p) : undefined}
+          />
+        ))}
+      </div>
+
+      {actionsEnabled && (
+        <PaneActionsSheet
+          open={sheetPane !== null}
+          onClose={() => setSheetPane(null)}
+          pane={sheetPane}
+          session={session}
+          readOnly={readOnly}
+          onRenamed={onRenamed}
+          onClosed={onClosed}
+        />
+      )}
+    </>
+  );
+}
+
+function PanePill({
+  pane,
+  active,
+  onSelect,
+  onLongPress,
+}: {
+  pane: AgentView;
+  active: boolean;
+  onSelect: (paneId: string) => void;
+  onLongPress?: () => void;
+}) {
+  const isShell = pane.kind === "shell";
+  // The "pN" suffix of the pane id disambiguates same-named panes (two claudes in one tab).
+  const tag = pane.paneId.split(":").pop();
+  // Prefer a user-set label over the agent/shell name — the icon still conveys which agent it is.
+  const name = pane.paneLabel ?? (isShell ? "shell" : pane.agent);
+  const longPress = useLongPress(onLongPress);
+
+  return (
+    <button
+      type="button"
+      onClick={() => onSelect(pane.paneId)}
+      {...longPress}
+      aria-current={active ? "true" : undefined}
+      className={cn(
+        "flex shrink-0 select-none items-center gap-1.5 whitespace-nowrap rounded-full px-2.5 py-1 text-sm font-medium transition-colors active:scale-95",
+        active
+          ? "bg-primary text-primary-foreground"
+          : "bg-muted text-muted-foreground hover:bg-muted/70",
+      )}
+    >
+      {isShell ? (
+        <TerminalSquare className="size-3.5 shrink-0" />
+      ) : (
+        <StatusDot status={pane.status} />
+      )}
+      <span>{name}</span>
+      <span
+        className={cn(
+          "font-mono text-[10px]",
+          active ? "text-primary-foreground/70" : "text-muted-foreground/60",
+        )}
+      >
+        {tag}
+      </span>
+    </button>
   );
 }

--- a/web/src/components/pane-strip.tsx
+++ b/web/src/components/pane-strip.tsx
@@ -99,7 +99,9 @@ function PanePill({
       {...longPress}
       aria-current={active ? "true" : undefined}
       className={cn(
-        "flex shrink-0 select-none items-center gap-1.5 whitespace-nowrap rounded-full px-2.5 py-1 text-sm font-medium transition-colors active:scale-95",
+        // select-none + -webkit-touch-callout:none stop iOS Safari's selection loupe / touch callout,
+        // whose native long-press gesture otherwise fires pointercancel and kills our hold timer.
+        "flex shrink-0 select-none [-webkit-touch-callout:none] items-center gap-1.5 whitespace-nowrap rounded-full px-2.5 py-1 text-sm font-medium transition-colors active:scale-95",
         active
           ? "bg-primary text-primary-foreground"
           : "bg-muted text-muted-foreground hover:bg-muted/70",

--- a/web/src/components/pane-strip.tsx
+++ b/web/src/components/pane-strip.tsx
@@ -6,6 +6,7 @@ import { SectionLabel } from "@/components/ui/section-label";
 import { StatusDot } from "@/components/status-badge";
 import { PaneActionsSheet } from "@/components/pane-actions-sheet";
 import { useLongPress } from "@/hooks/use-long-press";
+import { paneDisplayName } from "@/lib/types";
 import type { AgentView } from "@/lib/types";
 
 interface PaneStripProps {
@@ -88,8 +89,9 @@ function PanePill({
   const isShell = pane.kind === "shell";
   // The "pN" suffix of the pane id disambiguates same-named panes (two claudes in one tab).
   const tag = pane.paneId.split(":").pop();
-  // Prefer a user-set label over the agent/shell name — the icon still conveys which agent it is.
-  const name = pane.paneLabel ?? (isShell ? "shell" : pane.agent);
+  // A user label, then Claude's /rename session name, then the agent/shell name (see paneDisplayName)
+  // — the icon still conveys which agent it is.
+  const name = paneDisplayName(pane);
   const longPress = useLongPress(onLongPress);
 
   return (

--- a/web/src/components/pane-strip.tsx
+++ b/web/src/components/pane-strip.tsx
@@ -56,6 +56,9 @@ export function PaneStrip({
             active={p.paneId === currentPaneId}
             onSelect={onSelect}
             onLongPress={actionsEnabled ? () => setSheetPane(p) : undefined}
+            // Tapping the already-active pill would otherwise be a useless re-navigate; repurpose it
+            // to open the same actions sheet a long-press would, so it's not a dead tap.
+            onTapActive={actionsEnabled ? () => setSheetPane(p) : undefined}
           />
         ))}
       </div>
@@ -80,11 +83,14 @@ function PanePill({
   active,
   onSelect,
   onLongPress,
+  onTapActive,
 }: {
   pane: AgentView;
   active: boolean;
   onSelect: (paneId: string) => void;
   onLongPress?: () => void;
+  /** A plain tap on the pill when it's already `active` — opens actions instead of a no-op re-select. */
+  onTapActive?: () => void;
 }) {
   const isShell = pane.kind === "shell";
   // The "pN" suffix of the pane id disambiguates same-named panes (two claudes in one tab).
@@ -94,12 +100,23 @@ function PanePill({
   const name = paneDisplayName(pane);
   const longPress = useLongPress(onLongPress);
 
+  // A long-press already suppresses the ensuing click via longPress.onClickCapture (stops it before
+  // this ever runs), so this only ever sees a genuine tap.
+  function onClick() {
+    if (active && onTapActive) {
+      onTapActive();
+      return;
+    }
+    onSelect(pane.paneId);
+  }
+
   return (
     <button
       type="button"
-      onClick={() => onSelect(pane.paneId)}
+      onClick={onClick}
       {...longPress}
       aria-current={active ? "true" : undefined}
+      title={active && onTapActive ? "Tap for pane actions" : undefined}
       className={cn(
         // select-none + -webkit-touch-callout:none stop iOS Safari's selection loupe / touch callout,
         // whose native long-press gesture otherwise fires pointercancel and kills our hold timer.

--- a/web/src/components/tab-actions-sheet.test.tsx
+++ b/web/src/components/tab-actions-sheet.test.tsx
@@ -1,0 +1,145 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+
+import { server } from "@/test/setup";
+import { clearStatus } from "@/lib/status";
+import type { TabView } from "@/lib/types";
+import { TabActionsSheet } from "./tab-actions-sheet";
+
+// The long-press tab actions sheet: rename-only (herdr has tab.close, but Collie doesn't wire it), so
+// it opens straight into the prefilled rename input — no action list. A tab label can't be cleared
+// (herdr stores "" literally and rejects null), so a blank field can't be saved. Wired to the bridge
+// via lib/api (exercised through MSW); the parent gets onRenamed for the revalidate side-effect.
+
+beforeEach(() => clearStatus());
+
+const tab: TabView = {
+  tabId: "w1:t1",
+  workspaceId: "w1",
+  number: 1,
+  label: "1",
+  focused: true,
+  paneCount: 2,
+};
+
+function renderSheet(overrides: Partial<React.ComponentProps<typeof TabActionsSheet>> = {}) {
+  const props: React.ComponentProps<typeof TabActionsSheet> = {
+    open: true,
+    onClose: vi.fn(),
+    tab,
+    onRenamed: vi.fn(),
+    ...overrides,
+  };
+  render(<TabActionsSheet {...props} />);
+  return props;
+}
+
+describe("TabActionsSheet — rename", () => {
+  it("opens straight into the prefilled rename input (no action list)", () => {
+    renderSheet({ tab: { ...tab, label: "deploy" } });
+    expect(screen.getByPlaceholderText("name this tab")).toHaveValue("deploy");
+    // Rename-only: there's no separate "Rename" action row like the pane sheet has.
+    expect(screen.queryByRole("button", { name: "Rename" })).toBeNull();
+  });
+
+  it("autofocuses the input on open", async () => {
+    renderSheet();
+    await waitFor(() => expect(screen.getByPlaceholderText("name this tab")).toHaveFocus());
+  });
+
+  it("posts the trimmed label, then calls onRenamed and closes", async () => {
+    const user = userEvent.setup();
+    let body: unknown;
+    let url = "";
+    server.use(
+      http.post(/\/api\/tab\/[^/]+\/rename$/, async ({ request }) => {
+        url = request.url;
+        body = await request.json();
+        return HttpResponse.json({ ok: true });
+      }),
+    );
+    const props = renderSheet();
+    const input = screen.getByPlaceholderText("name this tab");
+    await user.clear(input);
+    await user.type(input, "  api  ");
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(props.onRenamed).toHaveBeenCalledTimes(1));
+    expect(body).toEqual({ label: "api" });
+    expect(url).toContain("/api/tab/w1%3At1/rename");
+    expect(props.onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables Save on a blank field — a tab has no clear", async () => {
+    const user = userEvent.setup();
+    renderSheet();
+    expect(screen.getByRole("button", { name: "Save" })).not.toBeDisabled();
+    await user.clear(screen.getByPlaceholderText("name this tab"));
+    expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
+  });
+
+  it("does NOT revalidate or close when the rename fails (error goes to the status channel)", async () => {
+    const user = userEvent.setup();
+    server.use(
+      http.post(/\/api\/tab\/[^/]+\/rename$/, () =>
+        HttpResponse.json({ ok: false, error: "tab not found" }),
+      ),
+    );
+    const props = renderSheet();
+    const input = screen.getByPlaceholderText("name this tab");
+    await user.clear(input);
+    await user.type(input, "x");
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(screen.getByRole("button", { name: "Save" })).not.toBeDisabled());
+    expect(props.onRenamed).not.toHaveBeenCalled();
+    expect(props.onClose).not.toHaveBeenCalled();
+  });
+
+  it("reprefills the current label when the sheet reopens, even mid-edit", async () => {
+    const user = userEvent.setup();
+    const { rerender } = render(
+      <TabActionsSheet open={true} onClose={vi.fn()} tab={tab} onRenamed={vi.fn()} />,
+    );
+    await user.clear(screen.getByPlaceholderText("name this tab"));
+    await user.type(screen.getByPlaceholderText("name this tab"), "half-typed");
+
+    rerender(<TabActionsSheet open={false} onClose={vi.fn()} tab={tab} onRenamed={vi.fn()} />);
+    rerender(<TabActionsSheet open={true} onClose={vi.fn()} tab={tab} onRenamed={vi.fn()} />);
+
+    expect(screen.getByPlaceholderText("name this tab")).toHaveValue("1");
+  });
+
+  it("reprefills when the target tab changes, even mid-edit", async () => {
+    const user = userEvent.setup();
+    const other: TabView = { ...tab, tabId: "w1:t2", label: "2" };
+    const { rerender } = render(
+      <TabActionsSheet open={true} onClose={vi.fn()} tab={tab} onRenamed={vi.fn()} />,
+    );
+    await user.clear(screen.getByPlaceholderText("name this tab"));
+    await user.type(screen.getByPlaceholderText("name this tab"), "half-typed");
+
+    rerender(<TabActionsSheet open={true} onClose={vi.fn()} tab={other} onRenamed={vi.fn()} />);
+
+    expect(screen.getByPlaceholderText("name this tab")).toHaveValue("2");
+  });
+
+  // The label is user text; it must render only as an <input> value / text node, never markup — same
+  // XSS boundary as pane labels and pane output.
+  it("renders a markup-looking label as literal text, injecting nothing", () => {
+    const xss = "<img src=x onerror=alert(1)>";
+    renderSheet({ tab: { ...tab, label: xss } });
+    expect(screen.getByPlaceholderText("name this tab")).toHaveValue(xss);
+    expect(document.querySelector("img")).toBeNull();
+  });
+});
+
+describe("TabActionsSheet — read-only", () => {
+  it("shows a note and no input when the device isn't authorised", () => {
+    renderSheet({ readOnly: true });
+    expect(screen.getByText(/read-only/i)).toBeInTheDocument();
+    expect(screen.queryByPlaceholderText("name this tab")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Save" })).toBeNull();
+  });
+});

--- a/web/src/components/tab-actions-sheet.test.tsx
+++ b/web/src/components/tab-actions-sheet.test.tsx
@@ -7,10 +7,12 @@ import { clearStatus } from "@/lib/status";
 import type { TabView } from "@/lib/types";
 import { TabActionsSheet } from "./tab-actions-sheet";
 
-// The long-press tab actions sheet: rename-only (herdr has tab.close, but Collie doesn't wire it), so
-// it opens straight into the prefilled rename input — no action list. A tab label can't be cleared
-// (herdr stores "" literally and rejects null), so a blank field can't be saved. Wired to the bridge
-// via lib/api (exercised through MSW); the parent gets onRenamed for the revalidate side-effect.
+// The long-press tab actions sheet — now STRUCTURALLY IDENTICAL to the pane sheet (the user asked for
+// them to match): an action-list first view (Rename / Close tab), with rename tucked behind its own
+// tap so opening the sheet never shoves a keyboard-triggering input at you. Two tab-specific rules,
+// both live-verified: a blank tab label can't be saved (herdr has no "clear" for a tab), and the
+// close confirm names the blast radius (closing a tab kills every pane in it). Wired to the bridge
+// via lib/api (exercised through MSW); the parent gets onRenamed / onClosed side-effect callbacks.
 
 beforeEach(() => clearStatus());
 
@@ -29,23 +31,52 @@ function renderSheet(overrides: Partial<React.ComponentProps<typeof TabActionsSh
     onClose: vi.fn(),
     tab,
     onRenamed: vi.fn(),
+    onClosed: vi.fn(),
     ...overrides,
   };
   render(<TabActionsSheet {...props} />);
   return props;
 }
 
-describe("TabActionsSheet — rename", () => {
-  it("opens straight into the prefilled rename input (no action list)", () => {
-    renderSheet({ tab: { ...tab, label: "deploy" } });
-    expect(screen.getByPlaceholderText("name this tab")).toHaveValue("deploy");
-    // Rename-only: there's no separate "Rename" action row like the pane sheet has.
-    expect(screen.queryByRole("button", { name: "Rename" })).toBeNull();
+describe("TabActionsSheet — action list", () => {
+  it("opens on the action list, not the rename input", () => {
+    renderSheet();
+    expect(screen.getByRole("button", { name: "Rename" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Close tab" })).toBeInTheDocument();
+    expect(screen.queryByPlaceholderText("name this tab")).toBeNull();
   });
 
-  it("autofocuses the input on open", async () => {
+  it("color-codes the Close tab row as destructive from the first tap, not just once armed", () => {
     renderSheet();
+    expect(screen.getByRole("button", { name: "Close tab" })).toHaveClass("text-destructive");
+  });
+});
+
+describe("TabActionsSheet — rename", () => {
+  it("stays on the action list until Rename is tapped, then shows the prefilled input", async () => {
+    const user = userEvent.setup();
+    renderSheet({ tab: { ...tab, label: "deploy" } });
+    expect(screen.queryByPlaceholderText("name this tab")).toBeNull();
+
+    await user.click(screen.getByRole("button", { name: "Rename" }));
+    expect(screen.getByPlaceholderText("name this tab")).toHaveValue("deploy");
+  });
+
+  it("autofocuses the input once rename mode opens", async () => {
+    const user = userEvent.setup();
+    renderSheet();
+    await user.click(screen.getByRole("button", { name: "Rename" }));
     await waitFor(() => expect(screen.getByPlaceholderText("name this tab")).toHaveFocus());
+  });
+
+  it("Back returns to the action list without saving", async () => {
+    const user = userEvent.setup();
+    renderSheet();
+    await user.click(screen.getByRole("button", { name: "Rename" }));
+    await user.click(screen.getByRole("button", { name: "Back" }));
+
+    expect(screen.queryByPlaceholderText("name this tab")).toBeNull();
+    expect(screen.getByRole("button", { name: "Rename" })).toBeInTheDocument();
   });
 
   it("posts the trimmed label, then calls onRenamed and closes", async () => {
@@ -60,6 +91,7 @@ describe("TabActionsSheet — rename", () => {
       }),
     );
     const props = renderSheet();
+    await user.click(screen.getByRole("button", { name: "Rename" }));
     const input = screen.getByPlaceholderText("name this tab");
     await user.clear(input);
     await user.type(input, "  api  ");
@@ -74,6 +106,7 @@ describe("TabActionsSheet — rename", () => {
   it("disables Save on a blank field — a tab has no clear", async () => {
     const user = userEvent.setup();
     renderSheet();
+    await user.click(screen.getByRole("button", { name: "Rename" }));
     expect(screen.getByRole("button", { name: "Save" })).not.toBeDisabled();
     await user.clear(screen.getByPlaceholderText("name this tab"));
     expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
@@ -87,6 +120,7 @@ describe("TabActionsSheet — rename", () => {
       ),
     );
     const props = renderSheet();
+    await user.click(screen.getByRole("button", { name: "Rename" }));
     const input = screen.getByPlaceholderText("name this tab");
     await user.clear(input);
     await user.type(input, "x");
@@ -97,49 +131,108 @@ describe("TabActionsSheet — rename", () => {
     expect(props.onClose).not.toHaveBeenCalled();
   });
 
-  it("reprefills the current label when the sheet reopens, even mid-edit", async () => {
+  it("resets back to the action list when the sheet reopens, even mid-rename", async () => {
     const user = userEvent.setup();
     const { rerender } = render(
-      <TabActionsSheet open={true} onClose={vi.fn()} tab={tab} onRenamed={vi.fn()} />,
+      <TabActionsSheet open={true} onClose={vi.fn()} tab={tab} onRenamed={vi.fn()} onClosed={vi.fn()} />,
     );
-    await user.clear(screen.getByPlaceholderText("name this tab"));
-    await user.type(screen.getByPlaceholderText("name this tab"), "half-typed");
+    await user.click(screen.getByRole("button", { name: "Rename" }));
+    expect(screen.getByPlaceholderText("name this tab")).toBeInTheDocument();
 
-    rerender(<TabActionsSheet open={false} onClose={vi.fn()} tab={tab} onRenamed={vi.fn()} />);
-    rerender(<TabActionsSheet open={true} onClose={vi.fn()} tab={tab} onRenamed={vi.fn()} />);
+    rerender(
+      <TabActionsSheet open={false} onClose={vi.fn()} tab={tab} onRenamed={vi.fn()} onClosed={vi.fn()} />,
+    );
+    rerender(
+      <TabActionsSheet open={true} onClose={vi.fn()} tab={tab} onRenamed={vi.fn()} onClosed={vi.fn()} />,
+    );
 
-    expect(screen.getByPlaceholderText("name this tab")).toHaveValue("1");
+    expect(screen.queryByPlaceholderText("name this tab")).toBeNull();
+    expect(screen.getByRole("button", { name: "Rename" })).toBeInTheDocument();
   });
 
-  it("reprefills when the target tab changes, even mid-edit", async () => {
+  it("resets back to the action list when the target tab changes, even mid-rename", async () => {
     const user = userEvent.setup();
     const other: TabView = { ...tab, tabId: "w1:t2", label: "2" };
     const { rerender } = render(
-      <TabActionsSheet open={true} onClose={vi.fn()} tab={tab} onRenamed={vi.fn()} />,
+      <TabActionsSheet open={true} onClose={vi.fn()} tab={tab} onRenamed={vi.fn()} onClosed={vi.fn()} />,
     );
-    await user.clear(screen.getByPlaceholderText("name this tab"));
-    await user.type(screen.getByPlaceholderText("name this tab"), "half-typed");
+    await user.click(screen.getByRole("button", { name: "Rename" }));
+    expect(screen.getByPlaceholderText("name this tab")).toBeInTheDocument();
 
-    rerender(<TabActionsSheet open={true} onClose={vi.fn()} tab={other} onRenamed={vi.fn()} />);
+    rerender(
+      <TabActionsSheet open={true} onClose={vi.fn()} tab={other} onRenamed={vi.fn()} onClosed={vi.fn()} />,
+    );
 
-    expect(screen.getByPlaceholderText("name this tab")).toHaveValue("2");
+    expect(screen.queryByPlaceholderText("name this tab")).toBeNull();
+    expect(screen.getByRole("button", { name: "Rename" })).toBeInTheDocument();
   });
 
   // The label is user text; it must render only as an <input> value / text node, never markup — same
   // XSS boundary as pane labels and pane output.
-  it("renders a markup-looking label as literal text, injecting nothing", () => {
+  it("renders a markup-looking label as literal text, injecting nothing", async () => {
+    const user = userEvent.setup();
     const xss = "<img src=x onerror=alert(1)>";
     renderSheet({ tab: { ...tab, label: xss } });
+    expect(document.querySelector("img")).toBeNull();
+    await user.click(screen.getByRole("button", { name: "Rename" }));
     expect(screen.getByPlaceholderText("name this tab")).toHaveValue(xss);
     expect(document.querySelector("img")).toBeNull();
   });
 });
 
+describe("TabActionsSheet — close", () => {
+  it("closes only after a two-tap confirm, then calls onClosed and closes the sheet", async () => {
+    const user = userEvent.setup();
+    let url = "";
+    server.use(
+      http.post(/\/api\/tab\/[^/]+\/close$/, ({ request }) => {
+        url = request.url;
+        return HttpResponse.json({ ok: true });
+      }),
+    );
+    const props = renderSheet();
+
+    await user.click(screen.getByRole("button", { name: "Close tab" }));
+    expect(props.onClosed).not.toHaveBeenCalled(); // first tap only arms
+
+    // Armed, the row names the blast radius (paneCount = 2).
+    await user.click(screen.getByRole("button", { name: "Tap again to close 2 panes" }));
+    await waitFor(() => expect(props.onClosed).toHaveBeenCalledExactlyOnceWith("w1:t1"));
+    expect(url).toContain("/api/tab/w1%3At1/close");
+    expect(props.onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("singularises the blast-radius confirm when the tab holds one pane", async () => {
+    const user = userEvent.setup();
+    renderSheet({ tab: { ...tab, paneCount: 1 } });
+    await user.click(screen.getByRole("button", { name: "Close tab" }));
+    expect(screen.getByRole("button", { name: "Tap again to close 1 pane" })).toBeInTheDocument();
+  });
+
+  it("does NOT close the sheet or fire onClosed when the close fails", async () => {
+    const user = userEvent.setup();
+    server.use(
+      http.post(/\/api\/tab\/[^/]+\/close$/, () =>
+        HttpResponse.json({ ok: false, error: "tab not found" }),
+      ),
+    );
+    const props = renderSheet();
+    await user.click(screen.getByRole("button", { name: "Close tab" }));
+    await user.click(screen.getByRole("button", { name: "Tap again to close 2 panes" }));
+
+    await waitFor(() => expect(screen.getByRole("button", { name: "Close tab" })).toBeInTheDocument());
+    expect(props.onClosed).not.toHaveBeenCalled();
+    expect(props.onClose).not.toHaveBeenCalled();
+  });
+});
+
 describe("TabActionsSheet — read-only", () => {
-  it("shows a note and no input when the device isn't authorised", () => {
+  it("shows a note and no write actions when the device isn't authorised", () => {
     renderSheet({ readOnly: true });
     expect(screen.getByText(/read-only/i)).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Rename" })).toBeNull();
     expect(screen.queryByPlaceholderText("name this tab")).toBeNull();
     expect(screen.queryByRole("button", { name: "Save" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Close tab" })).toBeNull();
   });
 });

--- a/web/src/components/tab-actions-sheet.tsx
+++ b/web/src/components/tab-actions-sheet.tsx
@@ -1,0 +1,113 @@
+import { useEffect, useRef, useState } from "react";
+import type { KeyboardEvent as ReactKeyboardEvent } from "react";
+import { Loader2 } from "lucide-react";
+
+import { BottomSheet } from "@/components/ui/sheet";
+import { Button } from "@/components/ui/button";
+import * as api from "@/lib/api";
+import { setStatus } from "@/lib/status";
+import type { TabView } from "@/lib/types";
+
+interface TabActionsSheetProps {
+  open: boolean;
+  onClose: () => void;
+  /** The tab this rename targets. Null while nothing is selected (sheet closed). */
+  tab: TabView | null;
+  /** Session scope for the rename write (undefined = primary). */
+  session?: string;
+  /** This device isn't authorised to write — show a read-only note instead of the input. */
+  readOnly?: boolean;
+  /** Fired after a successful rename so the parent can revalidate (the label lands on the next poll). */
+  onRenamed: () => void;
+}
+
+// Long-press actions for a single tab. Tabs support ONLY rename — herdr has a `tab.close` too, but
+// Collie deliberately doesn't wire tab-close — so, unlike the pane sheet's action list, this opens
+// straight into the rename input (no extra tap), with the current label prefilled and autofocused so
+// the phone keyboard pops immediately. Unlike a pane label, a tab label can't be cleared (herdr
+// stores an empty string literally and rejects null — both live-verified), so a blank field can't be
+// saved (Save disables). The label is user text rendered only into an <input> value / text node —
+// never markup — so it stays within the pane-output XSS boundary. Under read-only it's a note.
+export function TabActionsSheet({
+  open,
+  onClose,
+  tab,
+  session,
+  readOnly = false,
+  onRenamed,
+}: TabActionsSheetProps) {
+  const [label, setLabel] = useState("");
+  const [saving, setSaving] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Reprefill the label whenever the sheet opens on a (new) tab, so reopening never keeps a stale
+  // edit. Intentionally NOT keyed on the live label, so a background poll landing while you type
+  // can't clobber your edit.
+  useEffect(() => {
+    if (!open) return;
+    setLabel(tab?.label ?? "");
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, tab?.tabId]);
+
+  // Autofocus the input when the sheet opens (BottomSheet moves focus to the panel first; this
+  // parent-level effect runs after that child effect, so the input wins). Skipped under read-only,
+  // where there's no input.
+  useEffect(() => {
+    if (open && !readOnly) inputRef.current?.focus();
+  }, [open, readOnly]);
+
+  const trimmed = label.trim();
+
+  async function save() {
+    if (!tab || saving || !trimmed) return;
+    setSaving(true);
+    try {
+      const res = await api.renameTab(tab.tabId, trimmed, session);
+      if (res.ok) {
+        setStatus("Renamed", "success");
+        onRenamed();
+        onClose();
+      } else {
+        setStatus(res.error ?? "Rename failed", "error");
+      }
+    } catch (e) {
+      setStatus(e instanceof Error ? e.message : String(e), "error");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  function onInputKeyDown(e: ReactKeyboardEvent<HTMLInputElement>) {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      void save();
+    }
+  }
+
+  return (
+    <BottomSheet open={open} onClose={onClose} title="Rename tab">
+      {readOnly ? (
+        <p className="py-2 text-sm text-muted-foreground">
+          Read-only — this device isn't authorised to rename tabs.
+        </p>
+      ) : (
+        <div className="flex flex-col gap-3">
+          <label className="flex flex-col gap-1">
+            <span className="text-xs font-medium text-muted-foreground">Label</span>
+            <input
+              ref={inputRef}
+              value={label}
+              onChange={(e) => setLabel(e.target.value)}
+              onKeyDown={onInputKeyDown}
+              placeholder="name this tab"
+              className="h-11 rounded-lg border border-border bg-background px-3 text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+            />
+          </label>
+          <Button onClick={() => void save()} disabled={saving || !trimmed} className="h-11">
+            {saving ? <Loader2 className="size-4 animate-spin" /> : "Save"}
+          </Button>
+        </div>
+      )}
+    </BottomSheet>
+  );
+}

--- a/web/src/components/tab-actions-sheet.tsx
+++ b/web/src/components/tab-actions-sheet.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useRef, useState } from "react";
-import type { KeyboardEvent as ReactKeyboardEvent } from "react";
-import { Loader2 } from "lucide-react";
+import { Pencil, XCircle } from "lucide-react";
 
 import { BottomSheet } from "@/components/ui/sheet";
-import { Button } from "@/components/ui/button";
+import { ActionRow, DestructiveActionRow, RenameView } from "@/components/action-sheet-rows";
+import { usePendingConfirm } from "@/hooks/use-pending-confirm";
 import * as api from "@/lib/api";
 import { setStatus } from "@/lib/status";
 import type { TabView } from "@/lib/types";
@@ -11,23 +11,29 @@ import type { TabView } from "@/lib/types";
 interface TabActionsSheetProps {
   open: boolean;
   onClose: () => void;
-  /** The tab this rename targets. Null while nothing is selected (sheet closed). */
+  /** The tab these actions target. Null while nothing is selected (sheet closed). */
   tab: TabView | null;
-  /** Session scope for the rename write (undefined = primary). */
+  /** Session scope for the rename/close writes (undefined = primary). */
   session?: string;
-  /** This device isn't authorised to write — show a read-only note instead of the input. */
+  /** This device isn't authorised to write — show a read-only note instead of the actions. */
   readOnly?: boolean;
   /** Fired after a successful rename so the parent can revalidate (the label lands on the next poll). */
   onRenamed: () => void;
+  /** Fired after a successful close, with the closed tab id — the parent falls back to "All"/Home if
+   *  it was the selected/viewed tab, or revalidates so it drops out of the strip. */
+  onClosed: (tabId: string) => void;
 }
 
-// Long-press actions for a single tab. Tabs support ONLY rename — herdr has a `tab.close` too, but
-// Collie deliberately doesn't wire tab-close — so, unlike the pane sheet's action list, this opens
-// straight into the rename input (no extra tap), with the current label prefilled and autofocused so
-// the phone keyboard pops immediately. Unlike a pane label, a tab label can't be cleared (herdr
-// stores an empty string literally and rejects null — both live-verified), so a blank field can't be
-// saved (Save disables). The label is user text rendered only into an <input> value / text node —
-// never markup — so it stays within the pane-output XSS boundary. Under read-only it's a note.
+type Mode = "actions" | "rename";
+
+// Long-press actions for a single tab — the SAME structure as the pane sheet (the user asked for
+// them to match): opens on an action-list view (Rename / Close tab), with rename tucked behind its
+// own tap so opening the sheet never shoves a keyboard-triggering input at you. Shares the action
+// rows + rename view (action-sheet-rows) with the pane sheet so the two can't drift. Two differences
+// from a pane, both live-verified: a tab label can't be cleared (herdr stores "" literally and
+// rejects null), so a blank field can't be saved; and closing a tab kills EVERY pane inside it, so
+// the confirm names the blast radius. The label is user text rendered only into an <input> value /
+// text node — never markup. Both actions are writes, so under read-only they're replaced by a note.
 export function TabActionsSheet({
   open,
   onClose,
@@ -35,26 +41,30 @@ export function TabActionsSheet({
   session,
   readOnly = false,
   onRenamed,
+  onClosed,
 }: TabActionsSheetProps) {
+  const [mode, setMode] = useState<Mode>("actions");
   const [label, setLabel] = useState("");
   const [saving, setSaving] = useState(false);
+  const [closing, setClosing] = useState(false);
+  const { pending, confirm, reset } = usePendingConfirm();
   const inputRef = useRef<HTMLInputElement>(null);
 
-  // Reprefill the label whenever the sheet opens on a (new) tab, so reopening never keeps a stale
-  // edit. Intentionally NOT keyed on the live label, so a background poll landing while you type
-  // can't clobber your edit.
+  // Reset to the action list — and reprefill the label — whenever the sheet opens on a (new) tab, AND
+  // whenever it closes, so reopening never lands you mid-rename. Intentionally NOT keyed on the live
+  // label, so a background poll landing while you type can't clobber your edit.
   useEffect(() => {
+    setMode("actions");
     if (!open) return;
     setLabel(tab?.label ?? "");
+    reset();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open, tab?.tabId]);
 
-  // Autofocus the input when the sheet opens (BottomSheet moves focus to the panel first; this
-  // parent-level effect runs after that child effect, so the input wins). Skipped under read-only,
-  // where there's no input.
+  // Autofocus the label input when rename mode opens, so the phone keyboard pops without a second tap.
   useEffect(() => {
-    if (open && !readOnly) inputRef.current?.focus();
-  }, [open, readOnly]);
+    if (mode === "rename") inputRef.current?.focus();
+  }, [mode]);
 
   const trimmed = label.trim();
 
@@ -77,36 +87,69 @@ export function TabActionsSheet({
     }
   }
 
-  function onInputKeyDown(e: ReactKeyboardEvent<HTMLInputElement>) {
-    if (e.key === "Enter") {
-      e.preventDefault();
-      void save();
+  // Two-tap: the first tap arms (row flips to the blast-radius confirm), the second closes.
+  async function requestClose() {
+    if (!tab || closing) return;
+    if (!confirm(tab.tabId)) return;
+    setClosing(true);
+    try {
+      const res = await api.closeTab(tab.tabId, session);
+      if (res.ok) {
+        onClose();
+        onClosed(tab.tabId);
+      } else {
+        setStatus(res.error ?? "Close failed", "error");
+      }
+    } catch (e) {
+      setStatus(e instanceof Error ? e.message : String(e), "error");
+    } finally {
+      setClosing(false);
     }
   }
 
+  const confirming = !!tab && pending === tab.tabId;
+  // Closing a tab kills every pane in it — name the blast radius on the confirm so it's honest. The
+  // count rides on the tab record (snapshot `pane_count`); fall back to a plain confirm if it's 0.
+  const paneCount = tab?.paneCount ?? 0;
+  const confirmLabel =
+    paneCount > 0 ? `Tap again to close ${paneCount} pane${paneCount === 1 ? "" : "s"}` : "Tap again to close";
+
   return (
-    <BottomSheet open={open} onClose={onClose} title="Rename tab">
+    <BottomSheet open={open} onClose={onClose} title={tab ? `Tab ${tab.label}` : "Tab"}>
       {readOnly ? (
         <p className="py-2 text-sm text-muted-foreground">
-          Read-only — this device isn't authorised to rename tabs.
+          Read-only — this device isn't authorised to rename or close tabs.
         </p>
-      ) : (
-        <div className="flex flex-col gap-3">
-          <label className="flex flex-col gap-1">
-            <span className="text-xs font-medium text-muted-foreground">Label</span>
-            <input
-              ref={inputRef}
-              value={label}
-              onChange={(e) => setLabel(e.target.value)}
-              onKeyDown={onInputKeyDown}
-              placeholder="name this tab"
-              className="h-11 rounded-lg border border-border bg-background px-3 text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
-            />
-          </label>
-          <Button onClick={() => void save()} disabled={saving || !trimmed} className="h-11">
-            {saving ? <Loader2 className="size-4 animate-spin" /> : "Save"}
-          </Button>
+      ) : mode === "actions" ? (
+        <div className="flex flex-col gap-1">
+          <ActionRow
+            icon={<Pencil className="size-4 shrink-0 text-muted-foreground" />}
+            label="Rename"
+            onClick={() => setMode("rename")}
+          />
+          <DestructiveActionRow
+            icon={<XCircle className="size-4 shrink-0" />}
+            label="Close tab"
+            confirmLabel={confirmLabel}
+            closingLabel="Closing…"
+            armed={confirming}
+            closing={closing}
+            onClick={() => void requestClose()}
+          />
         </div>
+      ) : (
+        <RenameView
+          inputRef={inputRef}
+          label={label}
+          onLabelChange={setLabel}
+          onSave={() => void save()}
+          onBack={() => setMode("actions")}
+          saving={saving}
+          // A tab has no "clear" (herdr stores "" literally, rejects null), so a blank field can't be
+          // saved — Save disables. This is the one rename difference from a pane.
+          canSave={!!trimmed}
+          placeholder="name this tab"
+        />
       )}
     </BottomSheet>
   );

--- a/web/src/components/tab-strip.test.tsx
+++ b/web/src/components/tab-strip.test.tsx
@@ -1,6 +1,8 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
 
+import { server } from "@/test/setup";
 import { TabStrip } from "./tab-strip";
 import type { TabView } from "@/lib/types";
 
@@ -50,10 +52,44 @@ describe("TabStrip", () => {
   });
 });
 
-describe("TabStrip — long-press rename", () => {
+describe("TabStrip — long-press actions", () => {
   // A long-press on a chip reaches the DOM as a `contextmenu` event (Android Chrome / right-click);
-  // with onRenamed wired it opens the rename sheet (prefilled with the tab's label).
-  it("opens the rename sheet on a long-press (contextmenu) when onRenamed is wired", () => {
+  // with both actions wired it opens the actions sheet (rename / close), like the pane strip.
+  it("opens the actions sheet on a long-press (contextmenu) when the actions are wired", () => {
+    render(
+      <TabStrip
+        workspaceId="w1"
+        tabs={tabs}
+        agents={[]}
+        selected={null}
+        onSelect={vi.fn()}
+        onNewTab={vi.fn()}
+        onRenamed={vi.fn()}
+        onClosed={vi.fn()}
+      />,
+    );
+    expect(screen.queryByRole("button", { name: "Rename" })).toBeNull();
+    fireEvent.contextMenu(screen.getByRole("button", { name: "2" }));
+    expect(screen.getByRole("button", { name: "Rename" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Close tab" })).toBeInTheDocument();
+  });
+
+  it("stays inert on contextmenu when the actions are not wired", () => {
+    render(
+      <TabStrip
+        workspaceId="w1"
+        tabs={tabs}
+        agents={[]}
+        selected={null}
+        onSelect={vi.fn()}
+        onNewTab={vi.fn()}
+      />,
+    );
+    fireEvent.contextMenu(screen.getByRole("button", { name: "2" }));
+    expect(screen.queryByRole("button", { name: "Rename" })).toBeNull();
+  });
+
+  it("stays inert when only onRenamed is wired (both callbacks are required)", () => {
     render(
       <TabStrip
         workspaceId="w1"
@@ -65,29 +101,13 @@ describe("TabStrip — long-press rename", () => {
         onRenamed={vi.fn()}
       />,
     );
-    expect(screen.queryByPlaceholderText("name this tab")).toBeNull();
     fireEvent.contextMenu(screen.getByRole("button", { name: "2" }));
-    expect(screen.getByPlaceholderText("name this tab")).toHaveValue("2");
-  });
-
-  it("stays inert on contextmenu when onRenamed is not wired", () => {
-    render(
-      <TabStrip
-        workspaceId="w1"
-        tabs={tabs}
-        agents={[]}
-        selected={null}
-        onSelect={vi.fn()}
-        onNewTab={vi.fn()}
-      />,
-    );
-    fireEvent.contextMenu(screen.getByRole("button", { name: "2" }));
-    expect(screen.queryByPlaceholderText("name this tab")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Rename" })).toBeNull();
   });
 
   // Tapping the already-selected tab is otherwise a no-op re-select; with actions wired it opens the
-  // same rename sheet a long-press would, so the chip is never a dead tap.
-  it("opens the rename sheet on a plain tap of the already-selected tab", async () => {
+  // same actions sheet a long-press would, so the chip is never a dead tap.
+  it("opens the actions sheet on a plain tap of the already-selected tab", async () => {
     const user = userEvent.setup();
     const onSelect = vi.fn();
     render(
@@ -99,10 +119,11 @@ describe("TabStrip — long-press rename", () => {
         onSelect={onSelect}
         onNewTab={vi.fn()}
         onRenamed={vi.fn()}
+        onClosed={vi.fn()}
       />,
     );
     await user.click(screen.getByRole("button", { name: "1" }));
-    expect(screen.getByPlaceholderText("name this tab")).toHaveValue("1");
+    expect(screen.getByRole("button", { name: "Rename" })).toBeInTheDocument();
     expect(onSelect).not.toHaveBeenCalled();
   });
 
@@ -118,11 +139,44 @@ describe("TabStrip — long-press rename", () => {
         onSelect={onSelect}
         onNewTab={vi.fn()}
         onRenamed={vi.fn()}
+        onClosed={vi.fn()}
       />,
     );
     await user.click(screen.getByRole("button", { name: "2" }));
     expect(onSelect).toHaveBeenCalledExactlyOnceWith("w1:t2");
-    expect(screen.queryByPlaceholderText("name this tab")).toBeNull();
+    expect(screen.queryByRole("button", { name: "Rename" })).toBeNull();
+  });
+
+  // The two-tap close wiring the call-site fallbacks hang off: long-press → Close tab → confirm hits
+  // the bridge and fires the parent's onClosed with the tab id.
+  it("closes a tab through a two-tap confirm and reports the closed tab id", async () => {
+    const user = userEvent.setup();
+    const onClosed = vi.fn();
+    let url = "";
+    server.use(
+      http.post(/\/api\/tab\/[^/]+\/close$/, ({ request }) => {
+        url = request.url;
+        return HttpResponse.json({ ok: true });
+      }),
+    );
+    render(
+      <TabStrip
+        workspaceId="w1"
+        tabs={tabs}
+        agents={[]}
+        selected="w1:t1"
+        onSelect={vi.fn()}
+        onNewTab={vi.fn()}
+        onRenamed={vi.fn()}
+        onClosed={onClosed}
+      />,
+    );
+    fireEvent.contextMenu(screen.getByRole("button", { name: "2" })); // w1:t2, paneCount 1
+    await user.click(screen.getByRole("button", { name: "Close tab" }));
+    await user.click(screen.getByRole("button", { name: "Tap again to close 1 pane" }));
+
+    await waitFor(() => expect(onClosed).toHaveBeenCalledExactlyOnceWith("w1:t2"));
+    expect(url).toContain("/api/tab/w1%3At2/close");
   });
 
   // The tab label is user text — it must render as a plain text node, never markup (XSS boundary).

--- a/web/src/components/tab-strip.test.tsx
+++ b/web/src/components/tab-strip.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import { TabStrip } from "./tab-strip";
@@ -47,5 +47,98 @@ describe("TabStrip", () => {
     );
     await user.click(screen.getByRole("button", { name: /new tab/i }));
     expect(onNewTab).toHaveBeenCalledWith("w1");
+  });
+});
+
+describe("TabStrip — long-press rename", () => {
+  // A long-press on a chip reaches the DOM as a `contextmenu` event (Android Chrome / right-click);
+  // with onRenamed wired it opens the rename sheet (prefilled with the tab's label).
+  it("opens the rename sheet on a long-press (contextmenu) when onRenamed is wired", () => {
+    render(
+      <TabStrip
+        workspaceId="w1"
+        tabs={tabs}
+        agents={[]}
+        selected={null}
+        onSelect={vi.fn()}
+        onNewTab={vi.fn()}
+        onRenamed={vi.fn()}
+      />,
+    );
+    expect(screen.queryByPlaceholderText("name this tab")).toBeNull();
+    fireEvent.contextMenu(screen.getByRole("button", { name: "2" }));
+    expect(screen.getByPlaceholderText("name this tab")).toHaveValue("2");
+  });
+
+  it("stays inert on contextmenu when onRenamed is not wired", () => {
+    render(
+      <TabStrip
+        workspaceId="w1"
+        tabs={tabs}
+        agents={[]}
+        selected={null}
+        onSelect={vi.fn()}
+        onNewTab={vi.fn()}
+      />,
+    );
+    fireEvent.contextMenu(screen.getByRole("button", { name: "2" }));
+    expect(screen.queryByPlaceholderText("name this tab")).toBeNull();
+  });
+
+  // Tapping the already-selected tab is otherwise a no-op re-select; with actions wired it opens the
+  // same rename sheet a long-press would, so the chip is never a dead tap.
+  it("opens the rename sheet on a plain tap of the already-selected tab", async () => {
+    const user = userEvent.setup();
+    const onSelect = vi.fn();
+    render(
+      <TabStrip
+        workspaceId="w1"
+        tabs={tabs}
+        agents={[]}
+        selected="w1:t1"
+        onSelect={onSelect}
+        onNewTab={vi.fn()}
+        onRenamed={vi.fn()}
+      />,
+    );
+    await user.click(screen.getByRole("button", { name: "1" }));
+    expect(screen.getByPlaceholderText("name this tab")).toHaveValue("1");
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it("still switches on a tap of a non-selected tab even with actions wired", async () => {
+    const user = userEvent.setup();
+    const onSelect = vi.fn();
+    render(
+      <TabStrip
+        workspaceId="w1"
+        tabs={tabs}
+        agents={[]}
+        selected="w1:t1"
+        onSelect={onSelect}
+        onNewTab={vi.fn()}
+        onRenamed={vi.fn()}
+      />,
+    );
+    await user.click(screen.getByRole("button", { name: "2" }));
+    expect(onSelect).toHaveBeenCalledExactlyOnceWith("w1:t2");
+    expect(screen.queryByPlaceholderText("name this tab")).toBeNull();
+  });
+
+  // The tab label is user text — it must render as a plain text node, never markup (XSS boundary).
+  it("renders a markup-looking tab label as literal text, injecting nothing", () => {
+    const xss = "<img src=x onerror=alert(1)>";
+    render(
+      <TabStrip
+        workspaceId="w1"
+        tabs={[{ tabId: "w1:t1", workspaceId: "w1", number: 1, label: xss, focused: false, paneCount: 1 }]}
+        agents={[]}
+        selected={null}
+        onSelect={vi.fn()}
+        onNewTab={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole("button", { name: xss })).toBeInTheDocument();
+    expect(document.querySelector("img")).toBeNull();
   });
 });

--- a/web/src/components/tab-strip.tsx
+++ b/web/src/components/tab-strip.tsx
@@ -1,7 +1,9 @@
+import { useState } from "react";
 import { Plus } from "lucide-react";
 
 import { Chip } from "@/components/ui/chip";
 import { SectionLabel } from "@/components/ui/section-label";
+import { TabActionsSheet } from "@/components/tab-actions-sheet";
 import type { AgentView, TabView } from "@/lib/types";
 
 interface TabStripProps {
@@ -14,12 +16,19 @@ interface TabStripProps {
   onNewTab: (workspaceId: string) => void;
   /** Show the leading "All" chip (home space view); off for the in-pane tab bar. */
   allowAll?: boolean;
+  /** Session scope for the long-press tab rename (undefined = primary). */
+  session?: string;
+  /** Drop the long-press write action when the device isn't authorised (the sheet shows a note). */
+  readOnly?: boolean;
+  /** Revalidate after a rename. Long-press tab rename turns on only when this is wired. */
+  onRenamed?: () => void;
 }
 
 // The selected space's tabs as a horizontal strip — the second header row under SpaceStrip, mirroring
 // it one level down. "All" shows every tab's panes; tapping a tab filters the space to it; the
 // trailing + creates a new tab (and opens its fresh shell). The desktop-focused tab gets a ring; a
-// tab holding a blocked agent gets an alert dot.
+// tab holding a blocked agent gets an alert dot. A long-press on a tab chip opens its rename sheet
+// when the parent wires onRenamed (the "All" chip and the + never take long-press).
 export function TabStrip({
   workspaceId,
   tabs,
@@ -28,34 +37,56 @@ export function TabStrip({
   onSelect,
   onNewTab,
   allowAll = true,
+  session,
+  readOnly,
+  onRenamed,
 }: TabStripProps) {
+  const [sheetTab, setSheetTab] = useState<TabView | null>(null);
+
   const wsTabs = tabs
     .filter((t) => t.workspaceId === workspaceId)
     .sort((a, b) => a.number - b.number);
   if (wsTabs.length === 0) return null;
 
   return (
-    <div className="flex items-center gap-2 overflow-x-auto border-t border-border/40 px-3 py-2 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
-      <SectionLabel>Tabs</SectionLabel>
-      {allowAll && <Chip label="All" active={selected === null} onClick={() => onSelect(null)} />}
-      {wsTabs.map((t) => (
-        <Chip
-          key={t.tabId}
-          label={t.label}
-          active={selected === t.tabId}
-          ring={t.focused}
-          alert={agents.some((a) => a.tabId === t.tabId && a.status === "blocked")}
-          onClick={() => onSelect(t.tabId)}
+    <>
+      <div className="flex items-center gap-2 overflow-x-auto border-t border-border/40 px-3 py-2 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+        <SectionLabel>Tabs</SectionLabel>
+        {allowAll && <Chip label="All" active={selected === null} onClick={() => onSelect(null)} />}
+        {wsTabs.map((t) => (
+          <Chip
+            key={t.tabId}
+            label={t.label}
+            active={selected === t.tabId}
+            ring={t.focused}
+            alert={agents.some((a) => a.tabId === t.tabId && a.status === "blocked")}
+            onClick={() => onSelect(t.tabId)}
+            // Long-press (and a tap on the already-active tab) opens the rename sheet — only when the
+            // parent wired onRenamed; otherwise the chips stay plain tap-to-switch.
+            onLongPress={onRenamed ? () => setSheetTab(t) : undefined}
+            onTapActive={onRenamed ? () => setSheetTab(t) : undefined}
+          />
+        ))}
+        <button
+          type="button"
+          onClick={() => onNewTab(workspaceId)}
+          aria-label="New tab"
+          className="flex size-8 shrink-0 items-center justify-center rounded-full border border-dashed border-border text-muted-foreground transition-colors hover:bg-accent active:scale-95"
+        >
+          <Plus className="size-4" />
+        </button>
+      </div>
+
+      {onRenamed && (
+        <TabActionsSheet
+          open={sheetTab !== null}
+          onClose={() => setSheetTab(null)}
+          tab={sheetTab}
+          session={session}
+          readOnly={readOnly}
+          onRenamed={onRenamed}
         />
-      ))}
-      <button
-        type="button"
-        onClick={() => onNewTab(workspaceId)}
-        aria-label="New tab"
-        className="flex size-8 shrink-0 items-center justify-center rounded-full border border-dashed border-border text-muted-foreground transition-colors hover:bg-accent active:scale-95"
-      >
-        <Plus className="size-4" />
-      </button>
-    </div>
+      )}
+    </>
   );
 }

--- a/web/src/components/tab-strip.tsx
+++ b/web/src/components/tab-strip.tsx
@@ -16,19 +16,22 @@ interface TabStripProps {
   onNewTab: (workspaceId: string) => void;
   /** Show the leading "All" chip (home space view); off for the in-pane tab bar. */
   allowAll?: boolean;
-  /** Session scope for the long-press tab rename (undefined = primary). */
+  /** Session scope for the long-press tab actions (rename/close); undefined = primary. */
   session?: string;
-  /** Drop the long-press write action when the device isn't authorised (the sheet shows a note). */
+  /** Drop the long-press write actions when the device isn't authorised (the sheet shows a note). */
   readOnly?: boolean;
-  /** Revalidate after a rename. Long-press tab rename turns on only when this is wired. */
+  /** Revalidate after a rename. Long-press tab actions turn on only when this AND onClosed are set. */
   onRenamed?: () => void;
+  /** Refresh/fall back after a close. Enables long-press together with onRenamed. */
+  onClosed?: (tabId: string) => void;
 }
 
 // The selected space's tabs as a horizontal strip — the second header row under SpaceStrip, mirroring
 // it one level down. "All" shows every tab's panes; tapping a tab filters the space to it; the
 // trailing + creates a new tab (and opens its fresh shell). The desktop-focused tab gets a ring; a
-// tab holding a blocked agent gets an alert dot. A long-press on a tab chip opens its rename sheet
-// when the parent wires onRenamed (the "All" chip and the + never take long-press).
+// tab holding a blocked agent gets an alert dot. A long-press on a tab chip opens its actions sheet
+// (rename / close) when the parent wires both onRenamed and onClosed (the "All" chip and the + never
+// take long-press).
 export function TabStrip({
   workspaceId,
   tabs,
@@ -40,8 +43,12 @@ export function TabStrip({
   session,
   readOnly,
   onRenamed,
+  onClosed,
 }: TabStripProps) {
   const [sheetTab, setSheetTab] = useState<TabView | null>(null);
+  // Actions need both callbacks wired (revalidate on rename, fall back on close); without them the
+  // chips stay plain tap-to-switch — long-press is inert.
+  const actionsEnabled = !!onRenamed && !!onClosed;
 
   const wsTabs = tabs
     .filter((t) => t.workspaceId === workspaceId)
@@ -61,10 +68,10 @@ export function TabStrip({
             ring={t.focused}
             alert={agents.some((a) => a.tabId === t.tabId && a.status === "blocked")}
             onClick={() => onSelect(t.tabId)}
-            // Long-press (and a tap on the already-active tab) opens the rename sheet — only when the
-            // parent wired onRenamed; otherwise the chips stay plain tap-to-switch.
-            onLongPress={onRenamed ? () => setSheetTab(t) : undefined}
-            onTapActive={onRenamed ? () => setSheetTab(t) : undefined}
+            // Long-press (and a tap on the already-active tab) opens the actions sheet — only when the
+            // parent wired the actions; otherwise the chips stay plain tap-to-switch.
+            onLongPress={actionsEnabled ? () => setSheetTab(t) : undefined}
+            onTapActive={actionsEnabled ? () => setSheetTab(t) : undefined}
           />
         ))}
         <button
@@ -77,7 +84,7 @@ export function TabStrip({
         </button>
       </div>
 
-      {onRenamed && (
+      {actionsEnabled && (
         <TabActionsSheet
           open={sheetTab !== null}
           onClose={() => setSheetTab(null)}
@@ -85,6 +92,7 @@ export function TabStrip({
           session={session}
           readOnly={readOnly}
           onRenamed={onRenamed}
+          onClosed={onClosed}
         />
       )}
     </>

--- a/web/src/components/ui/chip.tsx
+++ b/web/src/components/ui/chip.tsx
@@ -1,4 +1,5 @@
 import { cn } from "@/lib/utils";
+import { useLongPress } from "@/hooks/use-long-press";
 
 interface ChipProps {
   label: string;
@@ -8,18 +9,46 @@ interface ChipProps {
   /** Alert dot for a blocked agent within this space/tab. */
   alert?: boolean;
   onClick: () => void;
+  /**
+   * Long-press (or right-click / Android contextmenu) opens actions for this chip — e.g. the tab
+   * rename sheet. Inert when unset (the space strip's chips don't wire it), so the handlers are safe
+   * to spread unconditionally.
+   */
+  onLongPress?: () => void;
+  /**
+   * A plain tap when the chip is already `active` — opens actions instead of a no-op re-select,
+   * mirroring the pane pill. Only meaningful alongside {@link onLongPress}.
+   */
+  onTapActive?: () => void;
 }
 
 // Pill button shared by the space and tab strips: active fill, an optional desktop-focus ring, and
-// an optional alert dot for a contained blocked agent.
-export function Chip({ label, active, ring, alert, onClick }: ChipProps) {
+// an optional alert dot for a contained blocked agent. Tab chips additionally wire a long-press to
+// open their rename sheet (space chips leave it unset — the handlers stay inert).
+export function Chip({ label, active, ring, alert, onClick, onLongPress, onTapActive }: ChipProps) {
+  const longPress = useLongPress(onLongPress);
+
+  // A long-press already suppresses the ensuing click (via longPress.onClickCapture), so this only
+  // ever sees a genuine tap. Tapping the already-active chip opens actions (when wired) rather than a
+  // dead re-select.
+  function handleClick() {
+    if (active && onTapActive) {
+      onTapActive();
+      return;
+    }
+    onClick();
+  }
+
   return (
     <button
       type="button"
-      onClick={onClick}
+      onClick={handleClick}
+      {...longPress}
       aria-current={active ? "true" : undefined}
       className={cn(
-        "relative shrink-0 whitespace-nowrap rounded-full px-3 py-1.5 text-sm font-medium transition-colors active:scale-95",
+        // select-none + -webkit-touch-callout:none stop iOS Safari's selection loupe / touch callout,
+        // whose native long-press gesture otherwise fires pointercancel and kills the hold timer.
+        "relative shrink-0 select-none [-webkit-touch-callout:none] whitespace-nowrap rounded-full px-3 py-1.5 text-sm font-medium transition-colors active:scale-95",
         active
           ? "bg-primary text-primary-foreground"
           : "bg-muted text-muted-foreground hover:bg-muted/70",

--- a/web/src/components/ui/sheet.test.tsx
+++ b/web/src/components/ui/sheet.test.tsx
@@ -15,7 +15,7 @@ describe("sheet — focus & labelling", () => {
     expect(screen.getByRole("dialog", { name: "Keys" })).toBeInTheDocument();
   });
 
-  it("exposes a single accessible Close (✕); the backdrop is aria-hidden but still dismisses", () => {
+  it("exposes a single accessible Close (✕); the backdrop is aria-hidden but still dismisses on a real tap (down+up on it)", () => {
     const onClose = vi.fn();
     const { container } = render(
       <SideSheet open onClose={onClose} title="Navigate">
@@ -24,9 +24,10 @@ describe("sheet — focus & labelling", () => {
     );
     // Only the header ✕ is in the a11y tree now — no giant duplicate "Close" from the backdrop.
     expect(screen.getAllByRole("button", { name: "Close" })).toHaveLength(1);
-    // ...but the backdrop still closes on a pointer tap.
+    // ...but the backdrop still closes on a genuine press-and-release on it.
     const backdrop = container.querySelector('button[aria-hidden="true"]');
     expect(backdrop).not.toBeNull();
+    fireEvent.pointerDown(backdrop!);
     fireEvent.click(backdrop!);
     expect(onClose).toHaveBeenCalledTimes(1);
   });
@@ -54,5 +55,91 @@ describe("sheet — focus & labelling", () => {
     );
     expect(document.activeElement).toBe(opener);
     opener.remove();
+  });
+});
+
+// The on-device bug: a long-press that opens the sheet leaves the finger down at mount time: the
+// browser's release `click` lands wherever the finger now is, which is the backdrop — and closing on
+// ANY backdrop click meant the sheet closed in the same instant it opened. The fix arms the dismiss
+// only when the pointer went DOWN on the backdrop too (press AND release on it), so a click whose
+// pointerdown started elsewhere (the pill, in the real gesture) is ignored.
+describe("BottomSheet — backdrop dismiss requires press AND release on the backdrop", () => {
+  it("stays open when pointerdown happened elsewhere (not the backdrop) and only the click lands on it", () => {
+    const onClose = vi.fn();
+    const { container } = render(
+      <BottomSheet open onClose={onClose} title="Actions">
+        body
+      </BottomSheet>,
+    );
+    // Simulate the pointerdown landing on something other than the backdrop (e.g. the pane pill that
+    // triggered the long-press), then the release click landing on the backdrop.
+    fireEvent.pointerDown(document.body);
+    const backdrop = container.querySelector('button[aria-hidden="true"]')!;
+    fireEvent.click(backdrop);
+    expect(onClose).not.toHaveBeenCalled();
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+  });
+
+  it("closes when both pointerdown and click land on the backdrop (a genuine backdrop tap)", () => {
+    const onClose = vi.fn();
+    const { container } = render(
+      <BottomSheet open onClose={onClose} title="Actions">
+        body
+      </BottomSheet>,
+    );
+    const backdrop = container.querySelector('button[aria-hidden="true"]')!;
+    fireEvent.pointerDown(backdrop);
+    fireEvent.click(backdrop);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("the ✕ button still closes regardless of the backdrop arm state", () => {
+    const onClose = vi.fn();
+    render(
+      <BottomSheet open onClose={onClose} title="Actions">
+        body
+      </BottomSheet>,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Close" }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("Escape still closes regardless of the backdrop arm state", () => {
+    const onClose = vi.fn();
+    render(
+      <BottomSheet open onClose={onClose} title="Actions">
+        body
+      </BottomSheet>,
+    );
+    fireEvent.keyDown(window, { key: "Escape" });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-arms per open: a stale arm from a previous open doesn't leak into the next one", () => {
+    const onClose = vi.fn();
+    const { container, rerender } = render(
+      <BottomSheet open onClose={onClose} title="Actions">
+        body
+      </BottomSheet>,
+    );
+    const backdrop = () => container.querySelector('button[aria-hidden="true"]')!;
+    fireEvent.pointerDown(backdrop());
+    // Close via Escape instead of the (now-armed) backdrop click, leaving the arm flag set to true.
+    fireEvent.keyDown(window, { key: "Escape" });
+    rerender(
+      <BottomSheet open={false} onClose={onClose} title="Actions">
+        body
+      </BottomSheet>,
+    );
+    rerender(
+      <BottomSheet open onClose={onClose} title="Actions">
+        body
+      </BottomSheet>,
+    );
+    onClose.mockClear();
+    // A click with no pointerdown in this new open should NOT close, even though a stale arm from the
+    // previous open was left set to true.
+    fireEvent.click(backdrop());
+    expect(onClose).not.toHaveBeenCalled();
   });
 });

--- a/web/src/components/ui/sheet.tsx
+++ b/web/src/components/ui/sheet.tsx
@@ -35,6 +35,18 @@ export function BottomSheet({ open, onClose, title, children, className }: Botto
   const titleId = React.useId();
   useDialogFocus(open, panelRef);
 
+  // Backdrop dismiss requires press AND release on the backdrop itself (the Radix
+  // outside-pointerdown rule) — NOT just whatever the browser happens to synthesize a `click` on. A
+  // long-press that opens this sheet has its finger still down at the moment the sheet mounts; the
+  // browser's release click then lands on whatever is now under the finger, which is the backdrop —
+  // and without this guard that click would immediately close the sheet it just opened. Arming only
+  // on a backdrop `pointerdown` means a click that originated elsewhere (e.g. the pill's release)
+  // never dismisses.
+  const backdropArmed = React.useRef(false);
+  React.useEffect(() => {
+    if (open) backdropArmed.current = false;
+  }, [open]);
+
   React.useEffect(() => {
     if (!open) return;
     const onKey = (e: KeyboardEvent) => {
@@ -104,13 +116,21 @@ export function BottomSheet({ open, onClose, title, children, className }: Botto
       aria-labelledby={title ? titleId : undefined}
     >
       {/* Backdrop: still dismisses on tap, but hidden from assistive tech — the ✕ in the header is
-          the single accessible "Close", so the dialog isn't announced with a giant duplicate. */}
+          the single accessible "Close", so the dialog isn't announced with a giant duplicate. Dismiss
+          fires only when the pointer went DOWN on the backdrop too — see backdropArmed above. */}
       <button
         type="button"
         aria-hidden="true"
         tabIndex={-1}
         className="absolute inset-0 bg-black/50 duration-200 animate-in fade-in"
-        onClick={onClose}
+        onPointerDown={() => {
+          backdropArmed.current = true;
+        }}
+        onClick={() => {
+          if (!backdropArmed.current) return;
+          backdropArmed.current = false;
+          onClose();
+        }}
       />
       <div
         ref={panelRef}
@@ -176,6 +196,19 @@ export function SideSheet({
   const panelRef = React.useRef<HTMLDivElement>(null);
   const titleId = React.useId();
   useDialogFocus(open, panelRef);
+
+  // Backdrop dismiss requires press AND release on the backdrop itself (the Radix
+  // outside-pointerdown rule) — NOT just whatever the browser happens to synthesize a `click` on. A
+  // long-press that opens this sheet has its finger still down at the moment the sheet mounts; the
+  // browser's release click then lands on whatever is now under the finger, which is the backdrop —
+  // and without this guard that click would immediately close the sheet it just opened. Arming only
+  // on a backdrop `pointerdown` means a click that originated elsewhere (e.g. the pill's release)
+  // never dismisses.
+  const backdropArmed = React.useRef(false);
+  React.useEffect(() => {
+    if (open) backdropArmed.current = false;
+  }, [open]);
+
   React.useEffect(() => {
     if (!open) return;
     const onKey = (e: KeyboardEvent) => {
@@ -227,13 +260,21 @@ export function SideSheet({
         )}
       </div>
       {/* Backdrop: dismisses on tap but hidden from assistive tech — the header ✕ is the accessible
-          "Close", so the drawer isn't announced with a giant duplicate close target. */}
+          "Close", so the drawer isn't announced with a giant duplicate close target. Dismiss fires
+          only when the pointer went DOWN on the backdrop too — see backdropArmed above. */}
       <button
         type="button"
         aria-hidden="true"
         tabIndex={-1}
         className="flex-1 bg-black/50 duration-200 animate-in fade-in"
-        onClick={onClose}
+        onPointerDown={() => {
+          backdropArmed.current = true;
+        }}
+        onClick={() => {
+          if (!backdropArmed.current) return;
+          backdropArmed.current = false;
+          onClose();
+        }}
       />
     </div>
   );

--- a/web/src/hooks/use-long-press.test.ts
+++ b/web/src/hooks/use-long-press.test.ts
@@ -13,6 +13,11 @@ function down(x = 0, y = 0, button = 0): ReactPointerEvent {
 function clickEvent(): ReactMouseEvent {
   return { preventDefault: vi.fn(), stopPropagation: vi.fn() } as unknown as ReactMouseEvent;
 }
+// A `contextmenu` event — what Android Chrome raises at the end of a long-press, and desktop on
+// right-click. The hook preventDefaults it and (idempotently) uses it as an alternative trigger.
+function contextMenuEvent(): ReactMouseEvent {
+  return { preventDefault: vi.fn(), stopPropagation: vi.fn() } as unknown as ReactMouseEvent;
+}
 
 describe("useLongPress", () => {
   beforeEach(() => vi.useFakeTimers());
@@ -49,18 +54,28 @@ describe("useLongPress", () => {
     const onLongPress = vi.fn();
     const { result } = renderHook(() => useLongPress(onLongPress));
     act(() => result.current.onPointerDown(down(0, 0)));
-    act(() => result.current.onPointerMove(down(0, 20))); // 20px > 10px tolerance
+    act(() => result.current.onPointerMove(down(0, 24))); // 24px > 16px tolerance
     act(() => vi.advanceTimersByTime(DELAY));
     expect(onLongPress).not.toHaveBeenCalled();
   });
 
-  it("keeps the timer through small jitter within the tolerance", () => {
+  it("keeps the timer through thumb jitter within the tolerance", () => {
     const onLongPress = vi.fn();
     const { result } = renderHook(() => useLongPress(onLongPress));
     act(() => result.current.onPointerDown(down(0, 0)));
-    act(() => result.current.onPointerMove(down(3, 4))); // within 10px
+    act(() => result.current.onPointerMove(down(10, 12))); // within 16px — a held thumb wobbles
     act(() => vi.advanceTimersByTime(DELAY));
     expect(onLongPress).toHaveBeenCalledTimes(1);
+  });
+
+  it("still cancels on pointercancel (a scroll intent the browser claimed)", () => {
+    const onLongPress = vi.fn();
+    const { result } = renderHook(() => useLongPress(onLongPress));
+    act(() => result.current.onPointerDown(down()));
+    act(() => vi.advanceTimersByTime(DELAY - 100));
+    act(() => result.current.onPointerCancel());
+    act(() => vi.advanceTimersByTime(200));
+    expect(onLongPress).not.toHaveBeenCalled();
   });
 
   it("ignores a non-primary pointer button", () => {
@@ -106,5 +121,71 @@ describe("useLongPress", () => {
     const click = clickEvent();
     act(() => result.current.onClickCapture(click));
     expect(click.preventDefault).not.toHaveBeenCalled();
+  });
+
+  // Android long-press / desktop right-click reach us as a `contextmenu` event, not (or not only) the
+  // hold timer. These cover that trigger and its idempotency against the timer.
+  it("opens via contextmenu and prevents the native menu (Android long-press / right-click)", () => {
+    const onLongPress = vi.fn();
+    const { result } = renderHook(() => useLongPress(onLongPress));
+    const e = contextMenuEvent();
+    act(() => result.current.onContextMenu(e));
+    expect(e.preventDefault).toHaveBeenCalled();
+    expect(onLongPress).toHaveBeenCalledTimes(1);
+  });
+
+  it("opens via contextmenu even when a pointercancel already killed the hold timer", () => {
+    const onLongPress = vi.fn();
+    const { result } = renderHook(() => useLongPress(onLongPress));
+    act(() => result.current.onPointerDown(down()));
+    act(() => result.current.onPointerCancel()); // native gesture cancels our timer first…
+    act(() => vi.advanceTimersByTime(DELAY));
+    expect(onLongPress).not.toHaveBeenCalled();
+    const e = contextMenuEvent();
+    act(() => result.current.onContextMenu(e)); // …contextmenu is the fallback that still opens it
+    expect(onLongPress).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not double-open when the hold timer already fired before contextmenu", () => {
+    const onLongPress = vi.fn();
+    const { result } = renderHook(() => useLongPress(onLongPress));
+    act(() => result.current.onPointerDown(down()));
+    act(() => vi.advanceTimersByTime(DELAY)); // timer opens it once
+    const e = contextMenuEvent();
+    act(() => result.current.onContextMenu(e));
+    expect(e.preventDefault).toHaveBeenCalled(); // still suppress the native menu
+    expect(onLongPress).toHaveBeenCalledTimes(1); // but never a second open
+  });
+
+  it("disarms the pending hold timer when contextmenu opens the sheet first", () => {
+    const onLongPress = vi.fn();
+    const { result } = renderHook(() => useLongPress(onLongPress));
+    act(() => result.current.onPointerDown(down()));
+    act(() => vi.advanceTimersByTime(DELAY - 100));
+    const e = contextMenuEvent();
+    act(() => result.current.onContextMenu(e)); // opens early
+    expect(onLongPress).toHaveBeenCalledTimes(1);
+    act(() => vi.advanceTimersByTime(200)); // the still-pending timer must not re-open
+    expect(onLongPress).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-opens on a second contextmenu after a fresh pointerdown resets the gesture", () => {
+    const onLongPress = vi.fn();
+    const { result } = renderHook(() => useLongPress(onLongPress));
+    // First open via contextmenu (no click follows, so the one-shot flag stays set)…
+    act(() => result.current.onContextMenu(contextMenuEvent()));
+    expect(onLongPress).toHaveBeenCalledTimes(1);
+    // …a new gesture's pointerdown (even a non-primary button, as a right-click sends) clears it, so
+    // the next contextmenu opens again instead of being swallowed.
+    act(() => result.current.onPointerDown(down(0, 0, 2)));
+    act(() => result.current.onContextMenu(contextMenuEvent()));
+    expect(onLongPress).toHaveBeenCalledTimes(2);
+  });
+
+  it("leaves the native contextmenu alone when disabled (onLongPress undefined)", () => {
+    const { result } = renderHook(() => useLongPress(undefined));
+    const e = contextMenuEvent();
+    act(() => result.current.onContextMenu(e));
+    expect(e.preventDefault).not.toHaveBeenCalled();
   });
 });

--- a/web/src/hooks/use-long-press.test.ts
+++ b/web/src/hooks/use-long-press.test.ts
@@ -1,0 +1,110 @@
+import { act, renderHook } from "@testing-library/react";
+import type { MouseEvent as ReactMouseEvent, PointerEvent as ReactPointerEvent } from "react";
+
+import { useLongPress } from "./use-long-press";
+
+// The pointer-based long-press behind the pane-pill actions sheet. Fake timers pin the 450ms hold;
+// the handlers are called directly with minimal synthetic events (only the fields the hook reads).
+const DELAY = 450;
+
+function down(x = 0, y = 0, button = 0): ReactPointerEvent {
+  return { button, clientX: x, clientY: y } as unknown as ReactPointerEvent;
+}
+function clickEvent(): ReactMouseEvent {
+  return { preventDefault: vi.fn(), stopPropagation: vi.fn() } as unknown as ReactMouseEvent;
+}
+
+describe("useLongPress", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it("fires onLongPress once after the delay while held", () => {
+    const onLongPress = vi.fn();
+    const { result } = renderHook(() => useLongPress(onLongPress));
+    act(() => result.current.onPointerDown(down()));
+    expect(onLongPress).not.toHaveBeenCalled();
+    act(() => vi.advanceTimersByTime(DELAY));
+    expect(onLongPress).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fire before the delay elapses", () => {
+    const onLongPress = vi.fn();
+    const { result } = renderHook(() => useLongPress(onLongPress));
+    act(() => result.current.onPointerDown(down()));
+    act(() => vi.advanceTimersByTime(DELAY - 1));
+    expect(onLongPress).not.toHaveBeenCalled();
+  });
+
+  it("cancels on pointerup before the delay (a normal tap)", () => {
+    const onLongPress = vi.fn();
+    const { result } = renderHook(() => useLongPress(onLongPress));
+    act(() => result.current.onPointerDown(down()));
+    act(() => vi.advanceTimersByTime(DELAY - 100));
+    act(() => result.current.onPointerUp());
+    act(() => vi.advanceTimersByTime(200));
+    expect(onLongPress).not.toHaveBeenCalled();
+  });
+
+  it("cancels when the pointer moves past the tolerance (a scroll/drag)", () => {
+    const onLongPress = vi.fn();
+    const { result } = renderHook(() => useLongPress(onLongPress));
+    act(() => result.current.onPointerDown(down(0, 0)));
+    act(() => result.current.onPointerMove(down(0, 20))); // 20px > 10px tolerance
+    act(() => vi.advanceTimersByTime(DELAY));
+    expect(onLongPress).not.toHaveBeenCalled();
+  });
+
+  it("keeps the timer through small jitter within the tolerance", () => {
+    const onLongPress = vi.fn();
+    const { result } = renderHook(() => useLongPress(onLongPress));
+    act(() => result.current.onPointerDown(down(0, 0)));
+    act(() => result.current.onPointerMove(down(3, 4))); // within 10px
+    act(() => vi.advanceTimersByTime(DELAY));
+    expect(onLongPress).toHaveBeenCalledTimes(1);
+  });
+
+  it("ignores a non-primary pointer button", () => {
+    const onLongPress = vi.fn();
+    const { result } = renderHook(() => useLongPress(onLongPress));
+    act(() => result.current.onPointerDown(down(0, 0, 2))); // right-click
+    act(() => vi.advanceTimersByTime(DELAY));
+    expect(onLongPress).not.toHaveBeenCalled();
+  });
+
+  it("suppresses the click that follows a fired long-press, but only once", () => {
+    const onLongPress = vi.fn();
+    const { result } = renderHook(() => useLongPress(onLongPress));
+    act(() => result.current.onPointerDown(down()));
+    act(() => vi.advanceTimersByTime(DELAY));
+
+    const first = clickEvent();
+    act(() => result.current.onClickCapture(first));
+    expect(first.preventDefault).toHaveBeenCalled();
+    expect(first.stopPropagation).toHaveBeenCalled();
+
+    // The flag is one-shot — a later click (no new long-press) navigates normally.
+    const second = clickEvent();
+    act(() => result.current.onClickCapture(second));
+    expect(second.preventDefault).not.toHaveBeenCalled();
+  });
+
+  it("does not suppress the click after a normal tap (no long-press fired)", () => {
+    const onLongPress = vi.fn();
+    const { result } = renderHook(() => useLongPress(onLongPress));
+    act(() => result.current.onPointerDown(down()));
+    act(() => vi.advanceTimersByTime(DELAY - 1));
+    act(() => result.current.onPointerUp());
+    const click = clickEvent();
+    act(() => result.current.onClickCapture(click));
+    expect(click.preventDefault).not.toHaveBeenCalled();
+  });
+
+  it("is inert when onLongPress is undefined (disabled)", () => {
+    const { result } = renderHook(() => useLongPress(undefined));
+    act(() => result.current.onPointerDown(down()));
+    act(() => vi.advanceTimersByTime(DELAY));
+    const click = clickEvent();
+    act(() => result.current.onClickCapture(click));
+    expect(click.preventDefault).not.toHaveBeenCalled();
+  });
+});

--- a/web/src/hooks/use-long-press.ts
+++ b/web/src/hooks/use-long-press.ts
@@ -6,7 +6,9 @@ import type { MouseEvent as ReactMouseEvent, PointerEvent as ReactPointerEvent }
 const LONG_PRESS_MS = 450;
 // Movement past this (px, from the press origin) cancels the pending long-press — that's a scroll or
 // a drag, not a hold. Keeps the strip's horizontal scroll working: a sideways pan cancels the timer.
-const MOVE_CANCEL_PX = 10;
+// Sized for a thumb: finger jitter during a deliberate hold is easily 10–15px, so a stricter bound
+// cancelled real holds on a phone; a scroll still moves well past this before the timer would fire.
+const MOVE_CANCEL_PX = 16;
 
 interface LongPressOptions {
   delayMs?: number;
@@ -19,6 +21,14 @@ interface LongPressOptions {
  * or `pointerup`/`pointercancel`/`pointerleave`, cancels it. When it fires we set a one-shot flag and
  * suppress the click that follows on release (via a capture-phase `onClickCapture` that stops the
  * event before the element's own `onClick`) — so a long-press opens the sheet WITHOUT also navigating.
+ *
+ * Mobile robustness: the naive timer alone failed on real phones. iOS Safari fires the text-selection
+ * loupe / touch callout and then `pointercancel`, killing the timer before it fires; Android Chrome
+ * raises `contextmenu` at the end of a long-press. So callers must ALSO set `-webkit-touch-callout:
+ * none` + `select-none` on the element (stops the iOS gestures that cause the premature cancel), and
+ * we treat `contextmenu` as an ALTERNATIVE trigger here (`onContextMenu`) — it opens the sheet even
+ * when a native cancel beat the hold timer, and preventDefaults the native menu. `fire` is idempotent
+ * per gesture so the timer and the contextmenu path can never double-open.
  *
  * Deliberately does NOT set `touch-action: none`: the element stays scrollable, and a scroll gesture
  * cancels the timer through the move/cancel path instead. Pass `onLongPress: undefined` to disable
@@ -44,22 +54,31 @@ export function useLongPress(
   // Drop a pending timer if the element unmounts mid-hold.
   useEffect(() => clear, [clear]);
 
+  // Open the sheet exactly once per gesture. Shared by the hold timer and the contextmenu trigger, so
+  // whichever wins the race opens it and the other is a no-op. Also disarms the timer so a pending
+  // hold can't re-open after contextmenu already did.
+  const fire = useCallback(() => {
+    if (!onLongPress || fired.current) return;
+    fired.current = true;
+    clear();
+    onLongPress();
+  }, [onLongPress, clear]);
+
   const onPointerDown = useCallback(
     (e: ReactPointerEvent) => {
       if (!onLongPress) return;
-      // Primary pointer only (0 for touch/pen too) — ignore right-click / secondary contacts.
-      if (e.button !== 0) return;
+      // A fresh press starts a fresh gesture: clear the one-shot flag FIRST, before the button check,
+      // so a repeat that reaches us via `contextmenu` (desktop right-click's pointerdown is button 2)
+      // can open again rather than being blocked by the previous gesture's still-set flag.
       fired.current = false;
+      // Primary pointer only (0 for touch/pen too) — ignore right-click / secondary contacts for the
+      // hold timer (right-click still opens via onContextMenu below).
+      if (e.button !== 0) return;
       startPos.current = { x: e.clientX, y: e.clientY };
       if (timer.current !== null) clearTimeout(timer.current);
-      timer.current = setTimeout(() => {
-        timer.current = null;
-        startPos.current = null;
-        fired.current = true;
-        onLongPress();
-      }, delayMs);
+      timer.current = setTimeout(fire, delayMs);
     },
-    [onLongPress, delayMs],
+    [onLongPress, delayMs, fire],
   );
 
   const onPointerMove = useCallback(
@@ -71,6 +90,20 @@ export function useLongPress(
       }
     },
     [clear, moveTolerance],
+  );
+
+  // Android Chrome raises `contextmenu` at the end of a long-press (desktop does on right-click). When
+  // actions are enabled we (1) preventDefault so the native menu never hijacks the gesture, and (2)
+  // trigger the sheet — this is the fallback path when a native `pointercancel` already killed the
+  // hold timer (the exact mobile failure this fixes). `fire` is idempotent, so if our timer already
+  // opened the sheet this only suppresses the native menu.
+  const onContextMenu = useCallback(
+    (e: ReactMouseEvent) => {
+      if (!onLongPress) return;
+      e.preventDefault();
+      fire();
+    },
+    [onLongPress, fire],
   );
 
   const onClickCapture = useCallback((e: ReactMouseEvent) => {
@@ -87,6 +120,7 @@ export function useLongPress(
     onPointerUp: clear,
     onPointerLeave: clear,
     onPointerCancel: clear,
+    onContextMenu,
     onClickCapture,
   };
 }

--- a/web/src/hooks/use-long-press.ts
+++ b/web/src/hooks/use-long-press.ts
@@ -1,0 +1,92 @@
+import { useCallback, useEffect, useRef } from "react";
+import type { MouseEvent as ReactMouseEvent, PointerEvent as ReactPointerEvent } from "react";
+
+// Hold a pill this long before the press counts as a long-press. Long enough that a tap or a scroll
+// fling never trips it, short enough to feel intentional rather than sluggish.
+const LONG_PRESS_MS = 450;
+// Movement past this (px, from the press origin) cancels the pending long-press — that's a scroll or
+// a drag, not a hold. Keeps the strip's horizontal scroll working: a sideways pan cancels the timer.
+const MOVE_CANCEL_PX = 10;
+
+interface LongPressOptions {
+  delayMs?: number;
+  moveTolerance?: number;
+}
+
+/**
+ * Pointer-based long-press. Spread the returned handlers onto the element you want to long-press
+ * (`<button {...useLongPress(open)} />`). `pointerdown` arms a timer; movement past `moveTolerance`,
+ * or `pointerup`/`pointercancel`/`pointerleave`, cancels it. When it fires we set a one-shot flag and
+ * suppress the click that follows on release (via a capture-phase `onClickCapture` that stops the
+ * event before the element's own `onClick`) — so a long-press opens the sheet WITHOUT also navigating.
+ *
+ * Deliberately does NOT set `touch-action: none`: the element stays scrollable, and a scroll gesture
+ * cancels the timer through the move/cancel path instead. Pass `onLongPress: undefined` to disable
+ * (the handlers become inert) so a caller can conditionally opt out without breaking the hook rules.
+ */
+export function useLongPress(
+  onLongPress: (() => void) | undefined,
+  { delayMs = LONG_PRESS_MS, moveTolerance = MOVE_CANCEL_PX }: LongPressOptions = {},
+) {
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const startPos = useRef<{ x: number; y: number } | null>(null);
+  // A long-press fired on the in-progress gesture → suppress the ensuing click so it doesn't navigate.
+  const fired = useRef(false);
+
+  const clear = useCallback(() => {
+    if (timer.current !== null) {
+      clearTimeout(timer.current);
+      timer.current = null;
+    }
+    startPos.current = null;
+  }, []);
+
+  // Drop a pending timer if the element unmounts mid-hold.
+  useEffect(() => clear, [clear]);
+
+  const onPointerDown = useCallback(
+    (e: ReactPointerEvent) => {
+      if (!onLongPress) return;
+      // Primary pointer only (0 for touch/pen too) — ignore right-click / secondary contacts.
+      if (e.button !== 0) return;
+      fired.current = false;
+      startPos.current = { x: e.clientX, y: e.clientY };
+      if (timer.current !== null) clearTimeout(timer.current);
+      timer.current = setTimeout(() => {
+        timer.current = null;
+        startPos.current = null;
+        fired.current = true;
+        onLongPress();
+      }, delayMs);
+    },
+    [onLongPress, delayMs],
+  );
+
+  const onPointerMove = useCallback(
+    (e: ReactPointerEvent) => {
+      const s = startPos.current;
+      if (!s) return;
+      if (Math.abs(e.clientX - s.x) > moveTolerance || Math.abs(e.clientY - s.y) > moveTolerance) {
+        clear();
+      }
+    },
+    [clear, moveTolerance],
+  );
+
+  const onClickCapture = useCallback((e: ReactMouseEvent) => {
+    if (!fired.current) return;
+    fired.current = false;
+    // Capture phase runs before the element's own bubble-phase onClick; stopping here cancels it.
+    e.preventDefault();
+    e.stopPropagation();
+  }, []);
+
+  return {
+    onPointerDown,
+    onPointerMove,
+    onPointerUp: clear,
+    onPointerLeave: clear,
+    onPointerCancel: clear,
+    onClickCapture,
+  };
+}

--- a/web/src/hooks/use-poll-busy.test.ts
+++ b/web/src/hooks/use-poll-busy.test.ts
@@ -1,0 +1,83 @@
+import { act, renderHook } from "@testing-library/react";
+
+import { usePollBusy, POLL_BUSY_THRESHOLD_MS } from "./use-poll-busy";
+import { isBusy } from "@/lib/busy";
+
+// Drive useRevalidator/useNavigation directly (hoisted so the vi.mock factory can close over the
+// holder), mirroring use-loading-stalled.test — no real router needed to pin loading states.
+const h = vi.hoisted(() => ({
+  rev: "idle" as "idle" | "loading",
+  nav: "idle" as "idle" | "loading" | "submitting",
+}));
+vi.mock("react-router", () => ({
+  useRevalidator: () => ({ state: h.rev }),
+  useNavigation: () => ({ state: h.nav }),
+}));
+
+const T = POLL_BUSY_THRESHOLD_MS;
+
+describe("usePollBusy — slow-poll busy signal", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    h.rev = "idle";
+    h.nav = "idle";
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    // The global afterEach (cleanup) unmounts the hook, whose cleanup effect clears the signal —
+    // so no state leaks between tests. (Reset-on-unmount is asserted directly below.)
+  });
+
+  it("stays quiet while idle", () => {
+    renderHook(() => usePollBusy());
+    expect(isBusy()).toBe(false);
+    act(() => vi.advanceTimersByTime(T * 2));
+    expect(isBusy()).toBe(false);
+  });
+
+  it("shows the bar only after the threshold while a poll stays in flight", () => {
+    h.rev = "loading";
+    renderHook(() => usePollBusy());
+    expect(isBusy()).toBe(false); // a slow poll must not flash the bar immediately
+    act(() => vi.advanceTimersByTime(T - 1));
+    expect(isBusy()).toBe(false);
+    act(() => vi.advanceTimersByTime(1));
+    expect(isBusy()).toBe(true);
+  });
+
+  it("never shows the bar for a fast poll that settles before the threshold", () => {
+    h.rev = "loading";
+    const { rerender } = renderHook(() => usePollBusy());
+    act(() => vi.advanceTimersByTime(T - 200));
+    h.rev = "idle"; // settled in time
+    act(() => rerender());
+    act(() => vi.advanceTimersByTime(1_000)); // past where the original timer would have fired
+    expect(isBusy()).toBe(false);
+  });
+
+  it("also trips on a slow navigation (revalidator idle)", () => {
+    h.nav = "loading"; // e.g. a black-holed pane-open
+    renderHook(() => usePollBusy());
+    act(() => vi.advanceTimersByTime(T));
+    expect(isBusy()).toBe(true);
+  });
+
+  it("resets to false once loading stops", () => {
+    h.rev = "loading";
+    const { rerender } = renderHook(() => usePollBusy());
+    act(() => vi.advanceTimersByTime(T));
+    expect(isBusy()).toBe(true);
+    h.rev = "idle";
+    act(() => rerender());
+    expect(isBusy()).toBe(false);
+  });
+
+  it("clears the signal on unmount so the bar can't get stuck on", () => {
+    h.rev = "loading";
+    const { unmount } = renderHook(() => usePollBusy());
+    act(() => vi.advanceTimersByTime(T));
+    expect(isBusy()).toBe(true);
+    act(() => unmount());
+    expect(isBusy()).toBe(false);
+  });
+});

--- a/web/src/hooks/use-poll-busy.test.ts
+++ b/web/src/hooks/use-poll-busy.test.ts
@@ -1,6 +1,6 @@
 import { act, renderHook } from "@testing-library/react";
 
-import { usePollBusy, POLL_BUSY_THRESHOLD_MS } from "./use-poll-busy";
+import { usePollBusy, NAV_BUSY_THRESHOLD_MS, POLL_BUSY_THRESHOLD_MS } from "./use-poll-busy";
 import { isBusy } from "@/lib/busy";
 
 // Drive useRevalidator/useNavigation directly (hoisted so the vi.mock factory can close over the
@@ -14,9 +14,10 @@ vi.mock("react-router", () => ({
   useNavigation: () => ({ state: h.nav }),
 }));
 
-const T = POLL_BUSY_THRESHOLD_MS;
+const NAV_T = NAV_BUSY_THRESHOLD_MS;
+const POLL_T = POLL_BUSY_THRESHOLD_MS;
 
-describe("usePollBusy — slow-poll busy signal", () => {
+describe("usePollBusy — two independent thresholds (nav vs. background poll)", () => {
   beforeEach(() => {
     vi.useFakeTimers();
     h.rev = "idle";
@@ -31,41 +32,52 @@ describe("usePollBusy — slow-poll busy signal", () => {
   it("stays quiet while idle", () => {
     renderHook(() => usePollBusy());
     expect(isBusy()).toBe(false);
-    act(() => vi.advanceTimersByTime(T * 2));
+    act(() => vi.advanceTimersByTime(POLL_T * 2));
     expect(isBusy()).toBe(false);
   });
 
-  it("shows the bar only after the threshold while a poll stays in flight", () => {
-    h.rev = "loading";
+  it("a navigation past its (short) threshold shows the bar", () => {
+    h.nav = "loading"; // e.g. a black-holed pane-open
     renderHook(() => usePollBusy());
-    expect(isBusy()).toBe(false); // a slow poll must not flash the bar immediately
-    act(() => vi.advanceTimersByTime(T - 1));
+    expect(isBusy()).toBe(false); // must not flash immediately
+    act(() => vi.advanceTimersByTime(NAV_T - 1));
     expect(isBusy()).toBe(false);
     act(() => vi.advanceTimersByTime(1));
     expect(isBusy()).toBe(true);
   });
 
-  it("never shows the bar for a fast poll that settles before the threshold", () => {
-    h.rev = "loading";
-    const { rerender } = renderHook(() => usePollBusy());
-    act(() => vi.advanceTimersByTime(T - 200));
-    h.rev = "idle"; // settled in time
-    act(() => rerender());
-    act(() => vi.advanceTimersByTime(1_000)); // past where the original timer would have fired
+  it("a background revalidation between the nav and poll thresholds does NOT show the bar", () => {
+    h.rev = "loading"; // on-device: routinely 0.5-1.5s over the reverse proxy
+    renderHook(() => usePollBusy());
+    act(() => vi.advanceTimersByTime(NAV_T)); // past the (shorter) nav threshold
+    expect(isBusy()).toBe(false); // but a poll gets the longer, ambient threshold
+    act(() => vi.advanceTimersByTime(POLL_T - NAV_T - 1));
     expect(isBusy()).toBe(false);
   });
 
-  it("also trips on a slow navigation (revalidator idle)", () => {
-    h.nav = "loading"; // e.g. a black-holed pane-open
+  it("a background revalidation past its (long) threshold shows the bar", () => {
+    h.rev = "loading";
     renderHook(() => usePollBusy());
-    act(() => vi.advanceTimersByTime(T));
+    act(() => vi.advanceTimersByTime(POLL_T - 1));
+    expect(isBusy()).toBe(false);
+    act(() => vi.advanceTimersByTime(1));
     expect(isBusy()).toBe(true);
+  });
+
+  it("never shows the bar for a fast poll that settles before its threshold", () => {
+    h.rev = "loading";
+    const { rerender } = renderHook(() => usePollBusy());
+    act(() => vi.advanceTimersByTime(POLL_T - 200));
+    h.rev = "idle"; // settled in time
+    act(() => rerender());
+    act(() => vi.advanceTimersByTime(5_000)); // past where the original timer would have fired
+    expect(isBusy()).toBe(false);
   });
 
   it("resets to false once loading stops", () => {
     h.rev = "loading";
     const { rerender } = renderHook(() => usePollBusy());
-    act(() => vi.advanceTimersByTime(T));
+    act(() => vi.advanceTimersByTime(POLL_T));
     expect(isBusy()).toBe(true);
     h.rev = "idle";
     act(() => rerender());
@@ -75,9 +87,37 @@ describe("usePollBusy — slow-poll busy signal", () => {
   it("clears the signal on unmount so the bar can't get stuck on", () => {
     h.rev = "loading";
     const { unmount } = renderHook(() => usePollBusy());
-    act(() => vi.advanceTimersByTime(T));
+    act(() => vi.advanceTimersByTime(POLL_T));
     expect(isBusy()).toBe(true);
     act(() => unmount());
     expect(isBusy()).toBe(false);
+  });
+
+  describe("overlapping nav + poll", () => {
+    it("shows once either crosses its threshold, and clears only once BOTH are idle", () => {
+      h.nav = "loading";
+      h.rev = "loading";
+      const { rerender } = renderHook(() => usePollBusy());
+
+      // Nav crosses its (short) threshold first — bar shows even though the poll is still under
+      // its own, longer threshold.
+      act(() => vi.advanceTimersByTime(NAV_T));
+      expect(isBusy()).toBe(true);
+
+      // The poll now also crosses its threshold while nav is still loading too — stays shown.
+      act(() => vi.advanceTimersByTime(POLL_T - NAV_T));
+      expect(isBusy()).toBe(true);
+
+      // Nav settles, but the poll is still loading (and already past its own threshold) — stays
+      // shown: clearing ONE past-threshold signal is not enough.
+      h.nav = "idle";
+      act(() => rerender());
+      expect(isBusy()).toBe(true);
+
+      // Only once the poll settles too does the bar clear.
+      h.rev = "idle";
+      act(() => rerender());
+      expect(isBusy()).toBe(false);
+    });
   });
 });

--- a/web/src/hooks/use-poll-busy.test.ts
+++ b/web/src/hooks/use-poll-busy.test.ts
@@ -47,12 +47,23 @@ describe("usePollBusy — two independent thresholds (nav vs. background poll)",
   });
 
   it("a background revalidation between the nav and poll thresholds does NOT show the bar", () => {
-    h.rev = "loading"; // on-device: routinely 0.5-1.5s over the reverse proxy
+    h.rev = "loading"; // on-device: routinely 0.5-3s over the reverse proxy, chronic-but-normal
     renderHook(() => usePollBusy());
     act(() => vi.advanceTimersByTime(NAV_T)); // past the (shorter) nav threshold
     expect(isBusy()).toBe(false); // but a poll gets the longer, ambient threshold
     act(() => vi.advanceTimersByTime(POLL_T - NAV_T - 1));
     expect(isBusy()).toBe(false);
+  });
+
+  it("a chronically slow mobile poll (2-5s) never shows the bar, only a hang past 6s does", () => {
+    h.rev = "loading"; // the reverse-proxy link this threshold exists for
+    renderHook(() => usePollBusy());
+    act(() => vi.advanceTimersByTime(2_000));
+    expect(isBusy()).toBe(false); // slow-but-normal round trip
+    act(() => vi.advanceTimersByTime(3_000)); // now at 5s
+    expect(isBusy()).toBe(false); // still slow-but-normal, must stay hidden
+    act(() => vi.advanceTimersByTime(1_000)); // now at 6s — genuinely hung
+    expect(isBusy()).toBe(true);
   });
 
   it("a background revalidation past its (long) threshold shows the bar", () => {

--- a/web/src/hooks/use-poll-busy.ts
+++ b/web/src/hooks/use-poll-busy.ts
@@ -1,0 +1,36 @@
+import { useEffect } from "react";
+import { useNavigation, useRevalidator } from "react-router";
+
+import { setPollBusy } from "@/lib/busy";
+
+// A healthy poll or route change settles well under this, so the busy bar stays invisible on routine
+// traffic — that anti-flicker property is deliberate (see connection-bar's resolve() note). Only a
+// revalidation/navigation still in flight past here (a laggy link or bridge) surfaces the strip.
+export const POLL_BUSY_THRESHOLD_MS = 500;
+
+/**
+ * Feed the app-wide busy bar from a SLOW background load — a revalidation (`useRevalidator`, the
+ * poll) or a route navigation (`useNavigation`, e.g. opening a pane) that stays in flight past
+ * `thresholdMs`. Mount ONCE inside the router (RootLayout). A fast poll never shows the bar (the
+ * timer is cleared before it fires); the signal resets the instant loading stops and on unmount, so
+ * the bar can never get stuck on. Complements the mutation counter in lib/busy.
+ */
+export function usePollBusy(thresholdMs = POLL_BUSY_THRESHOLD_MS): void {
+  const revalidator = useRevalidator();
+  const navigation = useNavigation();
+  // One combined "a load is in flight" boolean drives a single timer, keyed on the boolean so the
+  // effect re-runs only on a true↔false edge — a burst of fast polls never trips it.
+  const loading = revalidator.state === "loading" || navigation.state !== "idle";
+
+  useEffect(() => {
+    if (!loading) {
+      setPollBusy(false);
+      return;
+    }
+    const id = window.setTimeout(() => setPollBusy(true), thresholdMs);
+    return () => clearTimeout(id);
+  }, [loading, thresholdMs]);
+
+  // Clear the signal if this unmounts mid-poll (the idle-lock swaps the whole router out).
+  useEffect(() => () => setPollBusy(false), []);
+}

--- a/web/src/hooks/use-poll-busy.ts
+++ b/web/src/hooks/use-poll-busy.ts
@@ -9,13 +9,16 @@ import { setPollBusy } from "@/lib/busy";
 // the strip. Kept short/snappy because the user is actively watching for feedback.
 export const NAV_BUSY_THRESHOLD_MS = 500;
 
-// A background revalidation (the poll) is AMBIENT — nobody is staring at it, so only SUSTAINED lag
-// should surface the strip. On-device, over the user's HTTPS reverse proxy, a single poll routinely
-// takes >500ms while the hot poll interval itself is only 1.5s — at the nav threshold the bar would
-// re-trigger on nearly every tick and read as permanently stuck on. This threshold sits comfortably
-// above a whole hot-poll interval, so a merely-slow-on-mobile poll (0.5–1.5s round trip) never trips
-// it — only a genuinely degraded/laggy poll does.
-export const POLL_BUSY_THRESHOLD_MS = 2_000;
+// A background revalidation (the poll) is AMBIENT — nobody is staring at it, so the strip should
+// only fire when a poll has HUNG, not merely when the link is slow. On-device, over the user's
+// HTTPS reverse proxy with large streaming-pane payloads on a 1.5s hot-poll cadence, single
+// revalidations routinely sit in flight for 0.5–3s as chronic-but-normal behavior for that link —
+// "stops briefly, then continues" is not a problem and must never surface the strip. This threshold
+// is well past any plausible normal round-trip on that link (roughly halfway to the 12s supersede
+// kick in use-polling.ts's SUPERSEDE_MS, which force-restarts a poll stuck that long), so crossing
+// it is rare and means the poll is actually stuck — a signal worth surfacing as reassurance the app
+// isn't dead, not ambient noise on every slow tick.
+export const POLL_BUSY_THRESHOLD_MS = 6_000;
 
 /**
  * Feed the app-wide busy bar from two independent slow-load signals, each against its own

--- a/web/src/hooks/use-poll-busy.ts
+++ b/web/src/hooks/use-poll-busy.ts
@@ -1,36 +1,75 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useNavigation, useRevalidator } from "react-router";
 
 import { setPollBusy } from "@/lib/busy";
 
-// A healthy poll or route change settles well under this, so the busy bar stays invisible on routine
-// traffic — that anti-flicker property is deliberate (see connection-bar's resolve() note). Only a
-// revalidation/navigation still in flight past here (a laggy link or bridge) surfaces the strip.
-export const POLL_BUSY_THRESHOLD_MS = 500;
+// A route navigation is USER-BLOCKING — the user just tapped something (e.g. opening a pane) and is
+// staring at the screen waiting on it. A healthy navigation settles well under this, so the busy bar
+// stays invisible on routine taps; only a navigation still in flight past here (a laggy link) surfaces
+// the strip. Kept short/snappy because the user is actively watching for feedback.
+export const NAV_BUSY_THRESHOLD_MS = 500;
+
+// A background revalidation (the poll) is AMBIENT — nobody is staring at it, so only SUSTAINED lag
+// should surface the strip. On-device, over the user's HTTPS reverse proxy, a single poll routinely
+// takes >500ms while the hot poll interval itself is only 1.5s — at the nav threshold the bar would
+// re-trigger on nearly every tick and read as permanently stuck on. This threshold sits comfortably
+// above a whole hot-poll interval, so a merely-slow-on-mobile poll (0.5–1.5s round trip) never trips
+// it — only a genuinely degraded/laggy poll does.
+export const POLL_BUSY_THRESHOLD_MS = 2_000;
 
 /**
- * Feed the app-wide busy bar from a SLOW background load — a revalidation (`useRevalidator`, the
- * poll) or a route navigation (`useNavigation`, e.g. opening a pane) that stays in flight past
- * `thresholdMs`. Mount ONCE inside the router (RootLayout). A fast poll never shows the bar (the
- * timer is cleared before it fires); the signal resets the instant loading stops and on unmount, so
- * the bar can never get stuck on. Complements the mutation counter in lib/busy.
+ * Feed the app-wide busy bar from two independent slow-load signals, each against its own
+ * threshold: a route navigation (`useNavigation`, e.g. opening a pane — user-blocking,
+ * `navThresholdMs`) and a background revalidation (`useRevalidator`, the poll — ambient,
+ * `pollThresholdMs`). Mount ONCE inside the router (RootLayout).
+ *
+ * The two signals OR together into the shared `setPollBusy`: they can overlap (a poll already
+ * stalled when you open a pane), and the bar shows the instant EITHER is past its own threshold,
+ * clearing only once BOTH have settled. A fast load on either axis never shows the bar (its timer is
+ * cleared before it fires); each signal resets to false the instant its own loading stops, and
+ * unmount clears both. Complements the mutation counter in lib/busy.
  */
-export function usePollBusy(thresholdMs = POLL_BUSY_THRESHOLD_MS): void {
+export function usePollBusy(
+  navThresholdMs = NAV_BUSY_THRESHOLD_MS,
+  pollThresholdMs = POLL_BUSY_THRESHOLD_MS,
+): void {
   const revalidator = useRevalidator();
   const navigation = useNavigation();
-  // One combined "a load is in flight" boolean drives a single timer, keyed on the boolean so the
-  // effect re-runs only on a true↔false edge — a burst of fast polls never trips it.
-  const loading = revalidator.state === "loading" || navigation.state !== "idle";
+  // Two independent booleans, each driving its own timer — keyed on the boolean (not the raw state
+  // string/object), so each effect re-runs only on its own true↔false edge. A burst of fast polls
+  // never trips the poll timer, and it can't be reset early by an unrelated navigation edge (or
+  // vice versa) since the two timers are fully decoupled.
+  const navLoading = navigation.state !== "idle";
+  const pollLoading = revalidator.state === "loading";
+
+  const [navPast, setNavPast] = useState(false);
+  const [pollPast, setPollPast] = useState(false);
 
   useEffect(() => {
-    if (!loading) {
-      setPollBusy(false);
+    if (!navLoading) {
+      setNavPast(false);
       return;
     }
-    const id = window.setTimeout(() => setPollBusy(true), thresholdMs);
+    const id = window.setTimeout(() => setNavPast(true), navThresholdMs);
     return () => clearTimeout(id);
-  }, [loading, thresholdMs]);
+  }, [navLoading, navThresholdMs]);
 
-  // Clear the signal if this unmounts mid-poll (the idle-lock swaps the whole router out).
+  useEffect(() => {
+    if (!pollLoading) {
+      setPollPast(false);
+      return;
+    }
+    const id = window.setTimeout(() => setPollPast(true), pollThresholdMs);
+    return () => clearTimeout(id);
+  }, [pollLoading, pollThresholdMs]);
+
+  // Publish the OR of the two onto the shared store whenever either edge flips. setPollBusy is
+  // idempotent, so re-publishing an unchanged value (e.g. both effects settling on the same tick)
+  // is a no-op.
+  useEffect(() => {
+    setPollBusy(navPast || pollPast);
+  }, [navPast, pollPast]);
+
+  // Clear the signal if this unmounts mid-load (the idle-lock swaps the whole router out).
   useEffect(() => () => setPollBusy(false), []);
 }

--- a/web/src/lib/agent-groups.ts
+++ b/web/src/lib/agent-groups.ts
@@ -7,10 +7,13 @@ export interface AgentGroup {
   label: string;
   match: (s: AgentStatus) => boolean;
   accent?: boolean;
+  /** Section bullet class — the same status palette the badges use, so a group's color can't drift
+   *  from the status it collects. */
+  dot: string;
 }
 
 export const AGENT_GROUPS: readonly AgentGroup[] = [
-  { key: "needs", label: "Needs you", match: (s) => s === "blocked", accent: true },
-  { key: "working", label: "Working", match: (s) => s === "working" },
-  { key: "other", label: "Idle · done", match: (s) => s !== "blocked" && s !== "working" },
+  { key: "needs", label: "Needs you", match: (s) => s === "blocked", accent: true, dot: "bg-status-blocked" },
+  { key: "working", label: "Working", match: (s) => s === "working", dot: "bg-status-working" },
+  { key: "other", label: "Idle · done", match: (s) => s !== "blocked" && s !== "working", dot: "bg-status-idle" },
 ];

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -205,6 +205,18 @@ export function renamePane(
   });
 }
 
+/** Set a tab's label. Non-empty required — a tab has no "clear" (the bridge 400s a blank label). */
+export function renameTab(
+  tabId: string,
+  label: string,
+  session?: string,
+): Promise<ActionResponse> {
+  return req<ActionResponse>(withSession(`/api/tab/${encodeURIComponent(tabId)}/rename`, session), {
+    method: "POST",
+    body: JSON.stringify({ label }),
+  });
+}
+
 /** Create a new tab in a space, opening a fresh shell pane. `cwd` omitted = inherits the space dir. */
 export function createTab(
   workspaceId: string,

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -217,6 +217,13 @@ export function renameTab(
   });
 }
 
+/** Close a tab, killing every pane inside it. */
+export function closeTab(tabId: string, session?: string): Promise<ActionResponse> {
+  return req<ActionResponse>(withSession(`/api/tab/${encodeURIComponent(tabId)}/close`, session), {
+    method: "POST",
+  });
+}
+
 /** Create a new tab in a space, opening a fresh shell pane. `cwd` omitted = inherits the space dir. */
 export function createTab(
   workspaceId: string,

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -193,6 +193,18 @@ export function closePane(paneId: string, session?: string): Promise<ActionRespo
   });
 }
 
+/** Set (or clear) a pane's label. An empty/blank `label` clears it (the bridge sends `null` on). */
+export function renamePane(
+  paneId: string,
+  label: string,
+  session?: string,
+): Promise<ActionResponse> {
+  return req<ActionResponse>(withSession(`/api/pane/${encodeURIComponent(paneId)}/rename`, session), {
+    method: "POST",
+    body: JSON.stringify({ label }),
+  });
+}
+
 /** Create a new tab in a space, opening a fresh shell pane. `cwd` omitted = inherits the space dir. */
 export function createTab(
   workspaceId: string,

--- a/web/src/lib/busy.ts
+++ b/web/src/lib/busy.ts
@@ -1,13 +1,18 @@
 import { useSyncExternalStore } from "react";
 
-// App-wide "a mutation is in flight" signal. Every WRITE to the bridge (reply, keys, prompt-option
-// tap, upload, tab/space create, pane close, snooze) increments a counter for its duration; the top
-// <BusyBar/> reflects `count > 0`. Background READS (snapshot/pane polling) are deliberately NOT
-// tracked — they run on a constant timer, so the bar would never rest. Module-scoped, mirroring
-// lib/status, so any call site participates without prop-drilling. Concurrent mutations nest via the
-// counter, so the bar stays up until the LAST one settles.
+// App-wide "the bar should show" signal. Two independent sources feed it:
+//   1. Mutations — every WRITE to the bridge (reply, keys, prompt-option tap, upload, tab/space
+//      create, pane close, snooze) increments a counter for its duration.
+//   2. A SLOW poll — a background revalidation/navigation that stays in flight past a threshold sets
+//      a boolean (see hooks/use-poll-busy). A routine fast poll never trips it, so the bar stays
+//      invisible on healthy traffic; only a genuinely laggy read surfaces the strip.
+// The top <BusyBar/> reflects `count > 0 || pollStalled`. Background reads are otherwise NOT counted
+// as mutations — they run on a constant timer, so the counter alone would never rest. Module-scoped,
+// mirroring lib/status, so any call site participates without prop-drilling. Concurrent mutations
+// nest via the counter, so the bar stays up until the LAST one settles.
 
 let count = 0;
+let pollStalled = false;
 const listeners = new Set<() => void>();
 
 function emit() {
@@ -28,9 +33,20 @@ export function trackBusy<T>(p: Promise<T>): Promise<T> {
   });
 }
 
+/**
+ * Set whether a slow poll/revalidation is currently surfacing the bar. Idempotent (a no-op when
+ * unchanged, so it doesn't churn subscribers). Driven only by hooks/use-poll-busy, which clears it
+ * the moment loading stops and on unmount, so the bar can't get stuck on.
+ */
+export function setPollBusy(stalled: boolean): void {
+  if (pollStalled === stalled) return;
+  pollStalled = stalled;
+  emit();
+}
+
 /** Non-hook read of the busy state (for tests and any non-React consumer). */
 export function isBusy(): boolean {
-  return count > 0;
+  return count > 0 || pollStalled;
 }
 
 function subscribe(cb: () => void): () => void {

--- a/web/src/lib/busy.ts
+++ b/web/src/lib/busy.ts
@@ -3,9 +3,10 @@ import { useSyncExternalStore } from "react";
 // App-wide "the bar should show" signal. Two independent sources feed it:
 //   1. Mutations — every WRITE to the bridge (reply, keys, prompt-option tap, upload, tab/space
 //      create, pane close, snooze) increments a counter for its duration.
-//   2. A SLOW poll — a background revalidation/navigation that stays in flight past a threshold sets
-//      a boolean (see hooks/use-poll-busy). A routine fast poll never trips it, so the bar stays
-//      invisible on healthy traffic; only a genuinely laggy read surfaces the strip.
+//   2. A SLOW load — a background revalidation (the poll) or a route navigation that stays in flight
+//      past its own threshold sets a boolean (see hooks/use-poll-busy, which uses two independent
+//      thresholds — snappy for navigation, longer for the ambient poll). A routine fast poll never
+//      trips it, so the bar stays invisible on healthy traffic; only genuinely laggy loading does.
 // The top <BusyBar/> reflects `count > 0 || pollStalled`. Background reads are otherwise NOT counted
 // as mutations — they run on a constant timer, so the counter alone would never rest. Module-scoped,
 // mirroring lib/status, so any call site participates without prop-drilling. Concurrent mutations

--- a/web/src/lib/types.test.ts
+++ b/web/src/lib/types.test.ts
@@ -1,0 +1,42 @@
+import { paneDisplayName } from "./types";
+import type { AgentView } from "./types";
+
+// The one place the pane display-name priority lives, so every surface (pill, card, sidebar, header)
+// agrees: explicit user label > Claude's /rename session name > the agent name (or "shell").
+function pane(overrides: Partial<AgentView> = {}): AgentView {
+  return {
+    paneId: "w1:p1",
+    workspaceId: "w1",
+    workspaceLabel: "proj",
+    workspaceNumber: 1,
+    tabId: "w1:t1",
+    agent: "claude",
+    status: "idle",
+    cwd: "/home/proj",
+    focused: false,
+    kind: "agent",
+    ...overrides,
+  };
+}
+
+describe("paneDisplayName", () => {
+  it("prefers an explicit user label over everything", () => {
+    expect(paneDisplayName(pane({ paneLabel: "deploy", sessionName: "auth-refactor" }))).toBe("deploy");
+  });
+
+  it("falls back to Claude's /rename session name when there's no label", () => {
+    expect(paneDisplayName(pane({ sessionName: "auth-refactor" }))).toBe("auth-refactor");
+  });
+
+  it("falls back to the agent name when neither a label nor a session name is set", () => {
+    expect(paneDisplayName(pane({ agent: "codex" }))).toBe("codex");
+  });
+
+  it("shows \"shell\" for a bare shell pane with no label or session name", () => {
+    expect(paneDisplayName(pane({ kind: "shell", agent: "shell" }))).toBe("shell");
+  });
+
+  it("still lets a user label win on a shell pane", () => {
+    expect(paneDisplayName(pane({ kind: "shell", agent: "shell", paneLabel: "logs" }))).toBe("logs");
+  });
+});

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -15,6 +15,8 @@ export interface AgentView {
   focused: boolean;
   /** "agent" for an agent-bearing pane, "shell" for a bare shell. Absent = "agent". */
   kind?: "agent" | "shell";
+  /** User-set pane label (herdr `pane.rename`), when one is set; absent when the pane is unlabelled. */
+  paneLabel?: string;
 }
 
 /** A Herdr workspace ("space") — a project-scoped container of tabs. */

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -17,6 +17,24 @@ export interface AgentView {
   kind?: "agent" | "shell";
   /** User-set pane label (herdr `pane.rename`), when one is set; absent when the pane is unlabelled. */
   paneLabel?: string;
+  /**
+   * Claude's OWN session name (set in-agent via `/rename`), derived bridge-side from the pane text.
+   * Claude-only; absent for unnamed sessions and non-claude panes. Shown below an explicit `paneLabel`
+   * — see {@link paneDisplayName}. Render as text only (never markup) — same XSS boundary as paneLabel.
+   */
+  sessionName?: string;
+}
+
+/**
+ * The name to show for a pane, in priority order: an explicit user label (herdr `pane.rename`) wins,
+ * then Claude's own `/rename` session name, then the agent name (or "shell"). Both label and session
+ * name are rendered only as React text nodes by callers — never markup — so they stay within the
+ * pane-output XSS boundary.
+ */
+export function paneDisplayName(pane: AgentView): string {
+  if (pane.paneLabel) return pane.paneLabel;
+  if (pane.sessionName) return pane.sessionName;
+  return pane.kind === "shell" ? "shell" : pane.agent;
 }
 
 /** A Herdr workspace ("space") — a project-scoped container of tabs. */

--- a/web/src/routes/root.tsx
+++ b/web/src/routes/root.tsx
@@ -21,8 +21,9 @@ export function RootLayout() {
   const { paneId } = useParams();
 
   usePolling(data, paneId);
-  // Surface the busy bar when a poll/navigation runs slow (past the threshold) — routine fast polls
-  // stay invisible. Mounted here so the whole app shares one detector inside the router context.
+  // Surface the busy bar when a navigation or a poll runs slow, each against its own threshold —
+  // routine fast polls/navigations stay invisible. Mounted here so the whole app shares one
+  // detector inside the router context.
   usePollBusy();
   useAgentTransitions(data.agents, paneId ?? null);
   usePushSetup();

--- a/web/src/routes/root.tsx
+++ b/web/src/routes/root.tsx
@@ -1,6 +1,7 @@
 import { Outlet, useLoaderData, useParams, useRouteError } from "react-router";
 
 import { usePolling } from "@/hooks/use-polling";
+import { usePollBusy } from "@/hooks/use-poll-busy";
 import { useAgentTransitions } from "@/hooks/use-transitions";
 import { usePushSetup } from "@/hooks/use-push";
 import { OfflineBanner } from "@/components/offline-banner";
@@ -20,6 +21,9 @@ export function RootLayout() {
   const { paneId } = useParams();
 
   usePolling(data, paneId);
+  // Surface the busy bar when a poll/navigation runs slow (past the threshold) — routine fast polls
+  // stay invisible. Mounted here so the whole app shares one detector inside the router context.
+  usePollBusy();
   useAgentTransitions(data.agents, paneId ?? null);
   usePushSetup();
 

--- a/web/src/routes/space.tsx
+++ b/web/src/routes/space.tsx
@@ -103,6 +103,12 @@ export function SpaceRoute() {
               session={data.session}
               readOnly={isReadOnly(data.device)}
               onRenamed={() => revalidator.revalidate()}
+              // Closing the tab you're filtered to would strand you on an empty view — fall back to
+              // "All" (setTab(null)) in that case; either way revalidate so it drops out of the strip.
+              onClosed={(tabId) => {
+                if (tab === tabId) setTab(null);
+                revalidator.revalidate();
+              }}
             />
             <main className="flex-1">
               <SpaceView

--- a/web/src/routes/space.tsx
+++ b/web/src/routes/space.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from "react";
-import { useNavigate, useParams, useRouteLoaderData } from "react-router";
+import { useNavigate, useParams, useRevalidator, useRouteLoaderData } from "react-router";
 
 import { ConnectionBar } from "@/components/connection-bar";
 import { ReadOnlyBanner } from "@/components/read-only-banner";
@@ -16,6 +16,7 @@ import { useSpaceActions } from "@/hooks/use-spaces";
 import { ROOT_ROUTE_ID, type HomeData } from "@/lib/loaders";
 import { homePath, panePath, spacePath } from "@/lib/nav";
 import { setStatus } from "@/lib/status";
+import { isReadOnly } from "@/lib/types";
 
 // Space detail route: one space's tabs + panes, with the space/tab strips for in-space navigation.
 // Shares the root snapshot (no own loader), reading :spaceId from the URL — a deep-linkable,
@@ -26,6 +27,7 @@ export function SpaceRoute() {
   const online = useOnline();
   const stalled = useLoadingStalled();
   const navigate = useNavigate();
+  const revalidator = useRevalidator();
   const { newTab, newSpace } = useSpaceActions();
   const [newSpaceOpen, setNewSpaceOpen] = useState(false);
 
@@ -98,6 +100,9 @@ export function SpaceRoute() {
               selected={tab}
               onSelect={switchTab}
               onNewTab={newTab}
+              session={data.session}
+              readOnly={isReadOnly(data.device)}
+              onRenamed={() => revalidator.revalidate()}
             />
             <main className="flex-1">
               <SpaceView

--- a/web/src/test/handlers.ts
+++ b/web/src/test/handlers.ts
@@ -103,6 +103,7 @@ export const handlers = [
   http.post(/\/api\/pane\/[^/]+\/reply$/, () => HttpResponse.json({ ok: true })),
   http.post(/\/api\/pane\/[^/]+\/keys$/, () => HttpResponse.json({ ok: true })),
   http.post(/\/api\/pane\/[^/]+\/close$/, () => HttpResponse.json({ ok: true })),
+  http.post(/\/api\/pane\/[^/]+\/rename$/, () => HttpResponse.json({ ok: true })),
   http.post("/api/tab", () =>
     HttpResponse.json({
       ok: true,


### PR DESCRIPTION
## Do not merge yet — pending on-device testing by @AltanS

Adds pane-level rename/close from the phone UI, plus visible feedback when a background poll runs slow.

### What's in here

- **Bridge: `pane.rename` plumbing** — new write-gated, audited `POST /api/pane/:id/rename` (`{label: string | null}`, blank clears) calling Herdr's live-verified `pane.rename` RPC; the pane `label` now threads through `WirePane → StateEngine → AgentView.paneLabel` on both sides.
- **Web: long-press pane pills → actions sheet** — new pointer-based `useLongPress` hook (450ms hold, move-cancel so the strip still scrolls, click suppression so a long-press doesn't also switch panes) opening a `BottomSheet` with **Rename** (prefilled input, blank clears) and **Close** (the app's two-tap arm-then-confirm; navigates Home when closing the open pane). A set label replaces the default agent/shell name on pills, cards, the chat header, and sidebar rows. Read-only devices get a note instead of actions.
- **BusyBar on slow polls** — the existing 2px top strip now also appears when a revalidation/navigation stays in flight past 500ms; routine fast polls remain invisible (the deliberate anti-flicker behavior is preserved).
- **Docs** — `HERDR_API.md` gains the live-verified rename-method family (`pane.rename` / `tab.rename` / `workspace.rename`: param shapes, nullability differences, error codes, and the no-event caveat for `pane.rename`); README/ARCHITECTURE mention the long-press actions.

### Verification notes for testing

- Long-press a pane pill (strip shows only when a tab has ≥2 panes) → sheet opens without also switching panes; renaming updates the pill on the next poll; blank label restores the default name.
- Close from the sheet needs the second confirming tap; closing the currently-open pane returns Home.
- Native long-press behaviors on device (iOS callout / Android context menu) are the thing to watch — `select-none` is applied, but real-device feel is the test.
- Tests: 193 bridge + 740 web pass; both sides typecheck via root `bun run build`.

No version bump/CHANGELOG here by design — the 0.13.0 release commit on main will cite these hashes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Round 2 (after on-device testing)
- **Long-press fix:** OS gestures preempted the hold timer on real phones — now `-webkit-touch-callout:none` suppresses the iOS loupe/callout, and `contextmenu` (Android long-press / desktop right-click) is an idempotent alternative trigger; move tolerance 10→16px for thumb jitter (c713551)
- **Claude `/rename` session names:** extracted bridge-side from the rule above the `❯` prompt, threaded as `AgentView.sessionName`, shown everywhere via `paneDisplayName()` — priority: user pane label → Claude session name → agent name (d22fdd7)


## Round 3
- **Instant-dismiss root cause:** the sheet mounted mid-hold and the release click landed on the full-screen backdrop, closing it the same instant (the felt haptic proved the gesture fired). Backdrop now dismisses only when the pointer went DOWN on it too (Radix outside-pointerdown rule); plus tapping the already-active pill opens the actions sheet directly as a long-press-free path (90210ce)


## Round 4
- **Sheet polish:** opens on an action list (Rename / Close pane); rename is behind a tap with autofocus + Back; Close is destructive-styled from first render, two-tap confirm kept (ea20df0)
- **Tab rename:** long-press (or tap-again on the selected) tab chip → lean rename sheet; write-gated `POST /api/tab/:id/rename` + audit; live-verified: herdr stores `""` literally and rejects `null` for tab labels, so blank is refused — tabs have no clear (HERDR_API.md updated). `tab.close` exists upstream but is deliberately not wired (a9664b5)


## Round 5
- **Unified sheets + tab close:** tab sheet now structurally identical to the pane sheet via shared `action-sheet-rows.tsx` (ActionRow/DestructiveActionRow/RenameView — authored once, cannot drift); `tab.close` live-verified (bulk pane-close: `{tab_id}` → ok, kills every pane inside, `tab_not_found` on unknown; HERDR_API.md close-methods section) and wired write-gated + audited; confirm names the blast radius ("Tap again to close N panes"); closing the selected/viewed tab falls back to All / Home (37a470e)



## Round 4 — busy strip strobing (on-device)
- **Two thresholds instead of one** (3bfaa1c): on the phone via the HTTPS proxy, background polls routinely exceed the single 500ms threshold while hot-polling every 1.5s — the strip re-triggered on every tick and read as never stopping. Navigations (user-blocking, e.g. opening a pane) keep 500ms; background revalidations now need 2s in flight (longer than a full hot-poll interval — genuine lag, not mobile RTT). Signals OR together; the bar clears only when both settle.
- **Poll threshold → hung (6s)** (06516c4): 2s still strobed on-device — chronic 2s+ round-trips are that link's normal. Background polls now surface the strip only after 6s in flight (a hung poll, halfway to the 12s supersede); navigations keep 500ms.
