### PR TITLE
feat: own the tailscale serve mapping (supersedes #26)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,9 @@ COLLIE_HOST=127.0.0.1
 # With this enabled, set COLLIE_ALLOWED_ORIGINS and COLLIE_PUBLIC_HOSTS to match your proxy's hostname.
 # In this mode COLLIE_TRUSTED_USER has no effect (no tailscale serve injects the identity header) —
 # use COLLIE_DEVICE_HEADER for per-device auth instead (README → Variant C).
+# This is also the switch for any non-Tailscale mesh or tunnel — NetBird, ZeroTier, Cloudflare
+# Tunnel: Collie publishes nothing, you point your tunnel at 127.0.0.1:$COLLIE_PORT and start it
+# however you start your other services (README → Variant E).
 # COLLIE_SKIP_SERVE=1
 # Your public URL behind the proxy — shown as the "proxy" address by `collie-ctl.sh status`.
 # COLLIE_PUBLIC_URL=https://collie.example.com

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,3 +100,10 @@ Loopback bind only · exactly one hardened front door — `tailscale serve` (nev
 conforming reverse proxy per README Variant C (`COLLIE_SKIP_SERVE=1`) · same-origin gate · optional
 identity/device gates · strict CSP. A socket call can type into a real terminal — treat the bridge as
 remote shell access.
+
+**Collie manages exactly one front door: `tailscale serve`.** That's the one this project runs and
+tests, so it's the one whose lifecycle we own (`collie-ctl.sh` publishes it, records the mapping in
+`tailscale-managed-handler`, and only ever tears down a mapping matching that record). Every other
+tunnel — NetBird, ZeroTier, Cloudflare Tunnel — is `COLLIE_SKIP_SERVE=1` + README Variant E: the
+operator owns the ingress and Collie publishes nothing. **Don't add a second managed front door**;
+we'd be maintaining a CLI contract we can't test. See PR #26 for the full reasoning.

--- a/README.md
+++ b/README.md
@@ -385,9 +385,10 @@ repo's pre-commit / pre-push checks.
 ## Deployment variants
 
 The bridge always binds **loopback only**; what changes between deployments is *what sits in front
-of it* and *how a request proves who it is*. Four supported shapes — Tailscale by **person** (A),
-a co-located proxy by **device** (B), a reverse proxy as the sole front door (C), or an
-**off-host** identity proxy reached over the tailnet (D). Pick one.
+of it* and *how a request proves who it is*. Five supported shapes — Tailscale by **person** (A),
+a co-located proxy by **device** (B), a reverse proxy as the sole front door (C), an **off-host**
+identity proxy reached over the tailnet (D), or any other mesh or tunnel
+([E](#variant-e--any-other-mesh-or-tunnel-netbird-zerotier-cloudflare-tunnel)). Pick one.
 
 ### Variant A — `tailscale serve` + person identity (default)
 
@@ -662,6 +663,48 @@ A header-less request must be read-only. **If it says `"authorized":true`, your 
 > succeeds *there* even when the ACL is flawless. It is the most obvious machine to test from, since
 > it's the one you're configuring, and it will tell you your ACL is broken when it isn't. Reachability
 > is only observable from a second device.
+
+### Variant E — any other mesh or tunnel (NetBird, ZeroTier, Cloudflare Tunnel)
+
+Tailscale is the **default**, not a requirement. Collie's own Tailscale coupling is one header read
+and a convenience in `collie-ctl.sh`; the bridge itself is a loopback HTTP server that gates on
+`Host`, `Origin`, and two optional headers. Anything that can reach `127.0.0.1:$COLLIE_PORT` can
+front it.
+
+Collie deliberately **manages** only one front door — the one this project runs and tests. For every
+other tunnel you own the ingress and Collie stays out of the way:
+
+```bash
+COLLIE_SKIP_SERVE=1                                 # never run tailscale serve
+COLLIE_PUBLIC_HOSTS=collie.example.com              # exact public host — blocks DNS rebinding
+COLLIE_ALLOWED_ORIGINS=https://collie.example.com   # exact public origin for the same-origin gate
+```
+
+Then point your tunnel at `127.0.0.1:$COLLIE_PORT` and start it however you start your other
+services. `netbird expose 8787`, a ZeroTier-routed reverse proxy and `cloudflared tunnel` all work
+this way. `collie-ctl.sh start` will build, launch and supervise the bridge and publish nothing;
+`unserve` and `uninstall` likewise leave your tunnel alone, exactly as under
+[Variant C](#variant-c--reverse-proxy-as-the-only-front-door-no-tailscale).
+
+Three things to get right, none of them Collie-specific:
+
+1. **The [Variant B](#variant-b--identity-aware-proxy--per-device-authorisation) proxy requirements
+   apply verbatim.** Loopback upstream, the public `Host` forwarded unchanged (or listed in
+   `COLLIE_ALLOWED_ORIGINS`), and — if you use the device gate — the identity header **overridden**
+   on every request, never merely added.
+2. **`COLLIE_TRUSTED_USER` does nothing here.** It gates on `Tailscale-User-Login`, which only
+   `tailscale serve` injects. If your tunnel authenticates and injects a device identity, use
+   `COLLIE_DEVICE_HEADER` + `COLLIE_DEVICE_ALLOWLIST` instead; if it authenticates but injects
+   nothing, its own auth *is* the whole gate and anyone who passes it gets full Collie access.
+3. **Pin a stable hostname before you install the PWA.** A service-worker cache is per-origin, and
+   several tunnels hand out a fresh generated name per session. A name that changes gives you a new
+   install each time and makes `COLLIE_PUBLIC_HOSTS` unpinnable.
+
+> ⚠️ **Anything that publishes to the open internet is a `funnel` by another name.** The rule in
+> [Security](#-security--read-before-you-run-it) isn't about Tailscale, it's about reachability: this
+> socket is a shell running as you. If your tunnel offers a public URL, the auth in front of it is
+> the only thing between a stranger and that shell, so treat a shared PIN the way you'd treat a root
+> password — and prefer a tunnel scoped to your own devices over a public URL with a gate on it.
 
 ## Windows (experimental)
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "build": "bun run typecheck && cd web && bun install && bun run typecheck && bun run build",
     "build:web": "cd web && bun run build",
     "web:dev": "cd web && bun run dev",
-    "test": "bun test ./bridge",
+    "test": "bun test ./bridge && bash scripts/collie-ctl.test.sh",
+    "test:ctl": "bash scripts/collie-ctl.test.sh",
     "typecheck": "bunx tsc --noEmit"
   },
   "devDependencies": {

--- a/scripts/collie-ctl.sh
+++ b/scripts/collie-ctl.sh
@@ -41,6 +41,9 @@ SOCKET="${HERDR_SOCKET_PATH:-${HOME}/.config/herdr/herdr.sock}"
 # How tailscale serve exposes the bridge: "https" (default, needs a cert from the control
 # server) or "http" (plain HTTP over the tailnet — use this on Headscale / .internal domains).
 SERVE_MODE="${COLLIE_SERVE_MODE:-https}"
+# Records the ONE `tailscale serve` root mount Collie published, so teardown can prove the mapping
+# it is about to remove is still the one it created. Format: `<mode>:<port>|<HostPort>|<proxy>`.
+TAILSCALE_HANDLER_FILE="${CONFIG_DIR}/tailscale-managed-handler"
 BUN="$(command -v bun || true)"
 WEB_DIST="${PLUGIN_ROOT}/web/dist/index.html"
 
@@ -277,46 +280,248 @@ cmd_apply_update() {
   echo "✓ update complete"
 }
 
+# `tailscale serve … off` for one handler, treating "already gone" as success so teardown is
+# idempotent. Any other failure is real and must not be swallowed.
+remove_tailscale_handler() {
+  local description="$1" output
+  shift
+  if output="$(tailscale serve "$@" off 2>&1)"; then
+    return 0
+  fi
+  case "$output" in
+    *"handler does not exist"*) return 0 ;;
+  esac
+  [ -z "$output" ] || printf '%s\n' "$output" >&2
+  echo "error: failed to remove Collie's ${description} mapping" >&2
+  return 1
+}
+
+# Identify what currently owns the root mount we recorded: "absent", or "<protocol>|proxy:<target>".
+# This is the evidence teardown checks before removing anything.
+tailscale_root_fingerprint() {
+  local host_port="$1" port="$2" status_json result
+  [ -n "$BUN" ] || return 1
+  status_json="$(tailscale serve status --json 2>/dev/null)" || return 1
+  result="$(
+    printf '%s' "$status_json" |
+      COLLIE_SERVE_HOST_PORT="$host_port" COLLIE_SERVE_PORT="$port" "$BUN" -e '
+        let data = "";
+        process.stdin.on("data", chunk => data += chunk).on("end", () => {
+          try {
+            const config = JSON.parse(data || "{}");
+            const hostPort = process.env.COLLIE_SERVE_HOST_PORT;
+            const port = process.env.COLLIE_SERVE_PORT;
+            const handlers = config?.Web?.[hostPort]?.Handlers ?? {};
+            if (!Object.prototype.hasOwnProperty.call(handlers, "/")) {
+              process.stdout.write("absent");
+              return;
+            }
+            const listener = config?.TCP?.[port];
+            const protocol = listener?.HTTP === true ? "http" :
+              listener?.HTTPS === true ? "https" : "other";
+            const proxy = handlers["/"]?.Proxy;
+            process.stdout.write(typeof proxy === "string" && proxy ?
+              `${protocol}|proxy:${proxy}` : `${protocol}|other`);
+          } catch {
+            process.exitCode = 2;
+          }
+        });
+      '
+  )" || return 1
+  printf '%s\n' "$result"
+}
+
+# Remove ONLY the mapping Collie recorded as its own — never a blanket `tailscale serve reset`, and
+# never a blind `--https=443 off` that could take down a mapping someone else put there. With no
+# ownership record there is nothing to remove. If the recorded root has since been replaced, refuse
+# and keep the record: a wrong removal here silently unpublishes somebody else's service.
+stop_tailscale_serve() {
+  local managed_state="" managed_handler="" managed_mode="" managed_port=""
+  local managed_host_port="" managed_proxy="" extra="" current_fingerprint=""
+  if [ -f "$TAILSCALE_HANDLER_FILE" ]; then
+    managed_state="$(cat "$TAILSCALE_HANDLER_FILE" 2>/dev/null || true)"
+    IFS='|' read -r managed_handler managed_host_port managed_proxy extra <<< "$managed_state"
+    case "$managed_handler" in
+      http:*)
+        managed_mode="http"
+        managed_port="${managed_handler#http:}"
+        case "$managed_port" in
+          ''|*[!0-9]*) managed_mode="" ;;
+        esac
+        ;;
+      https:443)
+        managed_mode="https"
+        managed_port="443"
+        ;;
+    esac
+    if [ -z "$managed_mode" ] || [ -z "$managed_host_port" ] || [ -z "$managed_proxy" ] || [ -n "$extra" ]; then
+      echo "error: invalid managed Tailscale handler state: ${managed_state}" >&2
+      return 1
+    fi
+    case "$managed_host_port" in
+      *":${managed_port}") ;;
+      *)
+        echo "error: managed Tailscale HostPort does not match its listener: ${managed_state}" >&2
+        return 1
+        ;;
+    esac
+    case "$managed_proxy" in
+      http://127.0.0.1:[0-9]*) ;;
+      *)
+        echo "error: invalid managed Tailscale proxy target: ${managed_state}" >&2
+        return 1
+        ;;
+    esac
+  else
+    echo "tailscale serve: no Collie-managed mapping recorded"
+    return 0
+  fi
+  if ! command -v tailscale >/dev/null; then
+    echo "error: tailscale not found; retained the managed ${managed_handler} state for retry" >&2
+    return 1
+  fi
+  if ! current_fingerprint="$(tailscale_root_fingerprint "$managed_host_port" "$managed_port")"; then
+    echo "error: cannot inspect the managed Tailscale root; retained ownership state" >&2
+    return 1
+  fi
+  if [ "$current_fingerprint" = "absent" ]; then
+    if ! rm -f "$TAILSCALE_HANDLER_FILE"; then
+      echo "error: managed Tailscale root is absent but ownership state could not be removed" >&2
+      return 1
+    fi
+    echo "tailscale serve: managed root is already absent; cleared stale ownership state"
+    return 0
+  fi
+  if [ "$current_fingerprint" != "${managed_mode}|proxy:${managed_proxy}" ]; then
+    echo "error: managed Tailscale root was replaced; refusing to remove the current handler" >&2
+    return 1
+  fi
+  if [ "$managed_mode" = "http" ]; then
+    remove_tailscale_handler "HTTP :${managed_port} root mount" --http="$managed_port" --set-path=/ || {
+      echo "error: managed ingress cleanup incomplete; retained ${TAILSCALE_HANDLER_FILE} for retry" >&2
+      return 1
+    }
+  else
+    remove_tailscale_handler "HTTPS :443 root mount" --https=443 --set-path=/ || {
+      echo "error: managed ingress cleanup incomplete; retained ${TAILSCALE_HANDLER_FILE} for retry" >&2
+      return 1
+    }
+  fi
+  if ! rm -f "$TAILSCALE_HANDLER_FILE"; then
+    echo "error: Tailscale root was removed but ownership state could not be removed" >&2
+    return 1
+  fi
+  echo "tailscale serve: removed Collie's managed ${managed_handler} mapping"
+}
+
+# Refuse to publish over a root mount we don't own. `tailscale serve --bg … /` silently REPLACES an
+# existing root handler, so without this check a Collie start could unpublish an unrelated service
+# that got there first.
+ensure_tailscale_root_available() {
+  local port="$1" protocol="$2" status_json result
+  [ -n "$BUN" ] || {
+    echo "error: bun is required to inspect Tailscale serve ownership before publishing" >&2
+    return 1
+  }
+  if ! status_json="$(tailscale serve status --json 2>/dev/null)"; then
+    echo "error: cannot inspect Tailscale serve status; refusing to overwrite the root mount on :${port}" >&2
+    return 1
+  fi
+  if ! result="$(
+    printf '%s' "$status_json" |
+      COLLIE_SERVE_PORT="$port" COLLIE_SERVE_PROTOCOL="$protocol" "$BUN" -e '
+        let data = "";
+        process.stdin.on("data", chunk => data += chunk).on("end", () => {
+          try {
+            const config = JSON.parse(data || "{}");
+            const port = process.env.COLLIE_SERVE_PORT;
+            const protocol = process.env.COLLIE_SERVE_PROTOCOL;
+            const hasRoot = serveConfig =>
+              Object.entries(serveConfig?.Web ?? {}).some(([hostPort, server]) => {
+                const match = hostPort.match(/:(\d+)$/);
+                const handlers = server?.Handlers ?? {};
+                return match?.[1] === port && Object.prototype.hasOwnProperty.call(handlers, "/");
+              }) ||
+              Object.values(serveConfig?.Foreground ?? {}).some(hasRoot);
+            const hasProtocolMismatch = serveConfig => {
+              const listener = serveConfig?.TCP?.[port];
+              const mismatch = listener !== undefined &&
+                (protocol === "http" ? listener?.HTTP !== true : listener?.HTTPS !== true);
+              return mismatch ||
+                Object.values(serveConfig?.Foreground ?? {}).some(hasProtocolMismatch);
+            };
+            if (hasProtocolMismatch(config)) {
+              process.stdout.write("protocol-mismatch");
+              return;
+            }
+            const occupied = hasRoot(config);
+            process.stdout.write(occupied ? "occupied" : "free");
+          } catch {
+            process.exitCode = 2;
+          }
+        });
+      '
+  )"; then
+    echo "error: invalid Tailscale serve status; refusing to overwrite the root mount on :${port}" >&2
+    return 1
+  fi
+  if [ "$result" = "protocol-mismatch" ]; then
+    echo "error: Tailscale serve :${port} already uses the opposite listener protocol" >&2
+    return 1
+  fi
+  if [ "$result" = "occupied" ]; then
+    echo "error: Tailscale serve already has an unowned root mount on :${port}; refusing to overwrite it" >&2
+    return 1
+  fi
+}
+
 cmd_serve() {
   if [ "${COLLIE_SKIP_SERVE:-}" = "1" ]; then
+    # Still tear down: skipping teardown would strand a mapping published before the flag was
+    # flipped on, leaving the app reachable by a path the operator thinks is closed.
+    stop_tailscale_serve || return 1
     echo "tailscale serve skipped (COLLIE_SKIP_SERVE=1) — bridge is on 127.0.0.1:${PORT} only"
     return
   fi
-  command -v tailscale >/dev/null || { echo "note: tailscale not found; bridge is on 127.0.0.1:${PORT} only"; return; }
+  stop_tailscale_serve || return 1
+  command -v tailscale >/dev/null || {
+    echo "error: tailscale not found; cannot publish the tailnet front door" >&2
+    return 1
+  }
+  local tailscale_host; tailscale_host="$(self_dnsname)"
+  if [ -z "$tailscale_host" ]; then
+    echo "error: cannot determine Tailscale hostname; refusing to publish an untrackable root mount" >&2
+    return 1
+  fi
+  local expected_proxy="http://127.0.0.1:${PORT}"
   local out="${CONFIG_DIR}/serve.out"
   if [ "$SERVE_MODE" = "http" ]; then
-    if tailscale serve --bg --http="$PORT" "$PORT" >"$out" 2>&1; then
+    ensure_tailscale_root_available "$PORT" http || return 1
+    printf '%s|%s|%s\n' "http:${PORT}" "${tailscale_host}:${PORT}" "$expected_proxy" > "$TAILSCALE_HANDLER_FILE"
+    if tailscale serve --bg --http="$PORT" --set-path=/ "$PORT" >"$out" 2>&1; then
       echo "tailscale serve (http) → tailnet :${PORT} -> 127.0.0.1:${PORT}"
     else
-      echo "note: tailscale serve failed (try 'sudo tailscale set --operator=\$USER'):"; cat "$out"
+      rm -f "$TAILSCALE_HANDLER_FILE"
+      echo "note: tailscale serve failed (try 'sudo tailscale set --operator=\$USER'):"
+      cat "$out"
+      return 1
     fi
   else
-    if tailscale serve --bg "$PORT" >"$out" 2>&1; then
+    ensure_tailscale_root_available 443 https || return 1
+    printf '%s|%s|%s\n' "https:443" "${tailscale_host}:443" "$expected_proxy" > "$TAILSCALE_HANDLER_FILE"
+    if tailscale serve --bg --set-path=/ "$PORT" >"$out" 2>&1; then
       echo "tailscale serve (https) → tailnet :443 -> 127.0.0.1:${PORT}"
     else
-      echo "note: tailscale serve (https) failed — on Headscale/.internal domains use COLLIE_SERVE_MODE=http:"; cat "$out"
+      rm -f "$TAILSCALE_HANDLER_FILE"
+      echo "note: tailscale serve (https) failed — on Headscale/.internal domains use COLLIE_SERVE_MODE=http:"
+      cat "$out"
+      return 1
     fi
   fi
 }
 
