### PR TITLE
fix: preserve Herdr snapshot tab order

### DIFF
--- a/bridge/state-engine.test.ts
+++ b/bridge/state-engine.test.ts
@@ -189,6 +189,18 @@ describe("StateEngine — in-flight guard", () => {
 });
 
 describe("StateEngine — snapshot shaping", () => {
+  test("preserves the tab order reported by Herdr", async () => {
+    const { herdr, engine, poll } = makeEngine();
+    herdr.tabs = [
+      { ...herdr.tabs[0]!, tab_id: "w1:t2", number: 2, label: "second" },
+      { ...herdr.tabs[0]!, tab_id: "w1:t1", number: 1, label: "first" },
+    ];
+
+    await poll();
+
+    expect(engine.current().tabs.map((tab) => tab.tabId)).toEqual(["w1:t2", "w1:t1"]);
+  });
+
   test("splits agent panes from bare shell panes", async () => {
     const { herdr, engine, poll } = makeEngine();
     herdr.panes = [pane("w1:p1", "w1", "idle", "claude"), pane("w1:p2", "w1", "unknown", null)];

--- a/bridge/state-engine.ts
+++ b/bridge/state-engine.ts
@@ -249,16 +249,14 @@ export class StateEngine {
         }))
         .sort((a, b) => a.number - b.number);
 
-      const tabViews: TabView[] = tabs
-        .map((t) => ({
-          tabId: t.tab_id,
-          workspaceId: t.workspace_id,
-          number: t.number,
-          label: t.label,
-          focused: t.focused,
-          paneCount: t.pane_count,
-        }))
-        .sort((a, b) => a.number - b.number);
+      const tabViews: TabView[] = tabs.map((t) => ({
+        tabId: t.tab_id,
+        workspaceId: t.workspace_id,
+        number: t.number,
+        label: t.label,
+        focused: t.focused,
+        paneCount: t.pane_count,
+      }));
 
       // Detect transitions against the previous poll. First sighting of a pane never fires a
       // transition (so we don't notify for agents already blocked when the bridge starts).

--- a/web/src/components/tab-strip.test.tsx
+++ b/web/src/components/tab-strip.test.tsx
@@ -13,6 +13,28 @@ const tabs: TabView[] = [
 ];
 
 describe("TabStrip", () => {
+  it("renders tabs in snapshot order even when their stable numbers differ", () => {
+    render(
+      <TabStrip
+        workspaceId="w1"
+        tabs={[
+          { ...tabs[1]!, label: "Second" },
+          { ...tabs[0]!, label: "First" },
+        ]}
+        agents={[]}
+        selected={null}
+        onSelect={vi.fn()}
+        onNewTab={vi.fn()}
+      />,
+    );
+
+    const renderedTabs = screen
+      .getAllByRole("button")
+      .map((button) => button.textContent)
+      .filter((label) => label === "First" || label === "Second");
+    expect(renderedTabs).toEqual(["Second", "First"]);
+  });
+
   it("shows All plus only this workspace's tabs, and reports selection", async () => {
     const user = userEvent.setup();
     const onSelect = vi.fn();

--- a/web/src/components/tab-strip.tsx
+++ b/web/src/components/tab-strip.tsx
@@ -50,9 +50,7 @@ export function TabStrip({
   // chips stay plain tap-to-switch — long-press is inert.
   const actionsEnabled = !!onRenamed && !!onClosed;
 
-  const wsTabs = tabs
-    .filter((t) => t.workspaceId === workspaceId)
-    .sort((a, b) => a.number - b.number);
+  const wsTabs = tabs.filter((t) => t.workspaceId === workspaceId);
   if (wsTabs.length === 0) return null;
 
   return (

--- a/web/src/lib/spaces.test.ts
+++ b/web/src/lib/spaces.test.ts
@@ -25,22 +25,22 @@ const tab = (tabId: string, workspaceId: string, number: number): TabView => ({
 });
 
 describe("groupPanesByTab", () => {
-  const tabs = [tab("w1:t2", "w1", 2), tab("w1:t1", "w1", 1)]; // deliberately out of order
+  const tabs = [tab("w1:t2", "w1", 2), tab("w1:t1", "w1", 1)]; // differs from stable number order
 
-  it("groups panes by tab in tab-number order", () => {
+  it("preserves snapshot tab order when grouping panes", () => {
     const a1 = agent({ paneId: "w1:p1", workspaceId: "w1", tabId: "w1:t1" });
     const a2 = agent({ paneId: "w1:p2", workspaceId: "w1", tabId: "w1:t2" });
     const groups = groupPanesByTab("w1", tabs, [a1, a2], []);
-    expect(groups.map((g) => g.tabId)).toEqual(["w1:t1", "w1:t2"]);
-    expect(groups[0]!.panes).toEqual([a1]);
-    expect(groups[1]!.panes).toEqual([a2]);
+    expect(groups.map((g) => g.tabId)).toEqual(["w1:t2", "w1:t1"]);
+    expect(groups[0]!.panes).toEqual([a2]);
+    expect(groups[1]!.panes).toEqual([a1]);
   });
 
   it("includes shell panes alongside agents in their tab", () => {
     const a1 = agent({ paneId: "w1:p1", workspaceId: "w1", tabId: "w1:t1" });
     const shell = agent({ paneId: "w1:p2", workspaceId: "w1", tabId: "w1:t1", kind: "shell" });
-    const [first] = groupPanesByTab("w1", tabs, [a1], [shell]);
-    expect(first!.panes).toEqual([a1, shell]);
+    const group = groupPanesByTab("w1", tabs, [a1], [shell]).find((item) => item.tabId === "w1:t1");
+    expect(group!.panes).toEqual([a1, shell]);
   });
 
   it("collects panes whose tab isn't listed yet into a trailing '…' group", () => {

--- a/web/src/lib/spaces.ts
+++ b/web/src/lib/spaces.ts
@@ -19,7 +19,7 @@ export function groupPanesByTab(
   shellPanes: AgentView[],
 ): TabGroup[] {
   const panes = [...agents, ...shellPanes].filter((p) => p.workspaceId === workspaceId);
-  const wsTabs = tabs.filter((t) => t.workspaceId === workspaceId).sort((a, b) => a.number - b.number);
+  const wsTabs = tabs.filter((t) => t.workspaceId === workspaceId);
 
   const groups: TabGroup[] = wsTabs.map((t) => ({
     tabId: t.tabId,


### PR DESCRIPTION
## Summary

Preserve the tab order reported by Herdr from the bridge snapshot through the space grouping and tab-strip render paths.

Herdr can reorder tabs without renumbering their stable public numbers. Collie currently sorts `TabView` values by `number` in three layers, so a user-visible reorder is changed back to creation/number order before it reaches the screen.

## Reproduction

1. Open a Herdr workspace with at least two tabs.
2. Reorder the tabs in Herdr so the snapshot order differs from their stable numbers.
3. Open the same workspace or pane in Collie.

A minimal equivalent snapshot is:

```text
[t2 (number 2), t1 (number 1)]
```

Before this change, Collie projects and renders it as `[t1, t2]`. After this change, Collie keeps `[t2, t1]`, matching Herdr.

## Change

- Stop sorting tabs by `number` in the state engine.
- Keep the incoming order when grouping a workspace's panes by tab.
- Keep the incoming order in `TabStrip`.

Workspace ordering, agent priority ordering, pane ordering, tab IDs, and the `number` field itself are unchanged.

## Verification

The regression assertions failed before the production change in all three affected layers:

- state-engine snapshot projection
- workspace tab grouping
- rendered tab strip

After the change:

- `bun run typecheck` (root): pass
- `bun run test` (bridge): 219 pass
- `bun run typecheck` (web): pass
- `bun run test` (web): 906 pass
- `bash scripts/check-version.sh`: pass (`0.13.1`)
