### PR TITLE
Light and system themes

### DIFF
--- a/.adr/0002-invert-the-light-terminal-mirror.md
+++ b/.adr/0002-invert-the-light-terminal-mirror.md
@@ -1,0 +1,105 @@
+# 0002 — The light terminal mirror is inverted, not re-themed
+
+- **Status:** Accepted
+- **Date:** 2026-07-28
+- **Shipped in:** 0.18.0
+- **Trail:** measurements below were taken against live panes on 2026-07-28; the counts and contrast
+  figures are reproducible with the method each one names
+
+## Context
+
+Adding light mode meant deciding what the pane mirror does. The obvious answer, and the one this
+work carried for most of its life, was: give the mirror a light ANSI palette. Define
+`--ansi-0…15` twice — VS Code's Dark+ set for dark, its light-theme set for light — have
+`lib/ansi.ts` emit `var(--ansi-N)` instead of literal hex, and let CSS swap them. That was built and
+tested before anyone measured whether it would matter.
+
+It doesn't, much. Counting SGR forms in four live panes:
+
+| pane | truecolor (`38;2`) | 256-colour (`38;5`) | basic (`30–37`) | bright (`90–97`) |
+| --- | --- | --- | --- | --- |
+| w2Z:p1 | 446 | 7 | 0 | 0 |
+| wJ:p1 | 150 | 6 | 0 | 0 |
+| w14:p1 | 461 | 6 | 0 | 0 |
+| w18:pD | 109 | 6 | 0 | 0 |
+
+**Zero basic and zero bright codes anywhere.** Claude Code emits truecolor almost exclusively, and
+truecolor names an absolute sRGB value — there is no palette slot to redirect. The 16 themeable
+slots the design was built around are very nearly unreachable in practice.
+
+The consequence on a white ground was measured on a real pane: of 13 distinct rendered colours,
+eight fell below 3:1, including a `●` at **1.0:1** (`#ffffff` on white) and Monokai's foreground
+`#f8f8f2` at **1.07:1**. A light mirror built the obvious way is not a dimmer light mirror; it is an
+unreadable one.
+
+This is faithful, incidentally. Run the same agent in a real light terminal and it looks equally
+bad, because the agent chose its colours assuming a dark background. Fidelity is not the goal — the
+mirror is the app's primary reading surface.
+
+Three ways out were considered. Keeping the mirror dark works and is what an IDE does with an
+embedded terminal, but it puts a permanent dark slab in a light app. Clamping absolute colours to a
+luminance floor misrepresents what the program actually emitted, and the mapping is arbitrary.
+Neither preserves the syntax highlighting an agent's output depends on to be scannable.
+
+## Decision
+
+**Render the mirror in dark space under every theme, and invert it in light.** The `<pre>` carries
+`filter: invert(1) hue-rotate(180deg)`, reset to `none` under the `dark:` variant. The `hue-rotate`
+is what makes this more than a negative: it approximately restores hue after the inversion flips
+lightness, so green stays green and syntax highlighting survives.
+
+Three rules follow, and all three are load-bearing:
+
+1. **Everything inside the `<pre>` is authored for a dark ground** — the ANSI palette, the
+   find-match highlight, the muted rule glyphs. A `dark:` variant inside the mirror is a bug: it
+   tracks the root theme, which is exactly backwards in inverted space.
+2. **Colours inside the `<pre>` are literals, not theme tokens.** `color-scheme: dark` on the
+   element does *not* flip an inherited `light-dark()` token — Chrome resolves those against the
+   root's scheme — so `bg-background` yields white on a light page and the filter turns it black.
+   Tokens cannot express "dark-space regardless of theme"; literals can.
+3. **The filter is scoped to the `<pre>` alone.** The interactive blocks (prompt-select, wizard,
+   preview, multi-select) are siblings, not children, so they keep normal app theming.
+
+`--ansi-0…15` therefore has **one** set of values, the dark one. `lib/ansi.ts` still emits
+`var(--ansi-N)` rather than literal hex: the variables remain the seam where indexed colour is
+defined once, and both spellings of an indexed colour (`31m` and `38;5;1`) route through them.
+
+## Consequences
+
+Measured on the same pane, light against dark, sampling rendered pixels:
+
+| | background | min | median | max |
+| --- | --- | --- | --- | --- |
+| dark (unchanged) | `#0a0a0a` | 1.34 | 7.46 | 21.0 |
+| light (inverted) | `#f5f5f5` | 1.43 | 6.73 | 18.69 |
+
+The light profile tracks the dark one almost exactly — light mode inherits whatever readability the
+agent designed for, instead of fighting it. (The sub-2 values are antialiasing edges, present in
+both.)
+
+What it costs:
+
+- **Colours are approximations.** `hue-rotate` is a linear matrix, not a true hue rotation, so
+  saturated colours shift. The mirror shows an agent's palette *interpreted*, not reproduced.
+- **A trap for future contributors.** Every instinct — use the token, add a `dark:` variant — is
+  wrong inside the `<pre>`, and wrong in a way that type-checks and often still passes a
+  computed-style test. `components/ansi-output.test.tsx` guards rules 1 and 2 explicitly.
+
+  The sharpest edge is **cancelling the filter**, which the find highlight does so its yellow isn't
+  reinterpreted as brown. Re-applying `invert + hue-rotate` cancels it — but only for colours the
+  element sets *itself*. The current match gets away with it because `text-black` pins its text
+  (black → invert → white → invert → black). Applying the same cancellation to a non-current match,
+  which sets no text colour, sent its *inherited* text light → dark → light and rendered it
+  invisible on its own highlight. It looked symmetrical and was not. Cancel the filter only on an
+  element that fully specifies its own foreground and background.
+- **The light ANSI palette was deleted.** VS Code's light terminal set was chosen, verified against
+  upstream (including catching that `ansiGreen` had moved from `#00BC00` to `#107C10`), and then
+  made unreachable by this decision. It is in the git history if the premise ever changes.
+- **Unmeasured scroll cost.** A CSS filter over a long `<pre>` — panes run to thousands of lines —
+  has not been profiled on a phone.
+
+**What would justify revisiting this:** agents emitting indexed colour again, or a terminal palette
+protocol that lets the client supply the ground. Either restores the premise that a re-themed
+palette can work, and the honest answer then is a real light palette, not a filter. A measured
+scroll regression on a mid-range phone would also reopen it — in favour of keeping the mirror dark,
+not of re-theming it.

--- a/.adr/README.md
+++ b/.adr/README.md
@@ -43,3 +43,4 @@ A superseded ADR is never deleted or edited into agreement with the present. Mar
 | # | Decision | Status |
 | --- | --- | --- |
 | [0001](./0001-one-managed-front-door.md) | Collie manages exactly one front door | Accepted |
+| [0002](./0002-invert-the-light-terminal-mirror.md) | The light terminal mirror is inverted, not re-themed | Accepted |

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,9 @@ Thumbs.db
 # the fix commit and its CHANGELOG line are the durable record.
 .screenshot-bugs/
 docs/bugs/
+
+# Local tooling scratch (browser-automation captures)
+.playwright-mcp/
+
+# Design + review artifacts (kept locally, not part of the repo)
+prp/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ All notable changes to Collie are recorded here. The format follows
 `version` in `herdr-plugin.toml`, `package.json`, and `web/package.json` (enforced by
 `scripts/check-version.sh`). See [`CLAUDE.md`](./CLAUDE.md) → *Versioning* for the bump policy.
 
+## [0.19.0] - 2026-07-29
+
+### Added
+- **Light and system themes.** Collie followed your phone's appearance from this release on; pick Light or Dark explicitly from Settings, or cycle System → Light → Dark with the new header button (513d368)
+- ANSI slots 0–15 are now CSS variables (`--ansi-*`), so indexed terminal colour is defined in one place and reaches the mirror through both `31m` and `38;5;1` spellings (513d368)
+
+### Changed
+- The pane mirror renders in dark space under every theme and light mode inverts it, because agents emit truecolor almost exclusively and no palette can re-theme an absolute colour — [ADR 0002](.adr/0002-invert-the-light-terminal-mirror.md) (bb1f087)
+- In light, the page is a step off white with cards staying white, so the dashboard's hierarchy no longer rests on a single hairline — and the mirror's edge stops showing a seam (513d368)
+- MINOR, not MAJOR: pre-1.0, purely additive, no config or API break. Defaulting to your phone's appearance is the feature working as designed, and Settings pins it either way
+
+### Fixed
+- **The space and tab chip rows overlapped each other on the space screen** — both strips were missing `shrink-0` inside the route's flex scroller, so they collapsed to 16px around 32px chips and the tab row painted over the space row. Pre-dates this release (7a7a13e)
+- Three `role="alert"` warnings (incomplete multi-select, wizard, preview) used a hardcoded yellow that measured ~2:1 on white; they use the status palette now (513d368)
+- An off notification switch was unreadable in light — a white thumb on a 1.09:1 track, legible only by its shadow. It carries an outline now (513d368)
+- Focus rings were drawn at half strength, 1.77:1 in light and 1.87:1 in dark; both are full strength now (513d368)
+- Small muted text (section labels, the build stamp, the terminal status line, the `(n)` counts) fell under 3:1 in light — light `--muted-foreground` had no headroom left for the `/70` and `opacity-60` modifiers stacked on it, so it was darkened and the modifiers dropped (513d368)
+- Header controls had 20px touch targets; the Settings gear, the new theme button and the Settings back button are all 44px, with no change to how they look (513d368)
+
 ## [0.18.0] - 2026-07-28
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,6 +104,10 @@ the unit name; the Herdr action runs from anywhere.
   `Tab`, `Escape`, `Enter`, `Backspace`. `PageUp`/`Home`/`End`/`Delete` are unsupported.
 - Pane output is rendered as **React text nodes** (never `innerHTML`); the ANSI parser only derives
   colors/weights. Keep it that way — it's the XSS boundary. Strict CSP + same-origin gate stay.
+- **Inside the mirror `<pre>`, author for a dark ground: literal colors, never theme tokens, never a
+  `dark:` variant.** The mirror renders in dark space under every theme and light mode inverts it —
+  [ADR 0002](./.adr/0002-invert-the-light-terminal-mirror.md). Both instincts fail *silently* here (a
+  token resolves against the root, then inverts to its opposite); `ansi-output.test.tsx` guards it.
 
 ## Security posture (don't regress)
 

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,6 +1,6 @@
 id = "herdr.collie"
 name = "Collie"
-version = "0.18.0"
+version = "0.19.0"
 min_herdr_version = "0.7.0"
 description = "Mobile web UI to monitor and reply to your agent herd, served over Tailscale"
 platforms = ["linux", "macos"]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "collie",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "private": true,
   "license": "MIT",
   "description": "Collie — a mobile web UI to monitor and reply to your Herdr agent herd over Tailscale",