-# Remove ONLY Collie's tailscale serve mapping — the inverse of cmd_serve, NOT a blanket
-# `tailscale serve reset` (which would wipe every unrelated mapping on the host). We turn off
-# exactly the listener cmd_serve created, keyed off the same SERVE_MODE so the two stay symmetric:
-# https:443 by default, or http:$PORT in http mode. Best-effort (|| true) so teardown is idempotent
-# when the mapping is already gone.
-cmd_unserve() {
-  # Always attempt teardown, even under COLLIE_SKIP_SERVE=1: it's idempotent (|| true) and guarded by
-  # the `command -v tailscale` check, and skipping it would strand a stale serve mapping (from before
-  # the flag was flipped on) still publishing the app — a security hazard, not a convenience.
-  command -v tailscale >/dev/null || { echo "note: tailscale not found; no serve mapping to remove"; return; }
-  if [ "$SERVE_MODE" = "http" ]; then
-    tailscale serve --http="$PORT" off >/dev/null 2>&1 || true
-    echo "tailscale serve: removed Collie's http :${PORT} mapping"
-  else
-    tailscale serve --https=443 off >/dev/null 2>&1 || true
-    echo "tailscale serve: removed Collie's https :443 mapping"
-  fi
-}
+# The inverse of cmd_serve: remove Collie's own mapping and nothing else.
+cmd_unserve() { stop_tailscale_serve; }
 
 cmd_status() {
   print_status_banner
@@ -341,6 +546,12 @@ cmd_push_test() {
   [ -n "$BUN" ] || { echo "error: bun not found on PATH" >&2; exit 1; }
   "$BUN" run "${PLUGIN_ROOT}/scripts/push-test.ts" "$@"
 }
+
+# Sourced (by scripts/collie-ctl.test.sh) rather than run: define the functions and stop before the
+# dispatch, so a test can call one function in isolation with its dependencies stubbed out.
+if [ "${BASH_SOURCE[0]}" != "$0" ]; then
+  return 0
+fi
 
 case "${1:-}" in
   start)   cmd_start ;;

