### PR TITLE
fix: focus composer within mobile tap

### DIFF
--- a/web/src/components/agent-chat.test.tsx
+++ b/web/src/components/agent-chat.test.tsx
@@ -1,5 +1,5 @@
 import { useState, type ComponentProps } from "react";
-import { act, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { http, HttpResponse } from "msw";
 import { createMemoryRouter, RouterProvider, useParams } from "react-router";
@@ -382,8 +382,6 @@ describe("AgentChat — mirror tap must not pop the keyboard on option taps", ()
 
     await user.click(yes);
     await waitFor(() => expect(mockSubmit).toHaveBeenCalledTimes(1));
-    // focusInput() is deferred (setTimeout 0); let any buggy queued focus fire before asserting.
-    await new Promise((r) => setTimeout(r, 20));
     expect(box).not.toHaveFocus();
   });
 
@@ -394,6 +392,15 @@ describe("AgentChat — mirror tap must not pop the keyboard on option taps", ()
 
     await user.click(screen.getByText("recent pane output"));
     await waitFor(() => expect(box).toHaveFocus());
+  });
+
+  it("focuses during the tap event so mobile browsers can open the software keyboard", () => {
+    renderChat({ text: "recent pane output" });
+    const box = screen.getByPlaceholderText(/type a reply/i);
+
+    fireEvent.click(screen.getByText("recent pane output"));
+
+    expect(box).toHaveFocus();
   });
 });
 

--- a/web/src/components/composer.tsx
+++ b/web/src/components/composer.tsx
@@ -180,7 +180,7 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
   const effectiveStable = suppressEcho(terminalDraft);
   const effectiveRaw = suppressEcho(rawTerminalDraft);
 
-  useImperativeHandle(ref, () => ({ focusInput: focusInputEnd }), []);
+  useImperativeHandle(ref, () => ({ focusInput: focusInputImmediately }), []);
 
   useEffect(
     () => () => {
@@ -260,14 +260,15 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 
   const commands = commandsFor(agent);
 
+  function focusInputImmediately() {
+    const el = inputRef.current;
+    if (!el) return;
+    el.focus();
+    el.setSelectionRange(el.value.length, el.value.length);
+  }
+
   function focusInputEnd() {
-    setTimeout(() => {
-      const el = inputRef.current;
-      if (el) {
-        el.focus();
-        el.setSelectionRange(el.value.length, el.value.length);
-      }
-    }, 0);
+    setTimeout(focusInputImmediately, 0);
   }
 
   async function send(value: string, isDraft: boolean) {


### PR DESCRIPTION
## Summary

Focus the composer synchronously when the user taps raw terminal output, keeping the call inside the tap's user-activation window so mobile browsers can open the software keyboard.

## Reproduction

1. Open a pane in the Collie PWA on iOS.
2. Tap raw text in the terminal mirror instead of tapping the composer directly.
3. Observe that the composer may become focused after the tap, but the software keyboard does not open.
4. Tap the composer itself and observe that the keyboard opens normally.

The mirror path currently defers `focus()` with `setTimeout(0)`. Mobile browsers may no longer treat that callback as part of the user gesture, so programmatic focus cannot summon the keyboard.

## Change

`ComposerHandle.focusInput`, which is called by the terminal-mirror click handler, now focuses and positions the caret synchronously.

The existing deferred helper remains in place for internal flows that update the composer value first, including Take over, command insertion, and image upload. Interactive controls inside the mirror and text-selection taps keep their existing focus guards.

## Verification

A regression test now asserts that the textarea is focused before `fireEvent.click()` returns. It failed before the production change and passes afterward.

- `bun run typecheck` (root): pass
- `bun run test` (bridge): 218 pass
- `bun run typecheck` (web): pass
- `bun run test` (web): 906 pass
- `bash scripts/check-version.sh`: pass (`0.13.1`)
