### PR TITLE
fix: self_dnsname shells out to node, but Collie requires bun

### DIFF
--- a/scripts/collie-ctl.sh
+++ b/scripts/collie-ctl.sh
@@ -88,7 +88,7 @@ ensure_build() {
 }
 
 self_dnsname() {
-  tailscale status --json 2>/dev/null | node -e \
+  tailscale status --json 2>/dev/null | bun -e \
     "let d='';process.stdin.on('data',c=>d+=c).on('end',()=>{try{process.stdout.write(JSON.parse(d).Self.DNSName.replace(/\.\$/,''))}catch{}})"
 }
 


### PR DESCRIPTION
`self_dnsname()` in `scripts/collie-ctl.sh` parses `tailscale status --json`
by piping into `node -e '...'`. Collie is a Bun project (bun is required to
run the bridge, build the web UI, etc.) — Node isn't a stated dependency
anywhere, so on any host without Node on PATH this silently breaks and
`bridge_url()` falls back to the "Tailscale name unavailable" branch.

Swap `node -e` for `bun -e`; the one-liner is unchanged and works
identically since it only touches Node-compatible `process.stdin` /
`JSON.parse`, both of which Bun implements faithfully.

This is a latent correctness bug, not specific to any one platform —
found it while auditing the script for an unrelated port, but it's
independent of that and worth fixing on its own.

Verified against a live `tailscale status --json`: returns the expected
DNSName with the trailing dot stripped. Empty and malformed stdin both
silently no-op, matching the existing try/catch and the caller's fallback.