--- a/scripts/collie-ctl.sh
+++ b/scripts/collie-ctl.sh
@@ -211,7 +211,10 @@ cmd_start() {
     echo $! > "${CONFIG_DIR}/collie.pid"
     echo "bridge started (pid $(cat "${CONFIG_DIR}/collie.pid"), no systemd)"
   fi
-  cmd_serve
+  # A front door that won't come up must not abort `start`. The bridge is already running on
+  # loopback, and the banner is what the README's troubleshooting flow tells people to read — under
+  # `set -e` a bare `cmd_serve` would exit here and print nothing. cmd_serve reports its own reason.
+  cmd_serve || echo "note: the tailnet front door did not come up; the bridge is still on 127.0.0.1:${PORT}" >&2
   print_status_banner
 }
 
@@ -417,8 +420,15 @@ stop_tailscale_serve() {
 # Refuse to publish over a root mount we don't own. `tailscale serve --bg … /` silently REPLACES an
 # existing root handler, so without this check a Collie start could unpublish an unrelated service
 # that got there first.
+#
+# "Don't own" is decided by where the mount points, not by our ownership file. Every install that
+# predates ownership tracking has Collie's own root mount and NO record of it, so a pure file check
+# would refuse to republish on exactly the deployments that already work — bricking start/restart/
+# update on upgrade. A root already proxying to our own `http://127.0.0.1:$PORT` is therefore
+# adopted: republishing over it is a no-op, and we then record it. A foreground serve session is
+# never adopted — it belongs to a live process that is not us.
 ensure_tailscale_root_available() {
-  local port="$1" protocol="$2" status_json result
+  local port="$1" protocol="$2" expected_proxy="$3" status_json result
   [ -n "$BUN" ] || {
     echo "error: bun is required to inspect Tailscale serve ownership before publishing" >&2
     return 1
@@ -429,20 +439,25 @@ ensure_tailscale_root_available() {
   fi
   if ! result="$(
     printf '%s' "$status_json" |
-      COLLIE_SERVE_PORT="$port" COLLIE_SERVE_PROTOCOL="$protocol" "$BUN" -e '
+      COLLIE_SERVE_PORT="$port" COLLIE_SERVE_PROTOCOL="$protocol" \
+      COLLIE_SERVE_EXPECTED_PROXY="$expected_proxy" "$BUN" -e '
         let data = "";
         process.stdin.on("data", chunk => data += chunk).on("end", () => {
           try {
             const config = JSON.parse(data || "{}");
             const port = process.env.COLLIE_SERVE_PORT;
             const protocol = process.env.COLLIE_SERVE_PROTOCOL;
-            const hasRoot = serveConfig =>
-              Object.entries(serveConfig?.Web ?? {}).some(([hostPort, server]) => {
-                const match = hostPort.match(/:(\d+)$/);
-                const handlers = server?.Handlers ?? {};
-                return match?.[1] === port && Object.prototype.hasOwnProperty.call(handlers, "/");
-              }) ||
-              Object.values(serveConfig?.Foreground ?? {}).some(hasRoot);
+            const expectedProxy = process.env.COLLIE_SERVE_EXPECTED_PROXY;
+            // Proxy targets of every root handler bound to our port, in one serve config level.
+            const rootTargets = serveConfig =>
+              Object.entries(serveConfig?.Web ?? {})
+                .filter(([hostPort]) => hostPort.match(/:(\d+)$/)?.[1] === port)
+                .map(([, server]) => server?.Handlers ?? {})
+                .filter(handlers => Object.prototype.hasOwnProperty.call(handlers, "/"))
+                .map(handlers => handlers["/"]?.Proxy);
+            const foregroundTargets = serveConfig =>
+              Object.values(serveConfig?.Foreground ?? {})
+                .flatMap(fg => rootTargets(fg).concat(foregroundTargets(fg)));
             const hasProtocolMismatch = serveConfig => {
               const listener = serveConfig?.TCP?.[port];
               const mismatch = listener !== undefined &&
@@ -454,8 +469,17 @@ ensure_tailscale_root_available() {
               process.stdout.write("protocol-mismatch");
               return;
             }
-            const occupied = hasRoot(config);
-            process.stdout.write(occupied ? "occupied" : "free");
+            if (foregroundTargets(config).length > 0) {
+              process.stdout.write("occupied");
+              return;
+            }
+            const targets = rootTargets(config);
+            if (targets.length === 0) {
+              process.stdout.write("free");
+              return;
+            }
+            process.stdout.write(
+              targets.every(target => target === expectedProxy) ? "adoptable" : "occupied");
           } catch {
             process.exitCode = 2;
           }
@@ -472,6 +496,9 @@ ensure_tailscale_root_available() {
   if [ "$result" = "occupied" ]; then
     echo "error: Tailscale serve already has an unowned root mount on :${port}; refusing to overwrite it" >&2
     return 1
+  fi
+  if [ "$result" = "adoptable" ]; then
+    echo "tailscale serve: adopting the existing Collie root mount on :${port}"
   fi
 }
 
@@ -496,7 +523,7 @@ cmd_serve() {
   local expected_proxy="http://127.0.0.1:${PORT}"
   local out="${CONFIG_DIR}/serve.out"
   if [ "$SERVE_MODE" = "http" ]; then
-    ensure_tailscale_root_available "$PORT" http || return 1
+    ensure_tailscale_root_available "$PORT" http "$expected_proxy" || return 1
     printf '%s|%s|%s\n' "http:${PORT}" "${tailscale_host}:${PORT}" "$expected_proxy" > "$TAILSCALE_HANDLER_FILE"
     if tailscale serve --bg --http="$PORT" --set-path=/ "$PORT" >"$out" 2>&1; then
       echo "tailscale serve (http) → tailnet :${PORT} -> 127.0.0.1:${PORT}"
@@ -507,7 +534,7 @@ cmd_serve() {
       return 1
     fi
   else
-    ensure_tailscale_root_available 443 https || return 1
+    ensure_tailscale_root_available 443 https "$expected_proxy" || return 1
     printf '%s|%s|%s\n' "https:443" "${tailscale_host}:443" "$expected_proxy" > "$TAILSCALE_HANDLER_FILE"
     if tailscale serve --bg --set-path=/ "$PORT" >"$out" 2>&1; then
       echo "tailscale serve (https) → tailnet :443 -> 127.0.0.1:${PORT}"

--- a/scripts/collie-ctl.test.sh
+++ b/scripts/collie-ctl.test.sh
@@ -1,0 +1,257 @@
+#!/usr/bin/env bash
+# Lifecycle tests for scripts/collie-ctl.sh — the first coverage the control script has ever had.
+# Everything the script shells out to (tailscale, systemctl) is faked on a scratch PATH, with a
+# throwaway $HOME and config dir, so these run anywhere and touch nothing real.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CTL="${ROOT}/scripts/collie-ctl.sh"
+BASE_PATH="$PATH"
+TMP_ROOT="$(mktemp -d)"
+
+cleanup() { rm -rf "$TMP_ROOT"; }
+trap cleanup EXIT
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+assert_eq() {
+  [ "$1" = "$2" ] || fail "expected '$2', got '$1'"
+}
+
+assert_contains() {
+  case "$1" in
+    *"$2"*) ;;
+    *) fail "expected output to contain '$2'" ;;
+  esac
+}
+
+setup_case() {
+  CASE_DIR="${TMP_ROOT}/$1"
+  HOME_DIR="${CASE_DIR}/home"
+  CONFIG_DIR="${CASE_DIR}/config"
+  BIN_DIR="${CASE_DIR}/bin"
+  mkdir -p "$HOME_DIR" "$CONFIG_DIR" "$BIN_DIR"
+  cat > "${BIN_DIR}/systemctl" <<'EOF'
+#!/bin/sh
+exit 1
+EOF
+  chmod +x "${BIN_DIR}/systemctl"
+}
+
+run_ctl() {
+  HOME="$HOME_DIR" \
+  HERDR_PLUGIN_CONFIG_DIR="$CONFIG_DIR" \
+  PATH="${BIN_DIR}:${BASE_PATH}" \
+  bash "$CTL" "$@"
+}
+
+# A fake `tailscale` whose serve state lives in a JSON file the test can read and rewrite — so a test
+# can stage any ownership situation (ours, someone else's, absent) and assert what the script did.
+install_fake_tailscale() {
+  TS_STATUS="${CASE_DIR}/tailscale-status.json"
+  printf '{}\n' > "$TS_STATUS"
+  cat > "${BIN_DIR}/tailscale" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+if [ "\${1:-}" = status ] && [ "\${2:-}" = --json ]; then
+  echo '{"Self":{"DNSName":"host.example."}}'
+  exit 0
+fi
+if [ "\${1:-}" = serve ] && [ "\${2:-}" = status ] && [ "\${3:-}" = --json ]; then
+  cat "$TS_STATUS"
+  exit 0
+fi
+if [ "\${1:-}" = serve ] && [[ " \$* " == *" --bg "* ]]; then
+  target="\${!#}"
+  listener=443
+  protocol=HTTPS
+  for arg in "\$@"; do
+    case "\$arg" in
+      --http=*) listener="\${arg#--http=}"; protocol=HTTP ;;
+    esac
+  done
+  cat > "$TS_STATUS" <<JSON
+{"TCP":{"\${listener}":{"\${protocol}":true}},"Web":{"host.example:\${listener}":{"Handlers":{"/":{"Proxy":"http://127.0.0.1:\${target}"}}}}}
+JSON
+  exit 0
+fi
+if [ "\${1:-}" = serve ] && [[ " \$* " == *" off "* ]]; then
+  printf '{}\n' > "$TS_STATUS"
+  exit 0
+fi
+exit 2
+EOF
+  chmod +x "${BIN_DIR}/tailscale"
+}
+
+# Publishing must move cleanly between ports and modes, and must never clobber a root mount Collie
+# didn't create.
+test_tailscale_cutovers_and_collisions() {
+  setup_case tailscale
+  install_fake_tailscale
+
+  cat > "${CONFIG_DIR}/.env" <<'EOF'
+COLLIE_SERVE_MODE=http
+COLLIE_PORT=8787
+EOF
+  run_ctl serve > "${CASE_DIR}/start-8787.out"
+  assert_eq "$(cat "${CONFIG_DIR}/tailscale-managed-handler")" \
+    'http:8787|host.example:8787|http://127.0.0.1:8787'
+
+  cat > "${CONFIG_DIR}/.env" <<'EOF'
+COLLIE_SERVE_MODE=http
+COLLIE_PORT=9999
+EOF
+  run_ctl serve > "${CASE_DIR}/start-9999.out"
+  assert_eq "$(cat "${CONFIG_DIR}/tailscale-managed-handler")" \
+    'http:9999|host.example:9999|http://127.0.0.1:9999'
+
+  cat > "${CONFIG_DIR}/.env" <<'EOF'
+COLLIE_SKIP_SERVE=1
+COLLIE_PORT=9999
+EOF
+  run_ctl serve > "${CASE_DIR}/to-proxy.out"
+  [ ! -e "${CONFIG_DIR}/tailscale-managed-handler" ] || fail "Tailscale ownership survived proxy cutover"
+  assert_eq "$(cat "$TS_STATUS")" '{}'
+
+  collision='{"TCP":{"8787":{"HTTP":true}},"Web":{"host.example:8787":{"Handlers":{"/":{"Proxy":"http://127.0.0.1:7000"}}}}}'
+  printf '%s\n' "$collision" > "$TS_STATUS"
+  cat > "${CONFIG_DIR}/.env" <<'EOF'
+COLLIE_SERVE_MODE=http
+COLLIE_PORT=8787
+EOF
+  if run_ctl serve > "${CASE_DIR}/collision.out" 2>&1; then
+    fail "unowned Tailscale root collision was overwritten"
+  fi
+  assert_eq "$(cat "$TS_STATUS")" "$collision"
+  [ ! -e "${CONFIG_DIR}/tailscale-managed-handler" ] || fail "collision created ownership state"
+
+  opposite_https='{"TCP":{"8787":{"HTTPS":true}},"Web":{"host.example:8787":{"Handlers":{"/other":{"Proxy":"http://127.0.0.1:7002"}}}}}'
+  printf '%s\n' "$opposite_https" > "$TS_STATUS"
+  if run_ctl serve > "${CASE_DIR}/opposite-https.out" 2>&1; then
+    fail "HTTP publication replaced an unrelated HTTPS sibling listener"
+  fi
+  assert_eq "$(cat "$TS_STATUS")" "$opposite_https"
+
+  opposite_http='{"TCP":{"443":{"HTTP":true}},"Web":{"host.example:443":{"Handlers":{"/other":{"Proxy":"http://127.0.0.1:7003"}}}}}'
+  printf '%s\n' "$opposite_http" > "$TS_STATUS"
+  cat > "${CONFIG_DIR}/.env" <<'EOF'
+COLLIE_SERVE_MODE=https
+COLLIE_PORT=8787
+EOF
+  if run_ctl serve > "${CASE_DIR}/opposite-http.out" 2>&1; then
+    fail "HTTPS publication replaced an unrelated HTTP sibling listener"
+  fi
+  assert_eq "$(cat "$TS_STATUS")" "$opposite_http"
+  [ ! -e "${CONFIG_DIR}/tailscale-managed-handler" ] || fail "protocol mismatch created ownership state"
+
+  cat > "${CONFIG_DIR}/.env" <<'EOF'
+COLLIE_SERVE_MODE=http
+COLLIE_PORT=8787
+EOF
+
+  # Once we own a root, someone replacing it out from under us must stop teardown cold: removing a
+  # handler we no longer own would unpublish a service that isn't ours.
+  printf '{}\n' > "$TS_STATUS"
+  run_ctl serve > "${CASE_DIR}/owned.out"
+  owned_state="$(cat "${CONFIG_DIR}/tailscale-managed-handler")"
+  protocol_replacement='{"TCP":{"8787":{"HTTPS":true}},"Web":{"host.example:8787":{"Handlers":{"/":{"Proxy":"http://127.0.0.1:8787"}}}}}'
+  printf '%s\n' "$protocol_replacement" > "$TS_STATUS"
+  cat > "${CONFIG_DIR}/.env" <<'EOF'
+COLLIE_SKIP_SERVE=1
+COLLIE_PORT=8787
+EOF
+  if run_ctl serve > "${CASE_DIR}/protocol-replacement.out" 2>&1; then
+    fail "protocol-only Tailscale root replacement was removed"
+  fi
+  assert_eq "$(cat "$TS_STATUS")" "$protocol_replacement"
+  assert_eq "$(cat "${CONFIG_DIR}/tailscale-managed-handler")" "$owned_state"
+  replacement='{"TCP":{"8787":{"HTTP":true}},"Web":{"host.example:8787":{"Handlers":{"/":{"Proxy":"http://127.0.0.1:7001"}}}}}'
+  printf '%s\n' "$replacement" > "$TS_STATUS"
+  cat > "${CONFIG_DIR}/.env" <<'EOF'
+COLLIE_SKIP_SERVE=1
+COLLIE_PORT=8787
+EOF
+  if run_ctl serve > "${CASE_DIR}/replacement.out" 2>&1; then
+    fail "externally replaced Tailscale root was removed"
+  fi
+  assert_eq "$(cat "$TS_STATUS")" "$replacement"
+  assert_eq "$(cat "${CONFIG_DIR}/tailscale-managed-handler")" "$owned_state"
+}
+
+test_missing_tailscale_cli() {
+  setup_case tailscale-missing
+  ln -s "$(command -v dirname)" "${BIN_DIR}/dirname"
+  ln -s "$(command -v tr)" "${BIN_DIR}/tr"
+  cat > "${CONFIG_DIR}/.env" <<'EOF'
+COLLIE_PORT=8787
+EOF
+
+  set +e
+  HOME="$HOME_DIR" \
+  HERDR_PLUGIN_CONFIG_DIR="$CONFIG_DIR" \
+  PATH="$BIN_DIR" \
+  /bin/bash "$CTL" serve > "${CASE_DIR}/missing.out" 2>&1
+  rc=$?
+  set -e
+
+  [ "$rc" -ne 0 ] || fail "missing Tailscale CLI reported success"
+  output="$(cat "${CASE_DIR}/missing.out")"
+  assert_contains "$output" 'tailscale not found'
+  case "$output" in
+    *"open:"*) fail "missing Tailscale CLI printed an open URL" ;;
+  esac
+}
+
+# If the ownership record can't be deleted, teardown must report failure and KEEP the record —
+# dropping it would orphan a live mapping with nothing left that knows Collie owns it.
+test_state_delete_failures() {
+  setup_case state-delete-failures
+  cat > "${BIN_DIR}/tailscale" <<'EOF'
+#!/bin/sh
+exit 0
+EOF
+  chmod +x "${BIN_DIR}/tailscale"
+
+  local tailscale_state="${CONFIG_DIR}/tailscale-managed-handler"
+  printf 'http:8787|host.example:8787|http://127.0.0.1:8787\n' > "$tailscale_state"
+
+  local harness="${CASE_DIR}/harness.sh"
+  cat > "$harness" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+export HOME="$HOME_DIR"
+export HERDR_PLUGIN_CONFIG_DIR="$CONFIG_DIR"
+export PATH="$BIN_DIR:$BASE_PATH"
+source "$CTL"
+have_systemd() { return 1; }
+TAILSCALE_HANDLER_FILE="$tailscale_state"
+rm() { return 1; }
+
+tailscale_root_fingerprint() { echo absent; }
+if stop_tailscale_serve; then
+  exit 91
+fi
+[ -f "$tailscale_state" ] || exit 92
+
+tailscale_root_fingerprint() { echo 'http|proxy:http://127.0.0.1:8787'; }
+remove_tailscale_handler() { return 0; }
+if stop_tailscale_serve; then
+  exit 93
+fi
+[ -f "$tailscale_state" ] || exit 94
+EOF
+
+  bash "$harness" > "${CASE_DIR}/delete-failure.out" 2>&1
+}
+
+
+
+test_tailscale_cutovers_and_collisions
+test_missing_tailscale_cli
+test_state_delete_failures
+
+echo "collie-ctl lifecycle tests: passed"

--- a/scripts/collie-ctl.test.sh
+++ b/scripts/collie-ctl.test.sh
@@ -248,10 +248,83 @@ EOF
   bash "$harness" > "${CASE_DIR}/delete-failure.out" 2>&1
 }
 
+# An install that predates ownership tracking has Collie's OWN root mount and no record of it.
+# Publishing must adopt that mount, not refuse it — refusing breaks start/restart/update on every
+# deployment that upgrades into this feature.
+test_adopts_preexisting_collie_mount() {
+  setup_case adopt-preexisting
+  install_fake_tailscale
 
+  local preexisting='{"TCP":{"8787":{"HTTP":true}},"Web":{"host.example:8787":{"Handlers":{"/":{"Proxy":"http://127.0.0.1:8787"}}}}}'
+  printf '%s\n' "$preexisting" > "$TS_STATUS"
+  cat > "${CONFIG_DIR}/.env" <<'EOF'
+COLLIE_SERVE_MODE=http
+COLLIE_PORT=8787
+EOF
+  [ ! -e "${CONFIG_DIR}/tailscale-managed-handler" ] || fail "fixture already had ownership state"
+
+  run_ctl serve > "${CASE_DIR}/adopt-http.out" 2>&1 ||
+    fail "serve refused to adopt Collie's own pre-existing HTTP mount"
+  assert_eq "$(cat "${CONFIG_DIR}/tailscale-managed-handler")" \
+    'http:8787|host.example:8787|http://127.0.0.1:8787'
+
+  # Same for the HTTPS default, whose mount lives on :443 while the proxy target stays $PORT.
+  setup_case adopt-preexisting-https
+  install_fake_tailscale
+  printf '%s\n' '{"TCP":{"443":{"HTTPS":true}},"Web":{"host.example:443":{"Handlers":{"/":{"Proxy":"http://127.0.0.1:8787"}}}}}' > "$TS_STATUS"
+  cat > "${CONFIG_DIR}/.env" <<'EOF'
+COLLIE_PORT=8787
+EOF
+  run_ctl serve > "${CASE_DIR}/adopt-https.out" 2>&1 ||
+    fail "serve refused to adopt Collie's own pre-existing HTTPS mount"
+  assert_eq "$(cat "${CONFIG_DIR}/tailscale-managed-handler")" \
+    'https:443|host.example:443|http://127.0.0.1:8787'
+
+  # Negative control: a root mount proxying somewhere ELSE is still refused, so adoption can't be
+  # used to justify clobbering a stranger's mapping.
+  setup_case adopt-negative-control
+  install_fake_tailscale
+  foreign='{"TCP":{"8787":{"HTTP":true}},"Web":{"host.example:8787":{"Handlers":{"/":{"Proxy":"http://127.0.0.1:7000"}}}}}'
+  printf '%s\n' "$foreign" > "$TS_STATUS"
+  cat > "${CONFIG_DIR}/.env" <<'EOF'
+COLLIE_SERVE_MODE=http
+COLLIE_PORT=8787
+EOF
+  if run_ctl serve > "${CASE_DIR}/adopt-foreign.out" 2>&1; then
+    fail "adoption swallowed a foreign root mount"
+  fi
+  assert_eq "$(cat "$TS_STATUS")" "$foreign"
+  [ ! -e "${CONFIG_DIR}/tailscale-managed-handler" ] || fail "foreign mount created ownership state"
+}
+
+# A failed front door must not abort `start` — the bridge is up on loopback and the banner still has
+# to print, which is what the README's troubleshooting flow tells people to read.
+test_serve_failure_does_not_abort_start() {
+  setup_case serve-failure-start
+  local harness="${CASE_DIR}/harness.sh"
+  cat > "$harness" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+export HOME="$HOME_DIR"
+export HERDR_PLUGIN_CONFIG_DIR="$CONFIG_DIR"
+export PATH="$BIN_DIR:$BASE_PATH"
+source "$CTL"
+ensure_build() { return 0; }
+have_systemd() { return 1; }
+BUN=/bin/true
+cmd_serve() { echo "error: simulated serve failure" >&2; return 1; }
+print_status_banner() { echo "BANNER"; }
+cmd_start
+EOF
+  bash "$harness" > "${CASE_DIR}/start.out" 2>&1 ||
+    fail "a failing cmd_serve aborted cmd_start"
+  assert_contains "$(cat "${CASE_DIR}/start.out")" 'BANNER'
+}
 
 test_tailscale_cutovers_and_collisions
 test_missing_tailscale_cli
 test_state_delete_failures
+test_adopts_preexisting_collie_mount
+test_serve_failure_does_not_abort_start
 
 echo "collie-ctl lifecycle tests: passed"

--- a/scripts/git-hooks/pre-push
+++ b/scripts/git-hooks/pre-push
@@ -43,6 +43,15 @@ EOF
   exit 1
 fi
 
+echo "pre-push: running control-script lifecycle suite (collie-ctl.test.sh)…" >&2
+if ! (cd "$ROOT" && bash scripts/collie-ctl.test.sh); then
+  cat >&2 <<'EOF'
+✗ pre-push: collie-ctl lifecycle tests failed — push aborted.
+  Fix the failing tests, or override once with: SKIP_TESTS=1 git push
+EOF
+  exit 1
+fi
+
 echo "pre-push: running web test suite (vitest)…" >&2
 if ! (cd "$ROOT/web" && bun run test); then
   cat >&2 <<'EOF'


### PR DESCRIPTION
Extracts the Tailscale ownership tracking from #26, fixes the upgrade path it broke, and documents the bring-your-own-tunnel case that #26 was really reaching for. The NetBird front door itself is not taken — reasoning in https://github.com/AltanS/collie/pull/26#issuecomment-5085567630.

## What changes

**Ownership tracking** (`a004449`, authored by @iamtimmy). `cmd_unserve` used to run a blind `tailscale serve --https=443 off` keyed only off `COLLIE_SERVE_MODE`, so `unserve`/`uninstall` could silently unpublish a mapping Collie never created. Publishing had the mirror problem: `tailscale serve --bg … /` *replaces* an existing root handler. Both directions now prove ownership against a recorded `<config-dir>/tailscale-managed-handler`.

**Adopt-on-match** (`65889da`). The check as written refused to publish over *any* existing root mount, which is the state of every install that predates ownership tracking — Collie's own mount, no record of it. Verified against this host's real serve config and in the sandbox in both modes:

```
error: Tailscale serve already has an unowned root mount on :8787; refusing to overwrite it
```

Ownership is now decided by where the mount points. A root already proxying to our own `http://127.0.0.1:$PORT` is adopted; anything else is still refused; a foreground serve session is never adopted. Also stops a failed front door from aborting `start` — the bridge is up on loopback and the banner has to print.

**Variant E** (`6550041`). `COLLIE_SKIP_SERVE=1` was always the bring-your-own-ingress switch, just filed under "reverse proxy" where a NetBird or ZeroTier user wouldn't find it. Documents the general case, and records in CLAUDE.md why Collie manages exactly one front door.

## Tests

`scripts/collie-ctl.test.sh` is the first coverage the control script has had: fake `tailscale`/`systemctl` on a scratch PATH, throwaway `$HOME`, so it runs anywhere and touches nothing real. Wired into the pre-push hook (`bun run test` alone wouldn't have run it — the hook calls `bun test ./bridge` directly).

Every assertion negative-controlled by sabotaging a value and confirming the failure, then confirming restore is green.

Co-authored with @iamtimmy, whose commit this builds on.