### PR TITLE
fix: never send the submit key until the reply text is verified in the input box (#34)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to Collie are recorded here. The format follows
 `version` in `herdr-plugin.toml`, `package.json`, and `web/package.json` (enforced by
 `scripts/check-version.sh`). See [`CLAUDE.md`](./CLAUDE.md) → *Versioning* for the bump policy.
 
+## [0.17.0] - 2026-07-27
+
+### Fixed
+- **A reply sent while an agent dialog was focused answered the dialog instead.** The submit key approved whatever option was highlighted (Claude defaults to "Yes") and the message was destroyed, while the bridge reported success. Sending now refuses outright while a dialog is up, and otherwise types first and only submits once the text is verified in the input box (#34) — thanks @maikschuheida-spec
+
+### Changed
+- Free-text replies on harnesses with a block grammar (Claude) are two steps — type, verify, submit — so "Sent ✓" now means the text was seen in the input box. Harnesses without an adapter keep the previous one-shot send
+
 ## [0.16.1] - 2026-07-27
 
 ### Fixed

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,6 +1,6 @@
 id = "herdr.collie"
 name = "Collie"
-version = "0.16.1"
+version = "0.17.0"
 min_herdr_version = "0.7.0"
 description = "Mobile web UI to monitor and reply to your agent herd, served over Tailscale"
 platforms = ["linux", "macos"]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "collie",
-  "version": "0.16.1",
+  "version": "0.17.0",
   "private": true,
   "license": "MIT",
   "description": "Collie — a mobile web UI to monitor and reply to your Herdr agent herd over Tailscale",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "collie-web",
-  "version": "0.16.1",
+  "version": "0.17.0",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/web/src/components/agent-chat.tsx
+++ b/web/src/components/agent-chat.tsx
@@ -182,6 +182,22 @@ export function AgentChat({
         : null,
     [display, agent?.agent, grammarsOn],
   );
+  // Is a dialog (prompt/wizard/preview/multi-select) on screen right now? Any non-raw block means
+  // the TUI's keyboard belongs to it, so the composer must refuse a free-text send: the text would
+  // be swallowed and the submit key would answer the dialog (#34). Same parse source and adapter as
+  // the two probes above, so the three can't drift. This is the zero-latency fail-fast; the
+  // load-bearing protection is reply-action's verify-before-submit, which also covers a dialog that
+  // appears after this render.
+  const dialogPresent = useMemo(
+    () =>
+      grammarsOn
+        ? (adapterFor(agent?.agent)?.buildBlocks(splitLines(parseAnsi(display))) ?? []).some(
+            (b) => b.kind !== "raw",
+          )
+        : false,
+    [display, agent?.agent, grammarsOn],
+  );
+
   // Both are threaded to the composer: the RAW value (live) plus a stabilised one. extractInputDraft
   // is stateless, so it can't distinguish a stranded draft from the ~350ms flash where our OWN
   // just-sent reply sits on the "❯" line waiting for the bridge's pending Enter. The stabilised value
@@ -731,6 +747,7 @@ export function AgentChat({
             isShell={isShell}
             gone={gone}
             readOnly={readOnly}
+            dialogPresent={dialogPresent}
             text={text}
             terminalDraft={terminalDraft}
             rawTerminalDraft={rawTerminalDraft}

--- a/web/src/components/composer.test.tsx
+++ b/web/src/components/composer.test.tsx
@@ -8,7 +8,22 @@ import { createMemoryRouter, RouterProvider } from "react-router";
 import { clearStatus, useStatus } from "@/lib/status";
 import { isReloadHeld, __resetReloadGuard } from "@/lib/reload-guard";
 import { server } from "@/test/setup";
+import { recordReply } from "@/test/handlers";
 import { Composer } from "./composer";
+
+// A guarded send is TWO reply calls: type (submit:false), then — once the text is verified on the
+// input line — submit-only (empty text). Overriding the reply handler therefore has to keep the fake
+// pane's input line honest via recordReply, or the verification poll never passes. Helper so each
+// override says what it is asserting rather than repeating the protocol.
+function replyHandler(onTyped: (text: string) => void, onSubmit?: () => void) {
+  return http.post(/\/api\/pane\/[^/]+\/reply$/, async ({ request }) => {
+    const body = (await request.json()) as { text: string; submit?: boolean };
+    recordReply(body);
+    if (body.submit) onSubmit?.();
+    else onTyped(body.text);
+    return HttpResponse.json({ ok: true });
+  });
+}
 
 // Composer owns the send flow (draft → api.sendReply → clear/error) plus the destructive-command
 // two-tap guard. It uses useRevalidator, so it needs a data router like AgentChat's tests.
@@ -25,6 +40,7 @@ function renderComposer(overrides: Partial<ComponentProps<typeof Composer>> = {}
     isShell: false,
     gone: false,
     readOnly: false,
+    dialogPresent: false,
     text: "pane output",
     terminalDraft: null,
     rawTerminalDraft: null,
@@ -45,7 +61,67 @@ function StatusSentinel() {
   return <div data-testid="status">{status?.text ?? ""}</div>;
 }
 
+/** renderComposer + the status sentinel, for cases that assert on the status line. */
+function renderComposerWithStatus(overrides: Partial<ComponentProps<typeof Composer>> = {}) {
+  const props: ComponentProps<typeof Composer> = {
+    paneId: "w1:p1",
+    agent: "claude",
+    isShell: false,
+    gone: false,
+    readOnly: false,
+    dialogPresent: false,
+    text: "pane output",
+    terminalDraft: null,
+    rawTerminalDraft: null,
+    prefs: { wrap: true, fontSize: 11, rawTerminal: false },
+    setWrap: vi.fn(),
+    stepFontSize: vi.fn(),
+    setRawTerminal: vi.fn(),
+    onSent: vi.fn(),
+    ...overrides,
+  };
+  const router = createMemoryRouter([
+    {
+      path: "/",
+      element: (
+        <>
+          <StatusSentinel />
+          <Composer {...props} />
+        </>
+      ),
+    },
+  ]);
+  render(<RouterProvider router={router} />);
+  return props;
+}
+
 describe("Composer — send", () => {
+  // #34: a dialog owns the TUI's keyboard. Sending free text at one loses the message AND makes the
+  // submit key answer the dialog, approving whatever was highlighted. Nothing may leave the phone.
+  it("refuses to send while a dialog is on screen, and keeps the draft", async () => {
+    const user = userEvent.setup();
+    const calls: string[] = [];
+    server.use(
+      http.post(/\/api\/pane\/[^/]+\/keys$/, () => {
+        calls.push("keys");
+        return HttpResponse.json({ ok: true });
+      }),
+      replyHandler(() => calls.push("reply")),
+    );
+    // A stranded raw draft too, so the destructive pre-clear sweep would fire if the refusal came
+    // after it instead of before — those ctrl+k/Backspaces would land in the dialog.
+    const props = renderComposerWithStatus({ dialogPresent: true, rawTerminalDraft: "leftover" });
+    const box = screen.getByPlaceholderText(/type a reply/i);
+
+    await user.type(box, "please do not approve anything");
+    await user.click(screen.getByRole("button", { name: "Send" }));
+
+    await waitFor(() => expect(screen.getByTestId("status")).toHaveTextContent(/dialog is waiting/i));
+    expect(calls).toEqual([]); // no keys, no reply — nothing reached the pane at all
+    expect(box).toHaveValue("please do not approve anything"); // the message survives
+    expect(props.onSent).not.toHaveBeenCalled();
+  });
+
   it("sends non-destructive input on the first tap and clears the draft", async () => {
     const user = userEvent.setup();
     const props = renderComposer();
@@ -119,11 +195,7 @@ describe("Composer — send", () => {
         callLog.push("keys");
         return HttpResponse.json({ ok: true });
       }),
-      http.post(/\/api\/pane\/[^/]+\/reply$/, async ({ request }) => {
-        const body = (await request.json()) as { text: string };
-        callLog.push(`reply:${body.text}`);
-        return HttpResponse.json({ ok: true });
-      }),
+      replyHandler((typed) => callLog.push(`reply:${typed}`)),
     );
     renderComposer();
     const box = screen.getByPlaceholderText(/type a reply/i);
@@ -154,6 +226,7 @@ describe("Composer — send", () => {
       isShell: false,
       gone: false,
       readOnly: false,
+      dialogPresent: false,
       text: "pane output",
       terminalDraft: null,
       rawTerminalDraft: null,
@@ -236,6 +309,7 @@ function renderDraftHarness(overrides: Partial<ComponentProps<typeof Composer>> 
       isShell: false,
       gone: false,
       readOnly: false,
+      dialogPresent: false,
       text: "pane output",
       prefs: { wrap: true, fontSize: 11, rawTerminal: false },
       setWrap: vi.fn(),
@@ -449,10 +523,7 @@ describe("Composer — terminal-draft preview", () => {
         callOrder.push("keys");
         return HttpResponse.json({ ok: true });
       }),
-      http.post(/\/api\/pane\/[^/]+\/reply$/, async ({ request }) => {
-        callOrder.push(`reply:${((await request.json()) as { text: string }).text}`);
-        return HttpResponse.json({ ok: true });
-      }),
+      replyHandler((typed) => callOrder.push(`reply:${typed}`)),
     );
     renderDraftHarness();
     strandDraft("adopted line");
@@ -506,6 +577,7 @@ describe("Composer — in-flight echo suppression (match-last-sent)", () => {
       isShell: false,
       gone: false,
       readOnly: false,
+      dialogPresent: false,
       text: "pane output",
       terminalDraft: draft,
       rawTerminalDraft: draft,
@@ -538,11 +610,7 @@ describe("Composer — in-flight echo suppression (match-last-sent)", () => {
         callLog.push("keys");
         return HttpResponse.json({ ok: true });
       }),
-      http.post(/\/api\/pane\/[^/]+\/reply$/, async ({ request }) => {
-        const body = (await request.json()) as { text: string };
-        callLog.push(`reply:${body.text}`);
-        return HttpResponse.json({ ok: true });
-      }),
+      replyHandler((typed) => callLog.push(`reply:${typed}`)),
     );
     renderEcho("/rename");
     const box = screen.getByPlaceholderText(/type a reply/i);
@@ -576,11 +644,7 @@ describe("Composer — in-flight echo suppression (match-last-sent)", () => {
         callLog.push("keys");
         return HttpResponse.json({ ok: true });
       }),
-      http.post(/\/api\/pane\/[^/]+\/reply$/, async ({ request }) => {
-        const body = (await request.json()) as { text: string };
-        callLog.push(`reply:${body.text}`);
-        return HttpResponse.json({ ok: true });
-      }),
+      replyHandler((typed) => callLog.push(`reply:${typed}`)),
     );
     renderEcho("someone else's leftover");
     const box = screen.getByPlaceholderText(/type a reply/i);
@@ -819,13 +883,7 @@ describe("Composer — quick dock (in-flow, matches the keys dock)", () => {
   it("a quick-action tap sends its text through the reply path and closes the dock", async () => {
     const user = userEvent.setup();
     let replyText: string | null = null;
-    server.use(
-      http.post(/\/api\/pane\/[^/]+\/reply$/, async ({ request }) => {
-        const body = (await request.json()) as { text: string };
-        replyText = body.text;
-        return HttpResponse.json({ ok: true });
-      }),
-    );
+    server.use(replyHandler((typed) => (replyText = typed)));
     const props = renderComposer();
 
     await user.click(screen.getByRole("button", { name: "Quick" }));

--- a/web/src/components/composer.tsx
+++ b/web/src/components/composer.tsx
@@ -17,6 +17,7 @@ import { commandsFor } from "@/lib/agent-commands";
 import { isDestructiveInput } from "@/lib/destructive";
 import { useHoldReload } from "@/lib/reload-guard";
 import { isSelfEcho, normalizeDraft } from "@/hooks/use-terminal-draft";
+import { sendGuardedReply } from "@/lib/reply-action";
 import { TerminalDraftPreview } from "@/components/terminal-draft-preview";
 
 export interface ComposerHandle {
@@ -36,6 +37,9 @@ interface ComposerProps {
   gone: boolean;
   /** This device isn't authorised to type — locks the composer with a distinct placeholder. */
   readOnly: boolean;
+  /** A dialog (prompt/wizard/preview/multi-select) is on screen, so the TUI's keyboard belongs to it.
+   * Free-text sending is refused while true — see send(). Answer it with its own buttons instead. */
+  dialogPresent: boolean;
   /** Latest pane text — clears the pending-send preview once the mirror echoes the send back. */
   text: string;
   /** A user draft stranded on the terminal's "❯" input line (extractInputDraft), STABILISED across
@@ -111,7 +115,7 @@ function ComposerDock({
 }
 
 export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Composer(
-  { paneId, session, agent, isShell, gone, readOnly, text, terminalDraft, rawTerminalDraft, prefs, setWrap, stepFontSize, setRawTerminal, onSent, onOpenFind },
+  { paneId, session, agent, isShell, gone, readOnly, dialogPresent, text, terminalDraft, rawTerminalDraft, prefs, setWrap, stepFontSize, setRawTerminal, onSent, onOpenFind },
   ref,
 ) {
   const revalidator = useRevalidator();
@@ -274,6 +278,16 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
   async function send(value: string, isDraft: boolean) {
     const t = value.trim();
     if (!t || locked || sending) return;
+    // A dialog on screen owns the TUI's keyboard: our text is swallowed and the submit key ANSWERS
+    // the dialog, approving whatever option was highlighted (#34). Refuse BEFORE the destructive
+    // pre-clear sweep below — those ctrl+k/Backspaces would land in the dialog too. The input is
+    // kept: the user answers the dialog with its own buttons, then taps Send again. We never
+    // queue-and-auto-send, because the text may be a reaction to state the dialog just changed —
+    // sending is consent, and the conditions moved.
+    if (dialogPresent) {
+      setStatus("A dialog is waiting — answer it first, then send.", "error");
+      return;
+    }
     setSending(true);
     try {
       // Clear a stranded draft on the terminal's "❯" line before pane.send_text appends at cursor —
@@ -301,8 +315,10 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
         await new Promise((resolve) => setTimeout(resolve, TUI_SETTLE_MS));
       }
 
-      const res = await api.sendReply(paneId, t, true, session);
-      if (res.ok) {
+      // Guarded: types the text, verifies it reached the input box, and only THEN sends the submit
+      // key. A "stalled" outcome means nothing was submitted and the draft must survive (#34).
+      const res = await sendGuardedReply({ paneId, text: t, agent, session });
+      if (res.status === "sent") {
         if (isDraft) setInput(""); // phone-owned input — clear it once the reply is on its way
         // Remember what/when we sent, so the next few polls recognise this text echoing on the "❯"
         // line as our own in-flight reply rather than a stranded draft (suppressEcho above).
@@ -313,9 +329,11 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
           setHandledKey(normalizeDraft(effectiveRaw));
           setPreviewLatched(false);
         }
-        // ✓ flash on the send button + status line acknowledge the send immediately. The mirror only
-        // echoes in 1–3s; the "You sent: …" pending preview keeps the typed text visible until it
-        // lands (cleared by the next text update or a 6s safety timeout).
+        // ✓ flash on the send button + status line acknowledge a VERIFIED send (the text was seen in
+        // the input box before the submit key went out), so this lands slightly later than the old
+        // fire-and-forget ✓ but is now actually true. The "You sent: …" pending preview keeps the
+        // typed text visible until the mirror catches up (cleared by the next text update or a 6s
+        // safety timeout).
         setJustSent(true);
         if (sentTimer.current) clearTimeout(sentTimer.current);
         sentTimer.current = setTimeout(() => setJustSent(false), 1500);
@@ -326,9 +344,12 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
         lastSentTimerRef.current = setTimeout(() => setLastSent(null), 6000);
         onSent(); // you just acted — snap the mirror back to the live tail to see the result
       } else {
-        // textDelivered: text landed but Enter failed — keep the draft and surface the bridge's
-        // partial-failure message so the user checks the pane instead of double-sending.
-        setStatus(res.error ?? "Send failed", "error");
+        // "stalled" = the text never reached the input box, so NO submit key was sent (a dialog was
+        // probably holding focus). "error" with textDelivered = the text is in the pane but the
+        // submit failed. Either way the draft stays put: the user checks the pane rather than
+        // double-sending, and on a stall their message is still here to re-send once the dialog is
+        // answered.
+        setStatus(res.error, "error");
       }
     } catch (e) {
       setStatus(e instanceof Error ? e.message : String(e), "error");

--- a/web/src/lib/reply-action.test.ts
+++ b/web/src/lib/reply-action.test.ts
@@ -1,0 +1,176 @@
+import { http, HttpResponse } from "msw";
+
+import { server } from "@/test/setup";
+import { draftCarriesSend, sendGuardedReply } from "./reply-action";
+
+// The regression suite for #34: a free-text reply must never fire the submit key until the text is
+// verifiably sitting in the harness's input box. Before this, the reply path typed and then submitted
+// blind, so with a dialog focused the text was swallowed and the submit key ANSWERED the dialog —
+// approving whatever option was highlighted, while the bridge still reported {ok:true}.
+
+const BOX_RULE = "─".repeat(40); // clears the 20-glyph border threshold in harness/claude/markers
+const paneWithDraft = (draft: string) => `some output\n${BOX_RULE}\n❯ ${draft}\n${BOX_RULE}`;
+// A focused permission dialog: no input box at the tail at all, so extractInputDraft sees nothing.
+const paneWithDialog = "Do you want to proceed?\n ❯ 1. Yes\n   2. No\n\n Esc to cancel";
+
+/** Record every reply POST, and let the fake pane's screen be swapped per test. */
+function harness(screen: () => string) {
+  const calls: Array<{ text: string; submit: boolean }> = [];
+  server.use(
+    http.get(/\/api\/pane\/[^/]+$/, () =>
+      HttpResponse.json({ paneId: "w1:p1", text: screen(), truncated: false, revision: 1 }),
+    ),
+    http.post(/\/api\/pane\/[^/]+\/reply$/, async ({ request }) => {
+      const body = (await request.json()) as { text: string; submit: boolean };
+      calls.push(body);
+      return HttpResponse.json({ ok: true });
+    }),
+  );
+  return calls;
+}
+
+const instant = { sleep: async () => {} }; // no real waiting; the bounded loop still runs its attempts
+
+describe("draftCarriesSend", () => {
+  it("accepts the exact text, and the space-joined form of a wrapped draft", () => {
+    expect(draftCarriesSend("ship it please", "ship it please")).toBe(true);
+    expect(draftCarriesSend("ship it\nplease", "ship it please")).toBe(true);
+  });
+
+  it("accepts a windowed slice of a long draft", () => {
+    const sent = "a much longer message than the input box can show at one time";
+    expect(draftCarriesSend(sent, "message than the input box can show")).toBe(true);
+  });
+
+  it("rejects an empty, absent, or too-short remnant", () => {
+    expect(draftCarriesSend("anything", null)).toBe(false);
+    expect(draftCarriesSend("anything", "   ")).toBe(false);
+    // "a" IS a substring of the send, but one stray character is not evidence our text landed.
+    expect(draftCarriesSend("a much longer message", "a")).toBe(false);
+  });
+
+  it("requires the whole thing when the send is shorter than the floor", () => {
+    expect(draftCarriesSend("ok", "ok")).toBe(true);
+    expect(draftCarriesSend("ok", "o")).toBe(false);
+  });
+
+  it("rejects an unrelated draft", () => {
+    expect(draftCarriesSend("deploy to prod", "someone else's leftover")).toBe(false);
+  });
+});
+
+describe("sendGuardedReply", () => {
+  it("types, verifies the text on the input line, then submits", async () => {
+    const calls = harness(() => paneWithDraft("ship it please"));
+
+    const out = await sendGuardedReply({
+      paneId: "w1:p1",
+      text: "ship it please",
+      agent: "claude",
+      ...instant,
+    });
+
+    expect(out).toEqual({ status: "sent" });
+    // Two calls, in order: type without submitting, then submit-only with EMPTY text so the bridge
+    // sends nothing but its configured submitKeys.
+    expect(calls).toEqual([
+      { text: "ship it please", submit: false },
+      { text: "", submit: true },
+    ]);
+  });
+
+  it("#34: never sends the submit key when a dialog swallowed the text", async () => {
+    const calls = harness(() => paneWithDialog);
+
+    const out = await sendGuardedReply({
+      paneId: "w1:p1",
+      text: "please do not approve anything",
+      agent: "claude",
+      ...instant,
+    });
+
+    expect(out.status).toBe("stalled");
+    // THE regression assertion. The old path sent Enter here, which approved the highlighted "Yes".
+    expect(calls.some((c) => c.submit)).toBe(false);
+    expect(calls).toEqual([{ text: "please do not approve anything", submit: false }]);
+  });
+
+  it("#34: does not mistake somebody else's stranded draft for our text", async () => {
+    const calls = harness(() => paneWithDraft("an unrelated leftover line"));
+
+    const out = await sendGuardedReply({
+      paneId: "w1:p1",
+      text: "please do not approve anything",
+      agent: "claude",
+      ...instant,
+    });
+
+    expect(out.status).toBe("stalled");
+    expect(calls.some((c) => c.submit)).toBe(false);
+  });
+
+  it("keeps the legacy one-shot send for a harness with no adapter", async () => {
+    // No grammar → the input box is unreadable, so there is nothing to verify against. Guessing
+    // would strand a no-echo input (a shell's sudo prompt) with the submit key withheld forever.
+    const calls = harness(() => paneWithDialog);
+
+    const out = await sendGuardedReply({
+      paneId: "w1:p1",
+      text: "ls -la",
+      agent: "shell",
+      ...instant,
+    });
+
+    expect(out).toEqual({ status: "sent" });
+    expect(calls).toEqual([{ text: "ls -la", submit: true }]);
+  });
+
+  it("surfaces a failed type call without submitting", async () => {
+    const calls: Array<{ submit: boolean }> = [];
+    server.use(
+      http.post(/\/api\/pane\/[^/]+\/reply$/, async ({ request }) => {
+        calls.push((await request.json()) as { submit: boolean });
+        return HttpResponse.json({ ok: false, error: "herdr socket down" });
+      }),
+    );
+
+    const out = await sendGuardedReply({
+      paneId: "w1:p1",
+      text: "ship it please",
+      agent: "claude",
+      ...instant,
+    });
+
+    expect(out).toEqual({ status: "error", error: "herdr socket down" });
+    expect(calls.some((c) => c.submit)).toBe(false);
+  });
+
+  it("reports textDelivered when the text landed but the submit key failed", async () => {
+    server.use(
+      http.get(/\/api\/pane\/[^/]+$/, () =>
+        HttpResponse.json({
+          paneId: "w1:p1",
+          text: paneWithDraft("ship it please"),
+          truncated: false,
+          revision: 1,
+        }),
+      ),
+      http.post(/\/api\/pane\/[^/]+\/reply$/, async ({ request }) => {
+        const body = (await request.json()) as { submit: boolean };
+        return body.submit
+          ? HttpResponse.json({ ok: false, error: "keys failed" })
+          : HttpResponse.json({ ok: true });
+      }),
+    );
+
+    const out = await sendGuardedReply({
+      paneId: "w1:p1",
+      text: "ship it please",
+      agent: "claude",
+      ...instant,
+    });
+
+    expect(out.status).toBe("error");
+    expect(out).toMatchObject({ textDelivered: true });
+  });
+});

--- a/web/src/lib/reply-action.ts
+++ b/web/src/lib/reply-action.ts
@@ -1,0 +1,150 @@
+// The free-text reply path's race guard.
+//
+// Every OTHER path that types into a live TUI (prompt-, wizard-, preview-action) refuses to send a
+// key it hasn't first verified the pane is ready for — "Enter is never sent blind". The reply path
+// was the one exception: it typed the text, waited a fixed 350ms, and fired the submit key with
+// nothing checking what was on screen.
+//
+// That is issue #34, reproduced on a real pane: with a Claude permission dialog focused, the typed
+// text is swallowed and the submit key ANSWERS THE DIALOG — approving whatever option was
+// highlighted (Claude highlights "Yes" by default). The message is destroyed and the bridge still
+// reports {ok:true}, because both Herdr RPCs genuinely succeeded: an ack means "herdr took the
+// bytes" (HERDR_API.md), never "the TUI acted on them". So the bridge cannot detect this; only a
+// client that can read the input box can.
+//
+// The fix makes the submit key CONDITIONAL on evidence the text reached the input box: type
+// unsubmitted → poll fresh reads until the adapter sees our text on the "❯" line → only then
+// submit. If it never appears, NO key is sent and the caller keeps the draft. This is the same
+// choreography submitPreviewNote already uses for the note field, applied to the main input.
+
+import { fetchPane, sendReply } from "./api";
+import { parseAnsi } from "./ansi";
+import { splitLines } from "./blocks";
+import { adapterFor } from "./harness";
+import { POLL_ATTEMPTS, POLL_DELAY_MS, defaultSleep, type Sleep } from "./harness/guard";
+
+export type ReplyOutcome =
+  /** Text was verified in the input box and the submit key went through. */
+  | { status: "sent" }
+  /** Text never reached the input box — NO submit key was sent. The caller MUST keep the draft. */
+  | { status: "stalled"; error: string }
+  /** Transport/RPC failure. `textDelivered` = text is in the pane but unsubmitted; don't resend. */
+  | { status: "error"; error: string; textDelivered?: boolean };
+
+/** Minimum visible characters that must match before we believe the input box holds OUR text. */
+export const MIN_MATCH_CHARS = 8;
+
+/** extractInputDraft space-joins a wrapped draft, so compare on collapsed whitespace. */
+function collapse(s: string): string {
+  return s.replace(/\s+/g, " ").trim();
+}
+
+/**
+ * Whether the input box's visible draft is evidence that `sent` landed there. The box WINDOWS a long
+ * draft and folds its wrapped lines with spaces, so exact equality is too strict — requiring the
+ * visible draft to be a contiguous slice of what we typed is the strongest claim that survives
+ * windowing. The length floor stops a short unrelated remnant ("y", "n", a placeholder) from passing
+ * as a match; for a send shorter than the floor, the whole thing must be there.
+ */
+export function draftCarriesSend(sent: string, draft: string | null): boolean {
+  if (draft === null) return false;
+  const s = collapse(sent);
+  const d = collapse(draft);
+  if (d.length === 0) return false;
+  return s.includes(d) && d.length >= Math.min(s.length, MIN_MATCH_CHARS);
+}
+
+export interface GuardedReplyArgs {
+  paneId: string;
+  text: string;
+  /** The pane's agent — picks the adapter whose `extractInputDraft` can read the input box. */
+  agent: string | undefined | null;
+  /** The session the pane lives in (undefined = primary) — scopes every call. */
+  session?: string;
+  /** Lines to request per verification read (undefined = the bridge's default tail, which is where
+   *  the input box always is). */
+  requestedLines?: number;
+  /** Test seam for the poll pacing. */
+  sleep?: Sleep;
+}
+
+export async function sendGuardedReply(args: GuardedReplyArgs): Promise<ReplyOutcome> {
+  const adapter = adapterFor(args.agent ?? undefined);
+  // No grammar for this harness → the input box is unreadable, so there is nothing to verify
+  // against and the guard cannot run. Keep the legacy one-shot send rather than guess: a heuristic
+  // over the raw mirror has a false-negative that is worse than the bug — a no-echo input (a shell's
+  // sudo prompt) would never show the text, so the submit key would be withheld forever. Non-Claude
+  // harnesses gain this safety exactly when they gain an adapter.
+  if (!adapter) return oneShot(args);
+
+  let typed;
+  try {
+    typed = await sendReply(args.paneId, args.text, false, args.session);
+  } catch (e) {
+    return { status: "error", error: message(e) };
+  }
+  if (!typed.ok) return { status: "error", error: typed.error };
+
+  const sleep = args.sleep ?? defaultSleep;
+  for (let attempt = 0; attempt < POLL_ATTEMPTS; attempt++) {
+    // Read BEFORE the first sleep: pane.read is an on-demand live read, not a cached poll, so the
+    // text is often already on screen by the time the type call returns. That saves a whole
+    // POLL_DELAY_MS off the common path — the old blind flow always paid a fixed 350ms here.
+    if (attempt > 0) await sleep(POLL_DELAY_MS);
+    let draft: string | null = null;
+    try {
+      const fresh = await fetchPane(args.paneId, args.requestedLines, args.session);
+      draft = adapter.extractInputDraft(splitLines(parseAnsi(fresh.text)));
+    } catch {
+      continue; // transient read failure — the bounded loop is the timeout
+    }
+    if (draftCarriesSend(args.text, draft)) return submitOnly(args);
+  }
+
+  // The text never showed up on the input line. The likeliest cause is a dialog holding focus and
+  // eating the keystrokes — and the one thing we must NOT do is send the submit key anyway, because
+  // that is precisely what answers the dialog. Stop dead and let the caller keep the draft.
+  //
+  // If instead this is a false negative (the text IS in the box, the adapter just couldn't see it),
+  // nothing is lost: the next send's pre-clear sweep removes it, and the stranded-draft preview
+  // surfaces it in the meantime.
+  return {
+    status: "stalled",
+    error: "Message didn't reach the input box — a dialog may be waiting. Nothing was submitted.",
+  };
+}
+
+/** The pre-#34 behaviour: one call that types AND submits. Only for harnesses with no adapter. */
+async function oneShot(args: GuardedReplyArgs): Promise<ReplyOutcome> {
+  try {
+    const res = await sendReply(args.paneId, args.text, true, args.session);
+    return res.ok ? { status: "sent" } : { status: "error", error: res.error };
+  } catch (e) {
+    return { status: "error", error: message(e) };
+  }
+}
+
+/**
+ * Empty text + submit: `sendReplySteps` skips the send_text step entirely and sends ONLY the
+ * bridge's configured submit keys (COLLIE_SUBMIT_KEYS). So the submit-key contract stays
+ * server-owned and this whole guard needs no bridge change.
+ */
+async function submitOnly(args: GuardedReplyArgs): Promise<ReplyOutcome> {
+  try {
+    const res = await sendReply(args.paneId, "", true, args.session);
+    if (res.ok) return { status: "sent" };
+    // The text is verifiably sitting in the input box and only the submit key failed — same shape as
+    // the bridge's own partial-failure case. Tell the caller not to resend.
+    return {
+      status: "error",
+      error: "typed into the pane but not submitted — check the pane before resending",
+      textDelivered: true,
+    };
+  } catch (e) {
+    return { status: "error", error: message(e), textDelivered: true };
+  }
+}
+
+function message(e: unknown): string {
+  return e instanceof Error ? e.message : String(e);
+}

--- a/web/src/test/handlers.ts
+++ b/web/src/test/handlers.ts
@@ -114,11 +114,33 @@ export const fixtureTranscript: TranscriptEntry[] = [
   },
 ];
 
+// ── The fake pane's input box ────────────────────────────────────────────────────────────────────
+// A guarded reply (lib/reply-action.ts) types with submit:false and then polls pane reads until the
+// adapter can see that text on the "❯" line — only then does it send the submit key. So the fake
+// pane has to behave like a real TUI (text typed → it appears on the prompt line; submit → the line
+// clears) or no guarded send would ever verify and every send test would stall.
+let typedDraft = "";
+/** Reset between tests (setup.ts afterEach) so a draft can't leak into the next case. */
+export function resetTypedDraft(): void {
+  typedDraft = "";
+}
+/** Record what a reply POST did to the input line — exported so tests that override the reply
+ *  handler with their own can keep the fake pane honest. */
+export function recordReply(body: { text?: string; submit?: boolean }): void {
+  typedDraft = body.submit ? "" : body.text ?? "";
+}
+// 40 box glyphs clears the 20-glyph border threshold in isBoxBorder (harness/claude/markers.ts).
+const BOX_RULE = "─".repeat(40);
+/** `base` output with the current draft rendered inside a Claude-shaped input box below it. */
+export function paneTextWithDraft(base = "hello from the pane"): string {
+  return typedDraft ? `${base}\n${BOX_RULE}\n❯ ${typedDraft}\n${BOX_RULE}` : base;
+}
+
 // Default happy-path handlers; individual tests can override via server.use(...).
 export const handlers = [
   http.get("/api/snapshot", () => HttpResponse.json(fixtureSnapshot)),
   http.get(/\/api\/pane\/[^/]+$/, () =>
-    HttpResponse.json({ paneId: "w1:p1", text: "hello from the pane", truncated: false, revision: 1 }),
+    HttpResponse.json({ paneId: "w1:p1", text: paneTextWithDraft(), truncated: false, revision: 1 }),
   ),
   // Pane transcript history. Two turns, newest-anchored, with nothing older behind them.
   http.get(/\/api\/pane\/[^/]+\/history/, () =>
@@ -131,7 +153,10 @@ export const handlers = [
       fileTruncated: false,
     }),
   ),
-  http.post(/\/api\/pane\/[^/]+\/reply$/, () => HttpResponse.json({ ok: true })),
+  http.post(/\/api\/pane\/[^/]+\/reply$/, async ({ request }) => {
+    recordReply((await request.json()) as { text?: string; submit?: boolean });
+    return HttpResponse.json({ ok: true });
+  }),
   http.post(/\/api\/pane\/[^/]+\/keys$/, () => HttpResponse.json({ ok: true })),
   http.post(/\/api\/pane\/[^/]+\/close$/, () => HttpResponse.json({ ok: true })),
   http.post(/\/api\/pane\/[^/]+\/rename$/, () => HttpResponse.json({ ok: true })),

--- a/web/src/test/setup.ts
+++ b/web/src/test/setup.ts
@@ -3,7 +3,7 @@ import { afterAll, afterEach, beforeAll, beforeEach, vi } from "vitest";
 import { cleanup } from "@testing-library/react";
 import { setupServer } from "msw/node";
 
-import { handlers } from "./handlers";
+import { handlers, resetTypedDraft } from "./handlers";
 import { __resetConnectionHealth } from "@/lib/connection-health";
 
 // One MSW server for all tests; tests add per-case overrides with `server.use(...)`.
@@ -18,6 +18,7 @@ beforeEach(() => __resetConnectionHealth());
 afterEach(() => {
   cleanup();
   server.resetHandlers();
+  resetTypedDraft(); // the fake pane's input line, so a draft can't leak into the next test
 });
 afterAll(() => server.close());
 


### PR DESCRIPTION
Fixes #34.

## Reproduced

On a real Claude pane in the `collie-demo` sandbox, in manual mode, driving the exact endpoint the
phone uses. With a Bash permission dialog focused and **"1. Yes" highlighted**, I sent
`PROBE-CHARLIE do not approve anything`:

- the bridge returned `{"ok":true}`
- the dialog was dismissed and **the command executed** ("Listed 1 directory, ran 1 shell command")
- the message appears nowhere — not in the conversation, not in the input box

So this is not only a lost message. The submit key **approved a tool call the user never saw**.
Claude highlights `Yes` by default, which is what makes it dangerous.

Control: the same send while the agent was merely *busy* queued correctly and was delivered. The
trigger is specifically a dialog holding focus — not load, and not the 350 ms settle.

A second channel, also reproduced: a message that lands in the input box unsubmitted renders in the
mirror and is then wiped by the *next* send's pre-clear sweep. That is the "renders in the input box
but never reaches the buffer" symptom from the report, and it explains "6+ times in a day" — the
retry destroys the stuck message.

## Why the bridge can't fix this

Both Herdr RPCs genuinely succeed. An ack means "herdr took the bytes" (`HERDR_API.md`), never "the
TUI acted on them". Only a client that can read the input box can tell the difference, so the guard
is client-side and **there is no bridge change in this PR**.

## The fix

Every other path that types into a live TUI (`prompt-`/`wizard-`/`preview-action`) already refuses to
send a key it hasn't verified the pane is ready for — "Enter is never sent blind". The reply path was
the one exception. It now uses the same choreography `submitPreviewNote` uses:

1. **Refuse outright while a dialog is on screen** — free, from blocks `agent-chat` already builds —
   and do it **before** the destructive pre-clear sweep, since those `ctrl+k`/Backspaces would
   otherwise land in the dialog too.
2. Type with `submit:false`.
3. Poll fresh reads until the adapter sees our text on the `❯` line.
4. Only then submit: empty text + `submit:true`, so the bridge sends nothing but its configured
   `submitKeys` and that contract stays server-owned.
5. Never verified → **no key is sent at all**, and the draft is kept so the message survives.

Refusal never queues-and-auto-sends: the text may be a reaction to state the dialog just changed, and
sending is consent.

**Scoped to harnesses with an adapter.** Without one the input box is unreadable, and a raw-mirror
heuristic has a worse failure than the bug — a no-echo input (a shell's `sudo` prompt) would never
show the text, stranding the submit key forever. Those keep the previous one-shot send; they gain
this safety when they gain an adapter.

The verification read happens *before* the first sleep, so the common path now costs one live
`pane.read` instead of the old fixed 350 ms `REPLY_SETTLE_MS`.

## Verification

- **Against the real captured dialog output** from the repro above: the fail-fast sees the dialog,
  and `extractInputDraft` yields nothing matching our text, so the submit key is withheld even if the
  fail-fast were bypassed by a dialog appearing after render.
- **Negative-controlled.** Reverting the guard fails the regression tests with
  `expected 'sent' to be 'stalled'`; removing the fail-fast fails the composer test. Restored → green.
- Test harness now models a real input box (typed text appears on the `❯` line, submit clears it), so
  the composer suite exercises the real two-step protocol rather than bypassing it.
- 1040 web tests, 318 bridge tests, both typechecks.

## Residual risk, stated honestly

The TOCTOU can't be eliminated — there is no transactional submit in these TUIs. The window shrinks
from ~2 s to one RPC round-trip, and the worst case degrades from "wrong approval, message destroyed,
`{ok:true}`" to "wrong approval, message preserved, and Collie says the send didn't land". It is no
longer silent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)