### PR TITLE
fix(bridge): gate /api/config like every other endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to Collie are recorded here. The format follows
 `version` in `herdr-plugin.toml`, `package.json`, and `web/package.json` (enforced by
 `scripts/check-version.sh`). See [`CLAUDE.md`](./CLAUDE.md) → *Versioning* for the bump policy.
 
+## [0.16.1] - 2026-07-27
+
+### Fixed
+- `/api/config` is now gated like every other endpoint — it was the one route that skipped the same-origin check and `COLLIE_PUBLIC_HOSTS`, noted by @Optic00 in #32 (a54afd9)
+
 ## [0.16.0] - 2026-07-27
 
 ### Added

--- a/bridge/server.ts
+++ b/bridge/server.ts
@@ -215,6 +215,14 @@ export function startServer(opts: {
 
       // ── Misc API ─────────────────────────────────────────────────────────
       if (pathname === "/api/config") {
+        // Read-level, like the other non-terminal endpoints. Nothing here is secret — the VAPID
+        // public key is handed to every browser by design — but this was the one route that skipped
+        // checkAccess entirely, so COLLIE_PUBLIC_HOSTS didn't cover it and a rebound DNS name could
+        // still read the build id. The client only ever calls this same-origin, and a refusal can't
+        // be mistaken for an outage: ConnectionBanner short-circuits to AuthErrorBanner before its
+        // red-state probe runs. Noted in #32.
+        const denied = guard(req, cfg, "read");
+        if (denied) return denied;
         return json({
           push: push.enabled,
           vapidPublicKey: push.publicKey,

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,6 +1,6 @@
 id = "herdr.collie"
 name = "Collie"
-version = "0.16.0"
+version = "0.16.1"
 min_herdr_version = "0.7.0"
 description = "Mobile web UI to monitor and reply to your agent herd, served over Tailscale"
 platforms = ["linux", "macos"]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "collie",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "private": true,
   "license": "MIT",
   "description": "Collie — a mobile web UI to monitor and reply to your Herdr agent herd over Tailscale",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "collie-web",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "private": true,
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
`/api/config` returned before calling `guard()`. There is no global gate in the bridge — every route
calls `checkAccess`/`guard` itself — so this was the one endpoint that bypassed both the same-origin
check and the `COLLIE_PUBLIC_HOSTS` allowlist.

Reproduced against a live 0.16.0 bridge, with a gated endpoint as the control:

```
/api/config    Origin: evil.example, Host: evil.example → 200  {"push":true,"vapidPublicKey":"BL_taz…","build":"0.16.0+9aa515f…"}
/api/snapshot  same headers                             → 403  host not allowed
```

**Severity is low.** What it exposes is the VAPID public key — handed to every browser by design —
and the build id. The bridge sends no CORS headers, so cross-origin JS can't read the response
anyway. The reason to close it is that `COLLIE_PUBLIC_HOSTS` exists specifically for DNS rebinding,
where the attacker's page *becomes* same-origin and the browser's own SOP stops helping. Every other
route is covered; this one wasn't.

**No client impact**, checked rather than assumed:

- The PWA only ever calls it same-origin (`api.fetchConfig`, `web/src/lib/api.ts:304`).
- Read level doesn't consult the device allowlist, so a read-only device is unaffected.
- It doubles as the connection banner's red-state liveness probe, but `ConnectionBanner`
  short-circuits to `AuthErrorBanner` on a 401/403 *before* the probe runs
  (`web/src/components/connection-banner.tsx:46`), so a refusal here can't surface as
  "bridge unreachable".

The route lives inside `Bun.serve`, which stays unit-untested per CLAUDE.md, so verification is the
live probe above plus its negative control — re-run post-deploy on 0.16.1.

Noted in passing by @Optic00 in #32. **This does not close #32** — the substance of that issue is the
bridge-wide blast radius of snooze/prefs, which is a design decision still open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)