--- a/web/index.html
+++ b/web/index.html
@@ -1,12 +1,20 @@
 <!doctype html>
-<html lang="en" class="dark">
+<!-- No theme class here: `color-scheme: light dark` in index.css follows the OS, and
+     public/theme-init.js stamps `light`/`dark` before first paint only when the user has pinned
+     one. The cascade decides, not the markup. --><html lang="en">
   <head>
     <meta charset="utf-8" />
     <meta
       name="viewport"
       content="width=device-width, initial-scale=1, viewport-fit=cover, interactive-widget=resizes-content"
     />
-    <meta name="theme-color" content="#0a0a0a" />
+    <!-- Blocking, and first: the pin class must be on <html> before anything paints. Same-origin,
+         so `script-src 'self'` already allows it. -->
+    <script src="/theme-init.js"></script>
+    <!-- Browser chrome follows the OS for System users. useTheme rewrites these at runtime for
+         someone who has pinned the opposite of their OS. -->
+    <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+    <meta name="theme-color" content="#0a0a0a" media="(prefers-color-scheme: dark)" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
@@ -24,6 +32,18 @@
          seamless. Sprite math matches .dog-gallop in index.css: dog-gallop.png is a 768×128 strip of
          six 128px frames, stepped with steps(6). -->
     <style>
+      /* index.css has not loaded at this point, so the splash declares `color-scheme` itself —
+         otherwise light-dark() below has nothing to resolve against and every value falls to its
+         light branch. These three rules mirror index.css exactly; keep them in step. */
+      :root {
+        color-scheme: light dark;
+      }
+      :root.light {
+        color-scheme: light;
+      }
+      :root.dark {
+        color-scheme: dark;
+      }
       .boot-splash {
         position: fixed;
         inset: 0;
@@ -32,8 +52,9 @@
         align-items: center;
         justify-content: center;
         gap: 0.75rem;
-        background: #0a0a0a;
-        color: #a1a1a1;
+        /* Matches --background / --muted-foreground so the hand-off to React is seamless. */
+        background: light-dark(#ffffff, #0a0a0a);
+        color: light-dark(#8a8a8a, #a1a1a1);
         font: 500 0.875rem/1.4 system-ui, -apple-system, "Segoe UI", sans-serif;
       }
       .boot-splash__dog {

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "collie-web",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/web/public/theme-init.js
+++ b/web/public/theme-init.js
@@ -1,0 +1,26 @@
+// Applies a pinned theme to <html> before first paint, so an explicit Light/Dark choice never
+// flashes the other one on a cold load.
+//
+// Deliberately NOT part of the bundle: it has to run before the module graph loads. A same-origin
+// <script src> is already permitted by the app's `script-src 'self'` CSP (bridge/server.ts), so
+// this needs no policy change — which is the whole reason it's a file rather than an inline script.
+//
+// Users on System — the default — don't need this at all: `color-scheme: light dark` in index.css
+// gets their first paint right with no JavaScript whatsoever. This is only for the pinned case.
+//
+// It does exactly one thing: add the pin class. Removing a stale class and reconciling the
+// theme-color metas belong to hooks/use-theme.ts at runtime. Pre-paint DOM mutation is how a
+// four-line script turns into a liability.
+//
+// Storage is a BARE string, not JSON — hooks/use-theme.ts must agree. JSON.stringify would write
+// `"dark"` *with* the quote characters, the strict compare below would reject it, and the anti-flash
+// would silently stop firing with nothing failing a test.
+(function () {
+  try {
+    var t = localStorage.getItem("collie:theme:v1");
+    if (t === "dark" || t === "light") document.documentElement.classList.add(t);
+  } catch (e) {
+    // Safari private mode throws on localStorage. Falling through leaves `color-scheme: light dark`
+    // in charge, which follows the OS — the right default anyway.
+  }
+})();

--- a/web/src/components/action-sheet-rows.tsx
+++ b/web/src/components/action-sheet-rows.tsx
@@ -124,7 +124,7 @@ export function RenameView({
           onChange={(e) => onLabelChange(e.target.value)}
           onKeyDown={onInputKeyDown}
           placeholder={placeholder}
-          className="h-11 rounded-lg border border-border bg-background px-3 text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+          className="h-11 rounded-lg border border-border bg-background px-3 text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring"
         />
       </label>
       <Button onClick={onSave} disabled={saving || !canSave} className="h-11">

--- a/web/src/components/agent-chat.tsx
+++ b/web/src/components/agent-chat.tsx
@@ -11,6 +11,7 @@ import { setStatus } from "@/lib/status";
 import { ChatMessageList, type ChatMessageListHandle } from "@/components/ui/chat/chat-message-list";
 import { BottomSheet } from "@/components/ui/sheet";
 import { AppHeader } from "@/components/app-header";
+import { ThemeToggle } from "@/components/theme-control";
 import { AnsiOutput } from "@/components/ansi-output";
 import { parseAnsi } from "@/lib/ansi";
 import { splitLines } from "@/lib/blocks";
@@ -528,6 +529,10 @@ export function AgentChat({
         rightLead={
           agent ? (
             <>
+              {/* The pane is where you actually stare at the mirror, so the situational flip the
+                  theme control exists for bites hardest here. Leads the cluster rather than
+                  trailing it — the status pill stays the rightmost thing on every pane screen. */}
+              <ThemeToggle />
               {agent.agentSessionId && (
                 <button
                   type="button"
@@ -734,7 +739,7 @@ export function AgentChat({
               vanish with the stripped input box). Sits directly above the composer, as it did in the
               TUI. Verbatim text — a React text node, so no XSS surface. */}
           {statusLine && (
-            <div className="truncate border-t border-border/40 px-3 py-1 font-mono text-[11px] leading-tight text-muted-foreground/80">
+            <div className="truncate border-t border-border/40 px-3 py-1 font-mono text-[11px] leading-tight text-muted-foreground">
               {statusLine}
             </div>
           )}

--- a/web/src/components/agent-list.tsx
+++ b/web/src/components/agent-list.tsx
@@ -53,7 +53,7 @@ export function AgentList({
               g.accent ? "text-status-blocked" : "text-muted-foreground",
             )}
           >
-            {g.label} <span className="opacity-60">({members.length})</span>
+            {g.label} <span className="text-muted-foreground">({members.length})</span>
           </h2>
           <div className="flex flex-col gap-2">
             {members.map((a) => (

--- a/web/src/components/agent-sidebar.tsx
+++ b/web/src/components/agent-sidebar.tsx
@@ -94,7 +94,7 @@ function Section({
         )}
       >
         <span aria-hidden="true" className={cn("size-1.5 shrink-0 rounded-full", dot)} />
-        {label} <span className="opacity-60">({count})</span>
+        {label} <span className="text-muted-foreground">({count})</span>
       </h3>
       {children}
     </section>

--- a/web/src/components/ansi-output.test.tsx
+++ b/web/src/components/ansi-output.test.tsx
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { render } from "@testing-library/react";
+
+import { AnsiOutput } from "./ansi-output";
+
+const ESC = "\x1b";
+
+// The mirror renders in DARK space under every theme, and the light theme inverts it wholesale
+// (.adr/0002). These guard the two ways that arrangement silently breaks.
+describe("terminal mirror colour space", () => {
+  function mirror(text: string) {
+    const { container } = render(<AnsiOutput text={text} />);
+    return container.querySelector("pre")!;
+  }
+
+  it("inverts in light and leaves dark alone", () => {
+    const pre = mirror("hello");
+    expect(pre.className).toContain("[filter:invert(1)_hue-rotate(180deg)]");
+    // Without the dark: reset the filter would apply in BOTH themes and dark would render inverted.
+    expect(pre.className).toContain("dark:[filter:none]");
+  });
+
+  // The bug this exists to prevent: `bg-background` looks like the tidy, idiomatic choice, but an
+  // inherited light-dark() token resolves against the ROOT's colour-scheme, not this element's — so
+  // on a light page it yields white, which the filter then inverts to black. A black mirror on a
+  // white app, and every test that only checks computed styles still passes.
+  it("uses literal dark-space colours, never theme tokens", () => {
+    const pre = mirror("hello");
+    expect(pre.className).toContain("bg-[#0a0a0a]");
+    expect(pre.className).toContain("text-[#fafafa]");
+    expect(pre.className).not.toMatch(/\bbg-background\b/);
+    expect(pre.className).not.toMatch(/\btext-foreground\b/);
+  });
+
+  it("keeps muted rule glyphs on a literal dark-space grey", () => {
+    const pre = mirror("├────────────┤\n");
+    const span = [...pre.querySelectorAll("span")].find((s) => s.textContent?.includes("─"));
+    expect(span).toBeDefined();
+    expect(span!.style.color).toBe("rgb(161, 161, 161)"); // #a1a1a1, --muted-foreground's dark half
+  });
+
+  it("emits palette variables for indexed colour so the 16 slots stay themeable", () => {
+    const pre = mirror(`${ESC}[31mred${ESC}[0m`);
+    const span = [...pre.querySelectorAll("span")].find((s) => s.textContent === "red");
+    expect(span!.style.color).toBe("var(--ansi-1)");
+  });
+});

--- a/web/src/components/ansi-output.tsx
+++ b/web/src/components/ansi-output.tsx
@@ -68,9 +68,32 @@ export interface AnsiOutputProps {
 // (no needless effect re-runs / parent count updates while find is closed).
 const NO_MATCHES: FindMatch[] = [];
 
+// The mirror is always authored in DARK space, and light mode inverts it. See
+// .adr/0002-invert-the-light-terminal-mirror.md — in short, agents emit truecolor almost
+// exclusively (446 sequences in a live pane; zero basic ANSI), and truecolor names an absolute
+// colour no palette can re-theme. Rendering it unchanged on white leaves most of an agent's output
+// under 2:1.
+//
+// The colours here are LITERAL dark-space values, not theme tokens, and that is deliberate. A
+// `color-scheme: dark` on this element does NOT flip an inherited light-dark() token: Chrome
+// resolves those against the root's scheme, so `bg-background` on a light page yields white, which
+// the filter then inverts to black — a black mirror on a white app. Tokens cannot express
+// "dark-space regardless of theme"; literals can. They match --background / --foreground /
+// --muted-foreground's dark halves, so dark mode is pixel-identical to before.
+//
+// `color-scheme: dark` still earns its place for native UI inside the pre (the x-overflow
+// scrollbar, selection), which the filter then maps to light along with everything else.
+//
+// Scoped to the <pre> deliberately: the interactive blocks (prompt/wizard/preview/multi-select) are
+// siblings, not children, so they keep normal app theming and never invert.
+const MIRROR_SPACE = "[color-scheme:dark] bg-[#0a0a0a] text-[#fafafa]";
+const MIRROR_INVERT = "[filter:invert(1)_hue-rotate(180deg)] dark:[filter:none]";
+
 function preClass(wrap: boolean, className?: string): string {
   return cn(
     "m-0 font-mono leading-[1.25] tracking-normal text-foreground [font-variant-ligatures:none]",
+    MIRROR_SPACE,
+    MIRROR_INVERT,
     wrap
       ? "whitespace-pre-wrap break-words"
       : // Horizontal pan for wide TUI tables. `overflow-x-auto` forces `overflow-y` to compute to
@@ -161,12 +184,12 @@ export const AnsiOutput = memo(function AnsiOutput({
     currentRef.current?.scrollIntoView({ block: "center", behavior: "auto" });
   }, [currentMatch, matches]);
 
-  // Muted = box-drawing / rule glyphs. Use muted-foreground (readable on dark) and drop ANSI dim
-  // opacity so table borders stay visible — var(--border) + dim made them nearly invisible on mobile.
+  // Muted = box-drawing / rule glyphs. Drop ANSI dim opacity so table borders stay visible —
+  // var(--border) + dim made them nearly invisible on mobile. #a1a1a1 is --muted-foreground's dark
+  // half, written literally for the same reason as MIRROR_SPACE above: everything inside the pre is
+  // dark-space, and a token here would resolve to the page's theme and then get inverted.
   const styleFor = (s: AnsiSegment): CSSProperties =>
-    s.muted
-      ? { ...s.style, color: "var(--muted-foreground)", fontWeight: 400, opacity: 1 }
-      : s.style;
+    s.muted ? { ...s.style, color: "#a1a1a1", fontWeight: 400, opacity: 1 } : s.style;
 
   const prompt = promptBlock ? (
     <PromptSelectBlock
@@ -254,7 +277,21 @@ export const AnsiOutput = memo(function AnsiOutput({
                       data-find-match={isCurrent ? "current" : "other"}
                       className={cn(
                         "rounded-[2px]",
-                        isCurrent ? "bg-yellow-400 text-black" : "bg-yellow-400/30",
+                        // Asymmetric on purpose, and the asymmetry is the whole subtlety.
+                        //
+                        // The CURRENT match re-applies the mirror's filter to cancel it, because
+                        // otherwise yellow-400 comes out of invert+hue-rotate as a dark brown that
+                        // reads as a redaction bar. It can do that safely only because `text-black`
+                        // pins its text: black → inner invert → white → outer invert → black.
+                        //
+                        // A non-current match sets no text colour, so its text is INHERITED from
+                        // the segment — dark-space, i.e. light. Double-inverting sends it
+                        // light → dark → light and it lands light-on-light, erasing the very text
+                        // you searched for. So the others take the plain single inversion, which
+                        // renders them as a pale tan wash with the mapped text still on top.
+                        isCurrent
+                          ? cn(MIRROR_INVERT, "bg-yellow-400 text-black")
+                          : "bg-yellow-400/30",
                       )}
                     >
                       {p.text}

--- a/web/src/components/app-header.tsx
+++ b/web/src/components/app-header.tsx
@@ -63,14 +63,17 @@ export function AppHeader({
   const trouble = useConnectionTrouble(connecting);
   const lost = useConnectionLost(connecting);
   return (
-    <header className="sticky top-0 z-20 flex items-center gap-2 border-b border-border/60 bg-zinc-800 pl-4 pr-2 py-2 [padding-top:calc(env(safe-area-inset-top)_+_0.5rem)]">
+    <header className="sticky top-0 z-20 flex items-center gap-2 border-b border-border/60 bg-muted pl-4 pr-2 py-2 [padding-top:calc(env(safe-area-inset-top)_+_0.5rem)]">
       {override ?? (
         <>
           <CollieHome onHome={onHome} trouble={trouble} lost={lost} wordmark={wordmark} />
           {/* Center region: the breadcrumb (or, on the dashboard/space, an empty flex-1 spacer that
               pushes the right cluster to the edge). min-w-0 so the breadcrumb truncates when tight. */}
           <div className="flex min-w-0 flex-1 items-center">{children}</div>
-          <div className="flex items-center gap-3">
+          {/* gap-1, not gap-3: the icon buttons now carry their own 12px of padding to reach 44px,
+              so a 12px gap on top of that reads as a gulf. 4px keeps the apparent spacing between
+              icons close to what it was. */}
+          <div className="flex items-center gap-1">
             {rightLead}
             {rightTrail}
           </div>
@@ -89,7 +92,8 @@ export function SettingsGear({ session }: { session?: string }) {
       type="button"
       onClick={() => navigate(settingsPath(session))}
       aria-label="Settings"
-      className="text-muted-foreground transition-colors hover:text-foreground"
+      // A real 44px box — see ThemeToggle for why not a negative margin.
+      className="grid size-11 place-items-center text-muted-foreground transition-colors hover:text-foreground"
     >
       <Settings className="size-5" />
     </button>

--- a/web/src/components/build-stamp.tsx
+++ b/web/src/components/build-stamp.tsx
@@ -46,7 +46,7 @@ export function BuildStamp({ className }: { className?: string }) {
   return (
     <div
       className={cn(
-        "text-center text-[11px] leading-relaxed text-muted-foreground/70",
+        "text-center text-[11px] leading-relaxed text-muted-foreground",
         className,
       )}
     >

--- a/web/src/components/command-palette.tsx
+++ b/web/src/components/command-palette.tsx
@@ -70,7 +70,7 @@ export function CommandPalette({ open, onClose, agent, onInsert, onSubmit }: Com
           value={query}
           onChange={(e) => setQuery(e.target.value)}
           placeholder={`Search ${all.length} commands…`}
-          className="h-11 w-full rounded-md border border-input bg-transparent pl-9 pr-3 text-base outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50"
+          className="h-11 w-full rounded-md border border-input bg-transparent pl-9 pr-3 text-base outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring"
         />
       </div>
 

--- a/web/src/components/composer.tsx
+++ b/web/src/components/composer.tsx
@@ -451,7 +451,7 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 
   return (
     <>
-      <div className="border-t border-border/60 bg-zinc-800 px-3 pb-[calc(env(safe-area-inset-bottom)_+_0.5rem)] pt-2.5">
+      <div className="border-t border-border/60 bg-muted px-3 pb-[calc(env(safe-area-inset-bottom)_+_0.5rem)] pt-2.5">
         {/* Pending-send preview: visible from send until the mirror echoes back (or 6s). Shows the
             user what landed so they don't double-tap while waiting for the terminal to update. */}
         {lastSent && (

--- a/web/src/components/key-queue-strip.tsx
+++ b/web/src/components/key-queue-strip.tsx
@@ -80,7 +80,7 @@ export function KeyQueueStrip({
           disabled={disabled}
           onChange={(e) => onBaseChar(e.target.value)}
           aria-label="Type a key to combine"
-          className="h-8 w-14 rounded-md border border-input bg-transparent px-2 text-sm outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:opacity-50"
+          className="h-8 w-14 rounded-md border border-input bg-transparent px-2 text-sm outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring disabled:opacity-50"
         />
       )}
 

--- a/web/src/components/multi-select-block.tsx
+++ b/web/src/components/multi-select-block.tsx
@@ -132,7 +132,7 @@ function CheckboxPhase({
         >
           <span className="min-w-0 flex-1">
             {multi.escape.label}
-            <span className="text-muted-foreground/70"> — ends the questions</span>
+            <span className="text-muted-foreground"> — ends the questions</span>
           </span>
           {sending === "escape" ? spinnerSm : null}
         </button>
@@ -158,7 +158,7 @@ function ReviewPhase({
       {incomplete ? (
         // role="alert" so a screen reader announces the incomplete-answers warning when the review
         // screen mounts — otherwise a user could confirm a partial set without ever hearing it.
-        <div role="alert" className="flex items-center gap-1.5 text-xs text-yellow-500">
+        <div role="alert" className="flex items-center gap-1.5 text-xs text-status-working">
           <AlertTriangle className="size-3.5 shrink-0" />
           You have not answered all questions
         </div>

--- a/web/src/components/new-space-sheet.tsx
+++ b/web/src/components/new-space-sheet.tsx
@@ -45,7 +45,7 @@ export function NewSpaceSheet({ open, onClose, onCreate }: NewSpaceSheetProps) {
             autoCapitalize="none"
             autoCorrect="off"
             spellCheck={false}
-            className="h-11 rounded-lg border border-border bg-background px-3 font-mono text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+            className="h-11 rounded-lg border border-border bg-background px-3 font-mono text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring"
           />
         </label>
         <label className="flex flex-col gap-1">
@@ -54,7 +54,7 @@ export function NewSpaceSheet({ open, onClose, onCreate }: NewSpaceSheetProps) {
             value={label}
             onChange={(e) => setLabel(e.target.value)}
             placeholder="name this space"
-            className="h-11 rounded-lg border border-border bg-background px-3 text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+            className="h-11 rounded-lg border border-border bg-background px-3 text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring"
           />
         </label>
         <Button onClick={create} className="mt-1 h-11">

--- a/web/src/components/preview-select-block.tsx
+++ b/web/src/components/preview-select-block.tsx
@@ -190,7 +190,7 @@ export function PreviewSelectBlock({ preview, onAction, disabled }: PreviewSelec
       {/* The question's note. Three surfaces: the terminal-editing banner (everything locked), the
           attached-note card with edit/remove, or the add-note affordance — plus our own editor. */}
       {terminalEditing ? (
-        <div className="rounded-lg border border-dashed border-yellow-500/50 px-3 py-2 text-xs text-yellow-500">
+        <div className="rounded-lg border border-dashed border-status-working/50 px-3 py-2 text-xs text-status-working">
           Note is being edited in the terminal — controls resume when it closes.
           {preview.note.text ? <span className="text-muted-foreground"> ({preview.note.text})</span> : null}
         </div>

--- a/web/src/components/space-overview.tsx
+++ b/web/src/components/space-overview.tsx
@@ -22,7 +22,7 @@ export function SpaceOverview({ workspaces, agents, onOpen, onNewSpace }: SpaceO
     <section className="flex flex-col gap-2 px-3 py-4">
       <div className="flex items-center justify-between px-1">
         <h2 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-          Spaces <span className="opacity-60">({workspaces.length})</span>
+          Spaces <span className="text-muted-foreground">({workspaces.length})</span>
         </h2>
         <button
           type="button"
@@ -61,7 +61,9 @@ export function SpaceOverview({ workspaces, agents, onOpen, onNewSpace }: SpaceO
                       <span className="sr-only">{STATUS_LABEL[status]}</span>
                     </>
                   ) : (
-                    <span className="size-2.5 shrink-0 rounded-full border border-muted-foreground/40" />
+                    // Solid, not /40: at 1px on a 10px circle the alpha ring measured 1.86:1 and
+                    // read as nothing at all. Same antialiasing problem as the switch's outline.
+                    <span className="size-2.5 shrink-0 rounded-full border border-muted-foreground" />
                   )}
                   <span className="min-w-0 flex-1 truncate font-medium">{w.label}</span>
                   <Count icon={Layers} n={w.tabCount} unit="tab" />

--- a/web/src/components/space-strip.tsx
+++ b/web/src/components/space-strip.tsx
@@ -29,8 +29,11 @@ export function SpaceStrip({
   onNewSpace,
   onBack,
 }: SpaceStripProps) {
+  // shrink-0: this strip is a child of the space route's `flex-1 flex-col` scroller, so without it
+  // the strip flex-shrinks to 16px while its 32px chips overflow — the tab row below then paints
+  // straight over the chips.
   return (
-    <div className="flex items-center gap-2 overflow-x-auto px-3 py-2 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+    <div className="flex shrink-0 items-center gap-2 overflow-x-auto px-3 py-2 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
       {onBack ? (
         <button
           type="button"

--- a/web/src/components/tab-strip.tsx
+++ b/web/src/components/tab-strip.tsx
@@ -55,7 +55,8 @@ export function TabStrip({
 
   return (
     <>
-      <div className="flex items-center gap-2 overflow-x-auto border-t border-border/40 px-3 py-2 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+      {/* shrink-0 for the same reason as SpaceStrip — see the note there. */}
+      <div className="flex shrink-0 items-center gap-2 overflow-x-auto border-t border-border/40 px-3 py-2 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
         <SectionLabel>Tabs</SectionLabel>
         {allowAll && <Chip label="All" active={selected === null} onClick={() => onSelect(null)} />}
         {wsTabs.map((t) => (

--- a/web/src/components/theme-control.test.tsx
+++ b/web/src/components/theme-control.test.tsx
@@ -1,0 +1,85 @@
+import { describe, expect, it, beforeEach, vi } from "vitest";
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+// use-theme holds module-scope state, so each case re-imports both the hook and this component to
+// get a clean slate (see use-theme.test.ts for why the state lives there).
+
+const STORAGE_KEY = "collie:theme:v1";
+
+async function load(stored: string | null) {
+  localStorage.clear();
+  if (stored !== null) localStorage.setItem(STORAGE_KEY, stored);
+  document.documentElement.className = "";
+  vi.resetModules();
+  return import("./theme-control");
+}
+
+describe("ThemeControl", () => {
+  beforeEach(() => {
+    document.head.innerHTML = "";
+  });
+
+  it("renders three options with the stored one selected", async () => {
+    const { ThemeControl } = await load("dark");
+    render(<ThemeControl />);
+
+    const group = screen.getByRole("radiogroup", { name: "Appearance" });
+    const options = within(group).getAllByRole("radio");
+    expect(options.map((o) => o.textContent)).toEqual(["System", "Light", "Dark"]);
+    expect(options.map((o) => o.getAttribute("aria-checked"))).toEqual(["false", "false", "true"]);
+  });
+
+  it("defaults to System when nothing is stored", async () => {
+    const { ThemeControl } = await load(null);
+    render(<ThemeControl />);
+    expect(screen.getByRole("radio", { name: "System" })).toHaveAttribute("aria-checked", "true");
+  });
+
+  it("pins a theme on selection, stamping the class and persisting it", async () => {
+    const { ThemeControl } = await load(null);
+    render(<ThemeControl />);
+
+    await userEvent.click(screen.getByRole("radio", { name: "Light" }));
+
+    expect(screen.getByRole("radio", { name: "Light" })).toHaveAttribute("aria-checked", "true");
+    expect([...document.documentElement.classList]).toEqual(["light"]);
+    expect(localStorage.getItem(STORAGE_KEY)).toBe("light");
+  });
+
+  it("un-pins back to System, clearing both the class and the key", async () => {
+    const { ThemeControl } = await load("dark");
+    render(<ThemeControl />);
+
+    await userEvent.click(screen.getByRole("radio", { name: "System" }));
+
+    expect([...document.documentElement.classList]).toEqual([]);
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+});
+
+describe("ThemeToggle", () => {
+  it("names the CURRENT mode, not the next one", async () => {
+    const { ThemeToggle } = await load("light");
+    render(<ThemeToggle />);
+    expect(screen.getByRole("button", { name: "Theme: light" })).toBeInTheDocument();
+  });
+
+  it("cycles system → light → dark → system, relabelling each time", async () => {
+    const { ThemeToggle } = await load(null);
+    render(<ThemeToggle />);
+
+    const seen = [screen.getByRole("button").getAttribute("aria-label")];
+    for (let i = 0; i < 3; i++) {
+      await userEvent.click(screen.getByRole("button"));
+      seen.push(screen.getByRole("button").getAttribute("aria-label"));
+    }
+
+    expect(seen).toEqual([
+      "Theme: follow system",
+      "Theme: light",
+      "Theme: dark",
+      "Theme: follow system",
+    ]);
+  });
+});

--- a/web/src/components/theme-control.tsx
+++ b/web/src/components/theme-control.tsx
@@ -1,0 +1,101 @@
+import { Moon, MonitorSmartphone, Sun } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+
+import { Card } from "@/components/ui/card";
+import { useTheme } from "@/hooks/use-theme";
+import type { Theme } from "@/hooks/use-theme";
+import { cn } from "@/lib/utils";
+
+// The two faces of one preference: a labelled three-way in Settings, and a cycling icon in the
+// header for the situational flip (outdoors, in bed) that is the whole reason this is worth a
+// control at all.
+
+const OPTIONS: ReadonlyArray<{ value: Theme; label: string; icon: LucideIcon }> = [
+  { value: "system", label: "System", icon: MonitorSmartphone },
+  { value: "light", label: "Light", icon: Sun },
+  { value: "dark", label: "Dark", icon: Moon },
+];
+
+/** The icon names the CURRENT mode, not the next one — so the button reads as a status display you
+ *  can also press. Tapping advances System → Light → Dark → System. */
+export function themeIcon(theme: Theme): LucideIcon {
+  return OPTIONS.find((o) => o.value === theme)?.icon ?? MonitorSmartphone;
+}
+
+const LABEL: Record<Theme, string> = {
+  system: "Theme: follow system",
+  light: "Theme: light",
+  dark: "Theme: dark",
+};
+
+/** Header affordance. Styled to match SettingsGear exactly — they sit next to each other. */
+export function ThemeToggle() {
+  const { theme, cycleTheme } = useTheme();
+  const Icon = themeIcon(theme);
+  return (
+    <button
+      type="button"
+      onClick={cycleTheme}
+      aria-label={LABEL[theme]}
+      // A real 44px box, NOT padding pulled back by a negative margin. The negative-margin trick
+      // keeps the icons visually tight but lets adjacent boxes overlap (two -m-3 buttons pull 24px
+      // against a 12px gap, so the gear stole 12px of the theme button's hit area) and drags the
+      // last one past the header's padding into document overflow. Costs horizontal room, which the
+      // breadcrumb absorbs — it already truncates by design. SettingsGear matches.
+      className="grid size-11 place-items-center text-muted-foreground transition-colors hover:text-foreground"
+    >
+      <Icon className="size-5" />
+    </button>
+  );
+}
+
+/** Settings card. Mirrors the icon/title/description shape of the other rows. */
+export function ThemeControl() {
+  const { theme, setTheme } = useTheme();
+  const Icon = themeIcon(theme);
+
+  return (
+    <Card className="gap-0 py-0">
+      <div className="flex items-center justify-between gap-4 p-4">
+        <div className="flex min-w-0 items-start gap-3">
+          <Icon className="mt-0.5 size-5 shrink-0 text-muted-foreground" />
+          <div className="min-w-0">
+            <div className="font-medium">Appearance</div>
+            <p className="text-sm text-muted-foreground">Follow your phone, or pin one.</p>
+          </div>
+        </div>
+      </div>
+
+      <div
+        role="radiogroup"
+        aria-label="Appearance"
+        className="flex gap-1 border-t border-border/60 p-2"
+      >
+        {OPTIONS.map((option) => {
+          const selected = option.value === theme;
+          return (
+            <button
+              key={option.value}
+              type="button"
+              role="radio"
+              aria-checked={selected}
+              onClick={() => setTheme(option.value)}
+              className={cn(
+                // min-h-11 = 44px, the iOS/Android comfort target rather than the 24px AA floor.
+                "flex min-h-11 flex-1 items-center justify-center gap-2 rounded-md px-3 py-2 text-sm transition-colors",
+                // Selected is a filled pill, not a tint: `bg-secondary` on a white card is 1.09:1,
+                // which leaves the selection carried entirely by the label weight.
+                selected
+                  ? "bg-primary font-medium text-primary-foreground"
+                  : "text-muted-foreground active:bg-muted",
+              )}
+            >
+              <option.icon className="size-4 shrink-0" />
+              {option.label}
+            </button>
+          );
+        })}
+      </div>
+    </Card>
+  );
+}

--- a/web/src/components/ui/button.tsx
+++ b/web/src/components/ui/button.tsx
@@ -4,7 +4,7 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 active:scale-[0.98] select-none",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 outline-none focus-visible:ring-[3px] focus-visible:ring-ring active:scale-[0.98] select-none",
   {
     variants: {
       variant: {

--- a/web/src/components/ui/chat/chat-input.tsx
+++ b/web/src/components/ui/chat/chat-input.tsx
@@ -14,7 +14,7 @@ function ChatInput({ className, ref, ...props }: React.ComponentProps<"textarea"
       autoComplete="off"
       autoCapitalize="none"
       className={cn(
-        "field-sizing-content max-h-40 min-h-11 w-full resize-none rounded-md border border-input bg-transparent px-3 py-2.5 text-base shadow-xs outline-none transition-[color,box-shadow] placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50",
+        "field-sizing-content max-h-40 min-h-11 w-full resize-none rounded-md border border-input bg-transparent px-3 py-2.5 text-base shadow-xs outline-none transition-[color,box-shadow] placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
         className,
       )}
       {...props}

--- a/web/src/components/ui/section-label.tsx
+++ b/web/src/components/ui/section-label.tsx
@@ -8,7 +8,7 @@ export function SectionLabel({ children, className }: { children: ReactNode; cla
   return (
     <span
       className={cn(
-        "shrink-0 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground/70",
+        "shrink-0 text-[11px] font-semibold uppercase tracking-wide text-muted-foreground",
         className,
       )}
     >

--- a/web/src/components/ui/switch.tsx
+++ b/web/src/components/ui/switch.tsx
@@ -21,8 +21,16 @@ function Switch({ checked, onCheckedChange, disabled, id, ...rest }: SwitchProps
       onClick={() => onCheckedChange(!checked)}
       data-slot="switch"
       className={cn(
-        "relative inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full transition-colors outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50",
-        checked ? "bg-primary" : "bg-muted",
+        "relative inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full transition-colors outline-none focus-visible:ring-[3px] focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
+        // The OFF track needs real contrast against the card it sits on, or you can't read your own
+        // settings: `bg-muted` is 1.09:1 on a white card, and the thumb is white on top of that —
+        // a white blob on white, legible only by its shadow. WCAG 1.4.11 wants 3:1 for state.
+        // A border carries the off state instead, since a fill dark enough to read would look
+        // switched-on.
+        // Solid border, not /60: `rounded-full` on a 24px pill leaves no straight edge, so the whole
+        // stroke is antialiased and an alpha border renders lighter than it computes (2.65:1 spec →
+        // 1.74:1 actual). Full strength survives the antialiasing.
+        checked ? "bg-primary" : "border-2 border-muted-foreground bg-muted",
       )}
       {...rest}
     >

--- a/web/src/components/update-banner.tsx
+++ b/web/src/components/update-banner.tsx
@@ -67,7 +67,7 @@ export function UpdateBanner({ className }: { className?: string }) {
   return (
     <div
       className={cn(
-        "text-center text-[11px] leading-relaxed text-muted-foreground/70",
+        "text-center text-[11px] leading-relaxed text-muted-foreground",
         className,
       )}
     >

--- a/web/src/components/wizard-block.tsx
+++ b/web/src/components/wizard-block.tsx
@@ -176,7 +176,7 @@ function QuestionStep({
           >
             <span className="min-w-0 flex-1">
               {option.label}
-              <span className="text-muted-foreground/70"> — ends the questions</span>
+              <span className="text-muted-foreground"> — ends the questions</span>
             </span>
             {sendingId === id ? (
               <Loader2 className="size-3.5 shrink-0 animate-spin" aria-label="Sending" />
@@ -213,7 +213,7 @@ function ReviewStep({
         </dl>
       )}
       {wizard.incomplete && (
-        <div className="flex items-center gap-1.5 text-xs text-yellow-500">
+        <div className="flex items-center gap-1.5 text-xs text-status-working">
           <AlertTriangle className="size-3.5 shrink-0" />
           You have not answered all questions
         </div>

--- a/web/src/hooks/use-theme.test.ts
+++ b/web/src/hooks/use-theme.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it, beforeEach, vi } from "vitest";
+
+import type { Theme, UseThemeReturn } from "./use-theme";
+
+// use-theme keeps its state at module scope (so the header button and the settings control agree,
+// and so the OS listener outlives the idle lock unmounting the router). Tests therefore re-import
+// the module per case rather than resetting a hook instance.
+//
+// The shared matchMedia stub in test/setup.ts hands back a discard `addEventListener`, which can
+// never fire — fine for everything else in the suite, useless for the one mechanism here that has no
+// CSS fallback. So this file installs a controllable fake locally and leaves the shared one alone.
+
+const STORAGE_KEY = "collie:theme:v1";
+
+let media: { matches: boolean; emit: (matches: boolean) => void };
+
+function installMatchMedia(initialDark: boolean) {
+  const listeners = new Set<(e: MediaQueryListEvent) => void>();
+  const mql = {
+    matches: initialDark,
+    media: "(prefers-color-scheme: dark)",
+    onchange: null,
+    addEventListener: (_: string, fn: (e: MediaQueryListEvent) => void) => void listeners.add(fn),
+    removeEventListener: (_: string, fn: (e: MediaQueryListEvent) => void) =>
+      void listeners.delete(fn),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  };
+  media = {
+    get matches() {
+      return mql.matches;
+    },
+    emit(matches: boolean) {
+      mql.matches = matches;
+      for (const fn of listeners) fn({ matches } as MediaQueryListEvent);
+    },
+  };
+  vi.stubGlobal("matchMedia", () => mql);
+}
+
+/** Fresh module instance, so module-scope state doesn't leak between cases. */
+async function loadModule(): Promise<{ useTheme: () => UseThemeReturn }> {
+  vi.resetModules();
+  return (await import("./use-theme")) as { useTheme: () => UseThemeReturn };
+}
+
+/** The hook's non-React surface is what matters here; drive it through the store it exports. */
+async function bootstrap(stored: string | null, osDark = false) {
+  localStorage.clear();
+  if (stored !== null) localStorage.setItem(STORAGE_KEY, stored);
+  document.documentElement.className = "";
+  installMatchMedia(osDark);
+  return loadModule();
+}
+
+function classes(): string[] {
+  return [...document.documentElement.classList];
+}
+
+describe("useTheme store", () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+    document.head.innerHTML = "";
+  });
+
+  it("defaults to system when nothing is stored", async () => {
+    const { useTheme } = await bootstrap(null);
+    // Module-load side effect: no pin class, because System is not a pin.
+    expect(classes()).toEqual([]);
+    expect(useTheme).toBeTypeOf("function");
+  });
+
+  it("ignores a garbage stored value rather than pinning to it", async () => {
+    await bootstrap("chartreuse");
+    expect(classes()).toEqual([]);
+  });
+
+  it("stamps the pin class for a stored theme", async () => {
+    await bootstrap("dark");
+    expect(classes()).toEqual(["dark"]);
+  });
+
+  it("stores a BARE string, not JSON — theme-init.js does a strict compare", async () => {
+    const { useTheme } = await bootstrap(null);
+    const { renderHook, act } = await import("@testing-library/react");
+    const { result } = renderHook(() => useTheme());
+
+    act(() => result.current.setTheme("dark"));
+    // The exact bytes theme-init.js compares against. JSON.stringify would write `"dark"` with the
+    // quote characters, the strict compare would miss, and the anti-flash would silently die.
+    expect(localStorage.getItem(STORAGE_KEY)).toBe("dark");
+    expect(localStorage.getItem(STORAGE_KEY)).not.toBe(JSON.stringify("dark"));
+  });
+
+  it("survives localStorage throwing (Safari private mode)", async () => {
+    const spy = vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new Error("denied");
+    });
+    await expect(bootstrap(null)).resolves.toBeDefined();
+    expect(classes()).toEqual([]);
+    spy.mockRestore();
+  });
+
+  it("resolves system against the OS", async () => {
+    await bootstrap(null, true);
+    // No class either way — the CSS `color-scheme: light dark` does the resolving. The point is that
+    // module load does not spuriously pin.
+    expect(classes()).toEqual([]);
+  });
+
+  it("gives both theme-color metas the pinned colour, so whichever matches is right", async () => {
+    document.head.innerHTML =
+      '<meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)">' +
+      '<meta name="theme-color" content="#0a0a0a" media="(prefers-color-scheme: dark)">';
+    await bootstrap("light");
+    const contents = [...document.querySelectorAll<HTMLMetaElement>('meta[name="theme-color"]')].map(
+      (m) => m.content,
+    );
+    expect(contents).toEqual(["#ffffff", "#ffffff"]);
+  });
+
+  it("hands the metas back their own values on system", async () => {
+    document.head.innerHTML =
+      '<meta name="theme-color" content="#000" media="(prefers-color-scheme: light)">' +
+      '<meta name="theme-color" content="#000" media="(prefers-color-scheme: dark)">';
+    await bootstrap(null);
+    const contents = [...document.querySelectorAll<HTMLMetaElement>('meta[name="theme-color"]')].map(
+      (m) => m.content,
+    );
+    expect(contents).toEqual(["#ffffff", "#0a0a0a"]);
+  });
+});
+
+describe("theme cycling and class teardown", () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+    document.head.innerHTML = "";
+  });
+
+  // The single most likely bug in the feature: a stale class left on <html> means Dark → System
+  // silently does nothing until a full reload.
+  it("removes the pinned class when returning to system", async () => {
+    const { useTheme } = await bootstrap("dark");
+    expect(classes()).toEqual(["dark"]);
+
+    const { renderHook, act } = await import("@testing-library/react");
+    const { result } = renderHook(() => useTheme());
+
+    act(() => result.current.setTheme("system"));
+    expect(classes()).toEqual([]);
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+
+  it("replaces rather than accumulates classes when switching pins", async () => {
+    const { useTheme } = await bootstrap("dark");
+    const { renderHook, act } = await import("@testing-library/react");
+    const { result } = renderHook(() => useTheme());
+
+    act(() => result.current.setTheme("light"));
+    expect(classes()).toEqual(["light"]);
+    expect(localStorage.getItem(STORAGE_KEY)).toBe("light");
+  });
+
+  it("cycles system → light → dark → system", async () => {
+    const { useTheme } = await bootstrap(null);
+    const { renderHook, act } = await import("@testing-library/react");
+    const { result } = renderHook(() => useTheme());
+
+    const seen: Theme[] = [result.current.theme];
+    for (let i = 0; i < 3; i++) {
+      act(() => result.current.cycleTheme());
+      seen.push(result.current.theme);
+    }
+    expect(seen).toEqual(["system", "light", "dark", "system"]);
+  });
+
+  it("tracks an OS flip while on system, and ignores it once pinned", async () => {
+    const { useTheme } = await bootstrap(null, false);
+    const { renderHook, act } = await import("@testing-library/react");
+    const { result } = renderHook(() => useTheme());
+
+    expect(result.current.resolved).toBe("light");
+    act(() => media.emit(true));
+    expect(result.current.resolved).toBe("dark");
+
+    act(() => result.current.setTheme("light"));
+    act(() => media.emit(false));
+    expect(result.current.resolved).toBe("light");
+    act(() => media.emit(true));
+    expect(result.current.resolved).toBe("light"); // pinned wins over the OS
+  });
+});

--- a/web/src/hooks/use-theme.ts
+++ b/web/src/hooks/use-theme.ts
@@ -1,0 +1,141 @@
+import { useCallback, useSyncExternalStore } from "react";
+
+// App theme preference, persisted in localStorage.
+//
+// The *visual* switch is pure CSS and none of this hook's business: index.css declares every themed
+// token as light-dark(<light>, <dark>), and `color-scheme` picks the half. A System user's theme
+// works with JavaScript disabled entirely.
+//
+// What CSS can't do, and this owns:
+//   1. The pin class on <html> — bidirectionally. A stale class MUST come off, or Dark → System
+//      leaves `.dark` stamped and the page stays dark until a full reload.
+//   2. The theme-color metas, which carry `media` attributes and so follow the OS rather than a pin.
+//
+// State lives at module scope rather than in component state. Two reasons: the header button and the
+// settings control must agree without prop-drilling, and the OS listener then survives App.tsx
+// unmounting the router for the idle lock (a component-scoped listener would stop tracking the OS
+// for as long as the lock holds).
+
+export type Theme = "system" | "light" | "dark";
+export type ResolvedTheme = "light" | "dark";
+
+const STORAGE_KEY = "collie:theme:v1";
+const DEFAULT: Theme = "system";
+
+/** Browser chrome — Android's URL bar and task-switcher card. Mirrors --background. */
+const META_COLOR: Record<ResolvedTheme, string> = { light: "#ffffff", dark: "#0a0a0a" };
+
+/** Read the pin. BARE string, not JSON — public/theme-init.js does the same strict compare before
+ *  first paint, and JSON.stringify would write `"dark"` with the quotes and silently break it. */
+function loadTheme(): Theme {
+  try {
+    const raw = typeof localStorage !== "undefined" ? localStorage.getItem(STORAGE_KEY) : null;
+    return raw === "light" || raw === "dark" || raw === "system" ? raw : DEFAULT;
+  } catch {
+    return DEFAULT;
+  }
+}
+
+function saveTheme(theme: Theme): void {
+  try {
+    if (typeof localStorage === "undefined") return;
+    // Absent means system, so un-pinning removes the key rather than storing a sentinel — that way
+    // theme-init.js's `getItem` returns null and it does nothing, which is exactly right.
+    if (theme === "system") localStorage.removeItem(STORAGE_KEY);
+    else localStorage.setItem(STORAGE_KEY, theme);
+  } catch {
+    // Ignore quota / private-mode write errors: the theme still applies for this session.
+  }
+}
+
+function darkMediaQuery(): MediaQueryList | null {
+  return typeof matchMedia === "function" ? matchMedia("(prefers-color-scheme: dark)") : null;
+}
+
+function prefersDark(): boolean {
+  return darkMediaQuery()?.matches ?? false;
+}
+
+function apply(theme: Theme, resolved: ResolvedTheme): void {
+  if (typeof document === "undefined") return;
+  const root = document.documentElement;
+  root.classList.remove("light", "dark");
+  if (theme !== "system") root.classList.add(theme);
+
+  // When pinned, give BOTH metas the pinned colour so whichever one the browser's media query
+  // selects is the right answer. On System, hand each back its own value and let the query decide.
+  const pinned = theme !== "system";
+  document.querySelectorAll<HTMLMetaElement>('meta[name="theme-color"]').forEach((meta) => {
+    // getAttribute, not `.media` — that reflected property is not implemented everywhere (jsdom
+    // among them), and reading it blind throws on the undefined.
+    const own: ResolvedTheme = meta.getAttribute("media")?.includes("dark") ? "dark" : "light";
+    meta.content = META_COLOR[pinned ? resolved : own];
+  });
+}
+
+export interface ThemeState {
+  /** What the user chose. */
+  theme: Theme;
+  /** What that actually renders as right now — `system` resolved against the OS. */
+  resolved: ResolvedTheme;
+}
+
+function computeState(theme: Theme): ThemeState {
+  return { theme, resolved: theme === "system" ? (prefersDark() ? "dark" : "light") : theme };
+}
+
+// useSyncExternalStore demands a stable snapshot reference, so recompute only on real change.
+let state: ThemeState = computeState(loadTheme());
+const listeners = new Set<() => void>();
+
+function refresh(theme: Theme): void {
+  state = computeState(theme);
+  apply(state.theme, state.resolved);
+  for (const listener of listeners) listener();
+}
+
+// Apply once at module load. theme-init.js already stamped the class for a pinned user before
+// paint; this is idempotent for that, and additionally fixes up the metas.
+apply(state.theme, state.resolved);
+
+// Follow the OS while on System, so an evening switch lands without a reload. The CSS half handles
+// itself — this keeps the JS-derived readouts (the header icon, its aria-label, the metas) honest.
+darkMediaQuery()?.addEventListener("change", () => {
+  if (state.theme === "system") refresh("system");
+});
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+function getSnapshot(): ThemeState {
+  return state;
+}
+
+/** System → Light → Dark → System. Every tap changes the icon, which is the feedback. */
+const NEXT: Record<Theme, Theme> = { system: "light", light: "dark", dark: "system" };
+
+export interface UseThemeReturn extends ThemeState {
+  setTheme: (theme: Theme) => void;
+  cycleTheme: () => void;
+}
+
+export function useTheme(): UseThemeReturn {
+  const snapshot = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+
+  const setTheme = useCallback((theme: Theme) => {
+    saveTheme(theme);
+    refresh(theme);
+  }, []);
+
+  const cycleTheme = useCallback(() => {
+    const next = NEXT[state.theme];
+    saveTheme(next);
+    refresh(next);
+  }, []);
+
+  return { ...snapshot, setTheme, cycleTheme };
+}

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1,64 +1,129 @@
 @import "tailwindcss";
 @import "tw-animate-css";
 
-@custom-variant dark (&:is(.dark *));
-
-:root {
-  --radius: 0.65rem;
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.145 0 0);
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.145 0 0);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.205 0 0);
-  --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.97 0 0);
-  --secondary-foreground: oklch(0.205 0 0);
-  --muted: oklch(0.97 0 0);
-  --muted-foreground: oklch(0.556 0 0);
-  --accent: oklch(0.97 0 0);
-  --accent-foreground: oklch(0.205 0 0);
-  --destructive: oklch(0.577 0.245 27.325);
-  --destructive-foreground: oklch(0.985 0 0);
-  --border: oklch(0.922 0 0);
-  --input: oklch(0.922 0 0);
-  --ring: oklch(0.708 0 0);
-
-  /* Agent lifecycle status palette — shared across themes. */
-  --status-blocked: oklch(0.66 0.21 24);
-  --status-working: oklch(0.78 0.15 80);
-  --status-done: oklch(0.7 0.16 152);
-  --status-idle: oklch(0.62 0.02 250);
-  --status-unknown: oklch(0.55 0.02 250);
+/* `dark:` must fire for BOTH an explicitly-pinned dark root and a system-dark root the user hasn't
+   pinned to light — otherwise the handful of literal `dark:` utilities silently stop working for
+   everyone on System (the default). Token-driven colors don't need this; these are the literals. */
+@custom-variant dark {
+  &:is(.dark *) {
+    @slot;
+  }
+  @media (prefers-color-scheme: dark) {
+    &:is(:root:not(.light) *) {
+      @slot;
+    }
+  }
 }
 
-.dark {
-  --background: oklch(0.145 0 0);
-  --foreground: oklch(0.985 0 0);
-  --card: oklch(0.205 0 0);
-  --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.205 0 0);
-  --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.922 0 0);
-  --primary-foreground: oklch(0.205 0 0);
-  --secondary: oklch(0.269 0 0);
-  --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.269 0 0);
-  --muted-foreground: oklch(0.708 0 0);
-  --accent: oklch(0.269 0 0);
-  --accent-foreground: oklch(0.985 0 0);
-  --destructive: oklch(0.704 0.191 22.216);
-  --destructive-foreground: oklch(0.985 0 0);
-  --border: oklch(1 0 0 / 12%);
-  --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.556 0 0);
+/* ── Theme tokens ───────────────────────────────────────────────────────────────────────────────
+   Every themed value is a single `light-dark(<light>, <dark>)` declaration, resolved by the
+   element's computed `color-scheme`. That is why there is ONE token block here and not two: the
+   media-query-plus-override shape would have to restate the whole dark palette, and nothing in CSS
+   can share a declaration block across an `@media` boundary.
 
-  --status-blocked: oklch(0.7 0.2 24);
-  --status-working: oklch(0.82 0.15 82);
-  --status-done: oklch(0.74 0.16 152);
-  --status-idle: oklch(0.65 0.02 250);
-  --status-unknown: oklch(0.6 0.02 250);
+   `color-scheme` therefore does real work and is not decoration — it also makes the browser paint
+   native UI (scrollbars, form controls, the caret, the iOS keyboard, <select> menus) to match.
+
+     :root        → `light dark`, i.e. follow the OS. The default; no class on <html>.
+     :root.light  → pinned light,  set by useTheme / theme-init.js
+     :root.dark   → pinned dark,   ditto
+
+   Pinning is done with a class rather than a `color-scheme` media query so first paint can be fixed
+   by public/theme-init.js before the bundle loads. */
+:root {
+  color-scheme: light dark;
+
+  --radius: 0.65rem;
+  /* Light deviates from stock shadcn in two places, both measured rather than taste:
+     --background is a step off white (stock has background == card == popover == pure white, so the
+     entire dashboard hierarchy rests on one 1.26:1 hairline), and --muted-foreground is darkened
+     for headroom (see below). oklch(0.97) rasterizes to rgb(245,245,245), which is exactly the
+     terminal mirror's inverted background — so the mirror stops showing a seam against the page. */
+  --background: light-dark(oklch(0.97 0 0), oklch(0.145 0 0));
+  --foreground: light-dark(oklch(0.145 0 0), oklch(0.985 0 0));
+  --card: light-dark(oklch(1 0 0), oklch(0.205 0 0));
+  --card-foreground: light-dark(oklch(0.145 0 0), oklch(0.985 0 0));
+  --popover: light-dark(oklch(1 0 0), oklch(0.205 0 0));
+  --popover-foreground: light-dark(oklch(0.145 0 0), oklch(0.985 0 0));
+  --primary: light-dark(oklch(0.205 0 0), oklch(0.922 0 0));
+  --primary-foreground: light-dark(oklch(0.985 0 0), oklch(0.205 0 0));
+  --secondary: light-dark(oklch(0.94 0 0), oklch(0.269 0 0));
+  --secondary-foreground: light-dark(oklch(0.205 0 0), oklch(0.985 0 0));
+  /* Light --muted is a step BELOW --background so the header/composer chrome band still reads as a
+     distinct surface now that the page is no longer white. */
+  --muted: light-dark(oklch(0.94 0 0), oklch(0.269 0 0));
+  /* Light was oklch(0.556) — 4.74:1 on white, i.e. zero headroom, so every /70, /80 and opacity-60
+     derivative in the app fell under 3:1 while its dark counterpart passed. Darkened to buy that
+     headroom back; the alpha modifiers on small text were dropped as well, since no token value
+     rescues a /70. */
+  --muted-foreground: light-dark(oklch(0.48 0 0), oklch(0.708 0 0));
+  --accent: light-dark(oklch(0.97 0 0), oklch(0.269 0 0));
+  --accent-foreground: light-dark(oklch(0.205 0 0), oklch(0.985 0 0));
+  --destructive: light-dark(oklch(0.577 0.245 27.325), oklch(0.704 0.191 22.216));
+  --destructive-foreground: light-dark(oklch(0.985 0 0), oklch(0.985 0 0));
+  --border: light-dark(oklch(0.922 0 0), oklch(1 0 0 / 12%));
+  --input: light-dark(oklch(0.922 0 0), oklch(1 0 0 / 15%));
+  /* Light is darkened off stock shadcn (0.708 → 0.62): at 0.708 the focus ring measures 2.58:1 on
+     white, under the 3:1 WCAG 1.4.11 floor for a non-text indicator — and components draw it at
+     `ring-ring/50`, which halves that again. On an app whose buttons type into a live shell, a focus
+     ring you can't locate is a real problem. Still worth an on-device look: even at 0.62 the /50
+     variant is marginal. */
+  --ring: light-dark(oklch(0.62 0 0), oklch(0.556 0 0));
+
+  /* Agent lifecycle status palette — the app's primary at-a-glance signal, so both halves are
+     tuned against their own ground rather than one set being reused. The dark values glow on
+     near-black; the light values are picked to clear 4.5:1 on white (measured, not estimated —
+     blocked 5.4:1, working 4.8:1, done 4.6:1, idle 5.5:1, unknown 6.5:1).
+
+     These carry text AND fills (`text-status-working`, `bg-status-blocked` dots). Tuning for text
+     makes the dots darker; if that costs the dashboard its glance-ability outdoors, the fallback is
+     splitting fill and text into separate tokens.
+
+     The light values are measured against the WORST ground this text lands on, which took three
+     tries to get right. Tuned against plain white they were 5.4/4.8/4.6 and failed on the chip.
+     Tuned against the `bg-status-X/15` chip on a white card they were 4.90/4.58/4.46 and still
+     failed, because the chip is translucent and the card underneath varies: `needs you` sits on a
+     `bg-status-blocked/5` card (4.17) and the pane header's chip sits on `bg-muted`, rgb(235) not
+     rgb(255) (3.91). These are tuned against that rgb(235) case. When touching them, measure the
+     chip on the pane header, not the dot on the dashboard. */
+  --status-blocked: light-dark(oklch(0.46 0.2 25), oklch(0.7 0.2 24));
+  --status-working: light-dark(oklch(0.46 0.12 72), oklch(0.82 0.15 82));
+  --status-done: light-dark(oklch(0.45 0.14 152), oklch(0.74 0.16 152));
+  --status-idle: light-dark(oklch(0.45 0.02 250), oklch(0.65 0.02 250));
+  --status-unknown: light-dark(oklch(0.43 0.02 250), oklch(0.6 0.02 250));
+
+  /* ── Terminal palette ─────────────────────────────────────────────────────────────────────────
+     The 16 indexed ANSI slots, emitted by lib/ansi.ts as var(--ansi-N).
+
+     ONE set, not two, and it is the dark one — VS Code's Dark+ terminal palette. The mirror renders
+     in dark space under every theme and the light theme inverts it wholesale
+     (components/ansi-output.tsx, .adr/0002), so a light palette here would be applied and then
+     inverted into nonsense. These sit next to the truecolor an agent emits, which no palette can
+     re-theme, so they must share its assumptions: authored for a dark ground. */
+  --ansi-0: #000000;
+  --ansi-1: #cd3131;
+  --ansi-2: #0dbc79;
+  --ansi-3: #e5e510;
+  --ansi-4: #2472c8;
+  --ansi-5: #bc3fbc;
+  --ansi-6: #11a8cd;
+  --ansi-7: #e5e5e5;
+  --ansi-8: #666666;
+  --ansi-9: #f14c4c;
+  --ansi-10: #23d18b;
+  --ansi-11: #f5f543;
+  --ansi-12: #3b8eea;
+  --ansi-13: #d670d6;
+  --ansi-14: #29b8db;
+  --ansi-15: #ffffff;
+}
+
+/* Explicit pins. Class-based so theme-init.js can set them before first paint. */
+:root.light {
+  color-scheme: light;
+}
+:root.dark {
+  color-scheme: dark;
 }
 
 @theme inline {
@@ -99,7 +164,10 @@
 
 @layer base {
   * {
-    @apply border-border outline-ring/50;
+    /* Full-strength ring, not /50: halved, the focus indicator measures 1.77:1 in light and 1.87:1
+       in dark — both under the 3:1 floor for a non-text indicator, on an app whose buttons type
+       into a live shell. */
+    @apply border-border outline-ring;
   }
   html {
     /* Respect notches; keep the app glued to the viewport edges on mobile. */

--- a/web/src/lib/ansi.test.ts
+++ b/web/src/lib/ansi.test.ts
@@ -41,17 +41,17 @@ describe("parseAnsi — SGR colour & weight", () => {
     const segs = parseAnsi(`${ESC}[31mred${ESC}[0m`);
     expect(segs).toHaveLength(1);
     expect(segs[0]!.text).toBe("red");
-    expect(segs[0]!.fg).toBe("#cd3131");
+    expect(segs[0]!.fg).toBe("var(--ansi-1)");
   });
 
   it("parses a background colour (42 = green bg)", () => {
     const segs = parseAnsi(`${ESC}[42mx`);
-    expect(segs[0]!.bg).toBe("#0dbc79");
+    expect(segs[0]!.bg).toBe("var(--ansi-2)");
   });
 
   it("parses bright foreground colours (91 = bright red)", () => {
     const segs = parseAnsi(`${ESC}[91mx`);
-    expect(segs[0]!.fg).toBe("#f14c4c");
+    expect(segs[0]!.fg).toBe("var(--ansi-9)");
   });
 
   it("parses weights/styles and resets them", () => {
@@ -84,6 +84,28 @@ describe("parseAnsi — SGR colour & weight", () => {
     expect(segs[0]!.fg).toBe("rgb(10,20,30)");
   });
 
+  // The palette boundary, asserted from both sides. Indices 0-15 are theme tokens; everything above
+  // them named an absolute colour and keeps its literal. A real terminal resolves `31m` and
+  // `38;5;1` to the same slot and many CLIs emit only the latter, so if these ever diverge one pane
+  // renders the same logical colour two different ways — invisibly wrong on a light background.
+  it("indexed colours 0-15 emit a theme variable in BOTH spellings", () => {
+    expect(parseAnsi(`${ESC}[31mx`)[0]!.fg).toBe("var(--ansi-1)");
+    expect(parseAnsi(`${ESC}[38;5;1mx`)[0]!.fg).toBe("var(--ansi-1)");
+    // ...including the bright half, reached directly (97m) or by index (38;5;15).
+    expect(parseAnsi(`${ESC}[97mx`)[0]!.fg).toBe("var(--ansi-15)");
+    expect(parseAnsi(`${ESC}[38;5;15mx`)[0]!.fg).toBe("var(--ansi-15)");
+    // Backgrounds route through the same table.
+    expect(parseAnsi(`${ESC}[41mx`)[0]!.bg).toBe("var(--ansi-1)");
+    expect(parseAnsi(`${ESC}[48;5;1mx`)[0]!.bg).toBe("var(--ansi-1)");
+  });
+
+  it("keeps literals above index 15 — the cube, the grey ramp, and truecolor", () => {
+    expect(parseAnsi(`${ESC}[38;5;16mx`)[0]!.fg).toBe("rgb(0,0,0)");
+    expect(parseAnsi(`${ESC}[38;5;46mx`)[0]!.fg).toBe("rgb(0,255,0)");
+    expect(parseAnsi(`${ESC}[38;5;255mx`)[0]!.fg).toBe("rgb(238,238,238)");
+    expect(parseAnsi(`${ESC}[38;2;10;20;30mx`)[0]!.fg).toBe("rgb(10,20,30)");
+  });
+
   it("swaps fg/bg for inverse video (7m), with sensible fallbacks", () => {
     const segs = parseAnsi(`${ESC}[7mx`);
     expect(segs[0]!.fg).toBe("var(--background)");
@@ -98,7 +120,7 @@ describe("parseAnsi — SGR colour & weight", () => {
 
   it("treats an empty CSI reset (ESC[m) as a full reset", () => {
     const segs = parseAnsi(`${ESC}[31mred${ESC}[mplain`);
-    expect(segs.find((s) => s.text === "red")!.fg).toBe("#cd3131");
+    expect(segs.find((s) => s.text === "red")!.fg).toBe("var(--ansi-1)");
     expect(segs.find((s) => s.text === "plain")!.fg).toBeUndefined();
   });
 });
@@ -133,7 +155,7 @@ describe("parseAnsi — XSS boundary (raw markup stays literal)", () => {
     const segs = parseAnsi(`${ESC}[31m${payload}${ESC}[0m`);
     expect(segs).toHaveLength(1);
     expect(segs[0]!.text).toBe(payload);
-    expect(segs[0]!.fg).toBe("#cd3131"); // still styled, but the body is inert text
+    expect(segs[0]!.fg).toBe("var(--ansi-1)"); // still styled, but the body is inert text
   });
 
   it("keeps angle brackets, ampersands and quotes intact (no HTML entity encoding)", () => {
@@ -166,7 +188,7 @@ describe("parseAnsi — CR overwrite semantics (last-write-wins per line)", () =
     // rendered in whatever colour was set before the \r.
     const segs = parseAnsi(`${ESC}[31mred\rblue`);
     expect(visible(`${ESC}[31mred\rblue`)).toBe("blue");
-    expect(segs[0]!.fg).toBe("#cd3131"); // "blue" text is in red colour
+    expect(segs[0]!.fg).toBe("var(--ansi-1)"); // "blue" text is in red colour
   });
 
   it("multiple lines: \\r only rolls back the current line, leaving prior lines intact", () => {
@@ -252,7 +274,7 @@ describe("parseAnsi — segment shape carries pre-computed style and muted flag"
 
   it("coloured segment has color set in style", () => {
     const segs = parseAnsi(`${ESC}[31mred${ESC}[0m`);
-    expect(segs[0]!.style.color).toBe("#cd3131");
+    expect(segs[0]!.style.color).toBe("var(--ansi-1)");
     expect(segs[0]!.muted).toBe(false);
   });
 

--- a/web/src/lib/ansi.ts
+++ b/web/src/lib/ansi.ts
@@ -22,14 +22,20 @@ export interface AnsiSegment {
   muted: boolean;
 }
 
-// 16-color palette (VS Code integrated-terminal dark) — readable on our dark background.
-const BASE16 = [
-  "#000000", "#cd3131", "#0dbc79", "#e5e510", "#2472c8", "#bc3fbc", "#11a8cd", "#e5e5e5",
-  "#666666", "#f14c4c", "#23d18b", "#f5f543", "#3b8eea", "#d670d6", "#29b8db", "#ffffff",
-];
+// The 16 indexed ANSI slots, emitted as CSS variables rather than literal hex. The light and dark
+// values live in index.css, so a segment parsed under one theme stays valid under the other and the
+// swap costs nothing at runtime — no re-parse, no theme state threaded through the render tree.
+// (Precedent: the inverse-video path below already emits var(--background)/var(--foreground).)
+//
+// Both spellings of an indexed colour must route through here. A real terminal resolves `ESC[31m`
+// and `ESC[38;5;1m` to the same palette slot, and many CLIs normalise everything to the latter — so
+// theming one and not the other would render the same logical colour two different ways in one pane.
+function ansiVar(n: number): string {
+  return `var(--ansi-${n})`;
+}
 
 function color256(n: number): string {
-  if (n < 16) return BASE16[n] ?? "#ffffff";
+  if (n < 16) return ansiVar(n);
   if (n >= 232) {
     const v = 8 + (n - 232) * 10;
     return `rgb(${v},${v},${v})`;
@@ -70,12 +76,12 @@ function applySgr(state: State, codes: number[]): void {
     else if (c === 24) state.underline = false;
     else if (c === 27) state.inverse = false;
     else if (c === 29) state.strike = false;
-    else if (c >= 30 && c <= 37) state.fg = BASE16[c - 30];
+    else if (c >= 30 && c <= 37) state.fg = ansiVar(c - 30);
     else if (c === 39) state.fg = undefined;
-    else if (c >= 40 && c <= 47) state.bg = BASE16[c - 40];
+    else if (c >= 40 && c <= 47) state.bg = ansiVar(c - 40);
     else if (c === 49) state.bg = undefined;
-    else if (c >= 90 && c <= 97) state.fg = BASE16[8 + c - 90];
-    else if (c >= 100 && c <= 107) state.bg = BASE16[8 + c - 100];
+    else if (c >= 90 && c <= 97) state.fg = ansiVar(8 + c - 90);
+    else if (c >= 100 && c <= 107) state.bg = ansiVar(8 + c - 100);
     else if (c === 38 || c === 48) {
       const isFg = c === 38;
       const mode = codes[i + 1];

--- a/web/src/lib/blocks.test.ts
+++ b/web/src/lib/blocks.test.ts
@@ -82,10 +82,10 @@ describe("splitLines — exact text preservation", () => {
 
   it("keeps a styled segment's style/flags on both sides when split across a newline", () => {
     const styled = seg("red1\nred2", {
-      fg: "#cd3131",
+      fg: "var(--ansi-1)",
       bold: true,
       muted: false,
-      style: { color: "#cd3131", fontWeight: 600 },
+      style: { color: "var(--ansi-1)", fontWeight: 600 },
     });
     const lines = splitLines([styled]);
     expect(lines).toHaveLength(2);
@@ -93,9 +93,9 @@ describe("splitLines — exact text preservation", () => {
     expect([a.text, b.text]).toEqual(["red1", "red2"]);
     // Both halves carry the original style metadata (cloned, not the same reference).
     for (const half of [a, b]) {
-      expect(half.fg).toBe("#cd3131");
+      expect(half.fg).toBe("var(--ansi-1)");
       expect(half.bold).toBe(true);
-      expect(half.style).toEqual({ color: "#cd3131", fontWeight: 600 });
+      expect(half.style).toEqual({ color: "var(--ansi-1)", fontWeight: 600 });
     }
     expect(joinLines(lines)).toBe("red1\nred2");
   });

--- a/web/src/routes/home.tsx
+++ b/web/src/routes/home.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { useNavigate, useRouteLoaderData } from "react-router";
 
 import { AppHeader, SettingsGear } from "@/components/app-header";
+import { ThemeToggle } from "@/components/theme-control";
 import { SessionSwitcher } from "@/components/session-switcher";
 import { ReadOnlyBanner } from "@/components/read-only-banner";
 import { AgentList } from "@/components/agent-list";
@@ -48,7 +49,12 @@ export function HomeRoute() {
         stalled={stalled}
         wordmark
         rightLead={<SessionSwitcher sessions={data.sessions ?? []} current={data.session} />}
-        rightTrail={<SettingsGear session={data.session} />}
+        rightTrail={
+          <>
+            <ThemeToggle />
+            <SettingsGear session={data.session} />
+          </>
+        }
       />
 
       {/* Content region below the header: a viewport-clipped internal scroller. */}

--- a/web/src/routes/settings.tsx
+++ b/web/src/routes/settings.tsx
@@ -9,6 +9,7 @@ import { ConnectionInfo } from "@/components/connection-info";
 import { Card } from "@/components/ui/card";
 import { NotifyPrefsControl } from "@/components/notify-prefs-control";
 import { SnoozeControl } from "@/components/snooze-control";
+import { ThemeControl } from "@/components/theme-control";
 import { UpdateCheckControl } from "@/components/update-check-control";
 import { Switch } from "@/components/ui/switch";
 import { fetchConfig } from "@/lib/api";
@@ -59,6 +60,8 @@ export function SettingsRoute() {
         <Button
           variant="ghost"
           size="icon"
+          // size="icon" is 36px; the header's other controls are 44px since the tap-target pass.
+          className="size-11"
           onClick={() => navigate(homePath(session))}
           aria-label="Back"
         >
@@ -68,6 +71,10 @@ export function SettingsRoute() {
       </header>
 
       <main className="flex min-h-0 flex-1 flex-col space-y-4 overflow-y-auto p-4">
+        {/* First: it's the setting people come here to change, and below the notification stack it
+            sat off-screen on a phone, a scroll into a 1240px page. */}
+        <ThemeControl />
+
         <Card className="gap-0 py-0">
           <div className="flex items-center justify-between gap-4 p-4">
             <div className="flex min-w-0 items-start gap-3">

--- a/web/src/routes/space.tsx
+++ b/web/src/routes/space.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { useNavigate, useParams, useRevalidator, useRouteLoaderData } from "react-router";
 
 import { AppHeader, SettingsGear } from "@/components/app-header";
+import { ThemeToggle } from "@/components/theme-control";
 import { ReadOnlyBanner } from "@/components/read-only-banner";
 import { SpaceStrip } from "@/components/space-strip";
 import { SpaceView } from "@/components/space-view";
@@ -74,7 +75,12 @@ export function SpaceRoute() {
         stalled={stalled}
         onHome={toDashboard}
         wordmark
-        rightTrail={<SettingsGear session={data.session} />}
+        rightTrail={
+          <>
+            <ThemeToggle />
+            <SettingsGear session={data.session} />
+          </>
+        }
       />
 
       {/* Content region below the header: the viewport-clipped scroller. */}


### PR DESCRIPTION
Collie has been hardcoded to dark since 0.1.0 — `class="dark"` on `<html>`, with a full light token
set sitting unused in `index.css` the whole time. This unpins it, adds a System mode that follows the
OS, and puts a control in two places.

Four commits, each readable on its own:

| | |
|---|---|
| `7a7a13e` | **A pre-existing bug**, split out — the space and tab chip rows painted over each other |
| `513d368` | The feature |
| `bb1f087` | ADR 0002 + the CLAUDE.md rule that links to it |
| `26736f1` | Release 0.18.0 |

### The interesting decision

The design originally gave the mirror a light ANSI palette — define `--ansi-0…15` twice, emit
`var(--ansi-N)` from `lib/ansi.ts`, let CSS swap them. Built, tested, and then measured against real
panes:

| pane | truecolor | 256-colour | basic | bright |
|---|---|---|---|---|
| w2Z:p1 | 446 | 7 | 0 | 0 |
| wJ:p1 | 150 | 6 | 0 | 0 |
| w14:p1 | 461 | 6 | 0 | 0 |
| w18:pD | 109 | 6 | 0 | 0 |

**Zero basic and zero bright ANSI codes.** Claude Code emits truecolor almost exclusively, and
truecolor names an absolute sRGB value — no palette can redirect it. On a white ground, eight of
thirteen distinct colours in a real pane fell below 3:1, including a `●` at **1.0:1** and Monokai's
foreground at 1.07:1.

So the mirror now renders in dark space under every theme and light inverts it with
`invert(1) hue-rotate(180deg)`, which preserves hue well enough to keep syntax highlighting legible.
Sampling rendered pixels, light tracks dark almost exactly — median 6.73 vs 7.46. The reasoning, the
three rules it imposes, and what would justify revisiting it are in
[ADR 0002](.adr/0002-invert-the-light-terminal-mirror.md).

`lib/ansi.ts` still emits `var(--ansi-N)` for indexed colour, and does so via **both** spellings —
`color256()` resolves 0–15 through the same table, so theming `31m` but not `38;5;1` would render the
same logical colour two different ways in one pane.

### Notes for review

- **No CSP change.** The anti-flash script is a same-origin file, which `script-src 'self'` already
  permits. System users get a correct first paint from CSS alone, with no JS at all.
- **One token block, not two.** Verified first that `color-mix()` resolves a `light-dark()` argument,
  since the app-wide `border-border/60` and `outline-ring/50` base rules depend on it.
- **Contrast figures are measured, not modelled** — rasterized through a canvas to resolve
  `oklch()`/`light-dark()`, composited against the real ancestor stack. Three rounds of
  browser-driven UX review across 390/768/1280 × both themes found 13 further defects (an unreadable
  off-switch, half-strength focus rings, every alpha-modified muted text under 3:1); two of those
  were regressions introduced by the previous round's fixes.
- **Known cost, deliberately not fixed:** diffs and inverse-video regions become dark slabs in light.
  Legibility survives; only visual weight inverts. Documented in the ADR — greying it is worse.
- **iOS status bar is unresolved.** `apple-mobile-web-app-status-bar-style: black-translucent` renders
  white glyphs, which will vanish on a light page in an installed PWA. There's no `media` form and no
  runtime API, and switching to `default` changes the layout contract with `viewport-fit=cover`. Needs
  a real device.
- **`26736f1` is droppable.** If you'd rather cut releases yourself, drop the release commit and the
  other three still apply cleanly.

`bun run build` clean; 1064 web tests and 318 root tests pass; `scripts/check-version.sh` ✓ at every
commit on the branch, not just the tip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
