### PR TITLE
feat(scripts): supervise the bridge with launchd on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,8 +137,9 @@ On the **host** (the tailnet node your agents run on):
 | **git** | Clone, and the `update` command. |
 
 Soft dependencies: **Node.js** (the control script uses it to extract your MagicDNS name from
-`tailscale status --json`; without it the banner falls back to the loopback URL) and **`systemd
---user`** (supervises the service; falls back to a `nohup` process without it). You never install JS
+`tailscale status --json`; without it the banner falls back to the loopback URL) and a **service
+supervisor** — `systemd --user` on Linux, **launchd** on macOS (both ship with the OS); a host with
+neither falls back to an unsupervised `nohup` process. You never install JS
 deps by hand — the build runs `bun install` for you; the backend imports only Bun + `node:*`.
 [`web-push`](https://www.npmjs.com/package/web-push) is optional and lazy (see [Web
 Push](#web-push-optional)).
@@ -207,9 +208,11 @@ The `✓` is a real probe — the script connected to the bridge's port and got 
 
 1. **`web/dist`** — the built UI. The bridge serves it from disk at request time, so later UI
    rebuilds go live without a restart.
-2. **A `systemd --user` service named `collie`** — unit file written to
-   `~/.config/systemd/user/collie.service`, enabled and started, auto-restarting on failure.
-   Inspect it with `systemctl --user status collie`. (No usable systemd? A `nohup` process with a
+2. **A supervised user service** — on Linux a `systemd --user` unit named `collie`, written to
+   `~/.config/systemd/user/collie.service`, enabled and started, auto-restarting on failure. Inspect
+   it with `systemctl --user status collie`. On macOS a launchd agent labelled `herdr.collie`, written
+   to `~/Library/LaunchAgents/herdr.collie.plist` and bootstrapped into `gui/$(id -u)`; inspect it
+   with `launchctl print gui/$(id -u)/herdr.collie`. (Neither supervisor? A `nohup` process with a
    pidfile in the config dir instead.)
 3. **A tailnet-only `tailscale serve` mapping** — the script ran `tailscale serve --bg 8787`:
    HTTPS on the host's MagicDNS name, `:443 → 127.0.0.1:8787`. Tailscale terminates TLS (managed
@@ -274,6 +277,12 @@ loginctl enable-linger $USER
 
 The unit is `enable`d, so with lingering it starts at boot with your user manager; the
 `tailscale serve` mapping is persistent (`--bg`) and comes back on its own.
+
+**On macOS there's nothing to enable.** `start` installs a launchd agent
+(`~/Library/LaunchAgents/herdr.collie.plist`) with `RunAtLoad`, so the bridge comes back when you log
+in and launchd restarts it if it exits abnormally. Inspect it with
+`launchctl print gui/$(id -u)/herdr.collie`. It's a *LaunchAgent*, not a daemon, so it starts at
+**login** rather than at boot — a Mac sitting at the login window is not serving Collie.
 
 ## Configure
 
@@ -396,7 +405,8 @@ Pause the bridge without removing anything (a later `start` brings it right back
 scripts/collie-ctl.sh stop      # or: herdr plugin action invoke stop --plugin herdr.collie
 ```
 
-To tear the service down completely — stop + disable it, remove the `systemd --user` unit, and remove
+To tear the service down completely — stop + disable it, remove the service definition (the
+`systemd --user` unit, or the launchd agent plist on macOS), and remove
 Collie's own `tailscale serve` mapping (port-scoped, so other tailnet mappings on the host survive) —
 use `uninstall`. It leaves your `.env` and the checkout untouched:
 
@@ -886,7 +896,9 @@ the proxy forward `Host` unchanged (Variant B, rule 4).
 **Collie is gone after a reboot.** A `systemd --user` unit only runs while you have a session — on a
 headless host enable lingering once (`loginctl enable-linger $USER`) and the `collie` unit (already
 `enable`d) starts at boot with your user manager. The `tailscale serve` mapping persists on its own
-(`--bg`), so lingering is usually the whole fix.
+(`--bg`), so lingering is usually the whole fix. On macOS the launchd agent starts at **login**, so
+check you're actually logged in (not sitting at the login window) and that the agent is loaded:
+`launchctl print gui/$(id -u)/herdr.collie`.
 
 **Phone shows a stale UI after a rebuild.** A PWA's service-worker cache is per-origin, so reaching
 Collie at two origins (a custom domain *and* the raw `host:8787`) gives you two installs, each

--- a/scripts/collie-ctl.sh
+++ b/scripts/collie-ctl.sh
@@ -1,13 +1,18 @@
 #!/usr/bin/env bash
 # Control script for Collie (the Herdr web bridge service). Invoked by the plugin's actions and usable directly.
-# The bridge runs as a systemd --user service (NOT a Herdr plugin pane — see ARCHITECTURE.md §3), so it
-# survives Herdr restarts and is supervised independently.
+# The bridge runs as a supervised user service — `systemd --user` on Linux, a launchd LaunchAgent on
+# macOS (NOT a Herdr plugin pane — see ARCHITECTURE.md §3), so it survives Herdr restarts, starts at
+# login and restarts on failure. Hosts with neither fall back to an unsupervised nohup + pidfile.
 set -euo pipefail
 
 PLUGIN_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 UNIT="collie"
 UNIT_FILE="${HOME}/.config/systemd/user/${UNIT}.service"
 PLUGIN_ID="herdr.collie"
+# macOS: launchd's stand-in for the systemd unit. Label is the plugin id, so `launchctl print` names
+# the job as `herdr plugin list` names the plugin.
+AGENT_LABEL="$PLUGIN_ID"
+AGENT_FILE="${HOME}/Library/LaunchAgents/${AGENT_LABEL}.plist"
 
 # Resolve the plugin config dir (where .env lives) the SAME way no matter how we're launched.
 # Herdr injects HERDR_PLUGIN_CONFIG_DIR when it runs our actions, but a direct `collie-ctl.sh` call
@@ -93,6 +98,39 @@ esac
 WEB_DIST="${PLUGIN_ROOT}/web/dist/index.html"
 
 have_systemd() { command -v systemctl >/dev/null && systemctl --user show-environment >/dev/null 2>&1; }
+
+# launchd does systemd's job here. Gate on Darwin too: the `gui/<uid>` domain is Darwin-only.
+have_launchd() { [ "$(uname -s)" = "Darwin" ] && command -v launchctl >/dev/null 2>&1; }
+launchd_domain() { echo "gui/$(id -u)"; }
+launchd_target() { echo "gui/$(id -u)/${AGENT_LABEL}"; }
+
+# Stop a bridge started by the unsupervised fallback and drop its pidfile. Also the migration path for
+# macOS installs predating launchd support, whose bridge still owns the port when the updated script
+# first bootstraps an agent.
+stop_pidfile_process() {
+  local pid_file="${CONFIG_DIR}/collie.pid" pid
+  [ -f "$pid_file" ] || return 0
+  pid="$(cat "$pid_file" 2>/dev/null || true)"
+  case "$pid" in
+    ''|*[!0-9]*) ;;
+    *)
+      if [ "$pid" -gt 1 ] 2>/dev/null; then
+        # The pidfile outlives its process (SIGKILL, a panic, a reboot) and pids get recycled, so
+        # confirm it is still ours — this also runs on `start`, where a wrong guess kills a bystander.
+        case "$(ps -p "$pid" -o command= 2>/dev/null)" in
+          *bridge/index.ts*) kill -- "$pid" 2>/dev/null || true ;;
+        esac
+      fi
+      ;;
+  esac
+  rm -f "$pid_file"
+}
+
+# Escape a value for XML character data — a checkout path containing `&` or `<` would otherwise emit a
+# plist launchd can't parse. `&` first, or it re-escapes the ampersands the later rules introduce.
+xml_escape() {
+  printf '%s' "$1" | sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g'
+}
 
 # Build the Vite/React PWA into web/dist. The bridge serves that directory; without it the API
 # still runs but the UI 503s. Safe to call repeatedly (no-op if already built, unless forced).
@@ -183,6 +221,20 @@ print_status_banner() {
   local svc
   if have_systemd; then
     svc="systemd --user (${UNIT}) · $(systemctl --user is-active "$UNIT" 2>/dev/null || echo unknown)"
+  elif have_launchd; then
+    # `launchctl print` fails when the label isn't loaded; a loaded-but-stopped job has no pid line.
+    local out pid
+    out="$(launchctl print "$(launchd_target)" 2>/dev/null || true)"
+    if [ -z "$out" ]; then
+      svc="launchd (${AGENT_LABEL}) · not loaded"
+    else
+      pid="$(printf '%s\n' "$out" | sed -n 's/^[[:space:]]*pid = \([0-9]*\).*/\1/p' | head -1)"
+      if [ -n "$pid" ]; then
+        svc="launchd (${AGENT_LABEL}) · active (pid ${pid})"
+      else
+        svc="launchd (${AGENT_LABEL}) · loaded, not running"
+      fi
+    fi
   elif [ -f "${CONFIG_DIR}/collie.pid" ]; then
     svc="pid $(cat "${CONFIG_DIR}/collie.pid" 2>/dev/null) (no systemd)"
   else
@@ -241,12 +293,91 @@ EOF
   systemctl --user daemon-reload
 }
 
+# The launchd counterpart to write_unit(), kept parallel so both describe one service:
+#   WantedBy=default.target -> RunAtLoad          Restart=on-failure -> KeepAlive/SuccessfulExit
+#   RestartSec=5            -> ThrottleInterval   WorkingDirectory   -> WorkingDirectory
+# No analogue: StartLimitIntervalSec (launchd has no start limit), NoNewPrivileges / PrivateTmp — the
+# agent is less confined than the unit. No ProcessType either: Background throttles CPU and I/O, and
+# the bridge answers a phone.
+#
+# Paths only, never config values — .env is mode 600 and may hold COLLIE_VAPID_PRIVATE, so
+# `_exec-bridge` sources it at launch rather than baking it into a readable plist.
+# HERDR_PLUGIN_CONFIG_DIR is passed because resolve_config_dir() must not shell out to `herdr` at
+# login, before the server is up.
+write_agent() {
+  [ -n "$BUN" ] || { echo "error: bun not found" >&2; exit 1; }
+  mkdir -p "$(dirname "$AGENT_FILE")" "$CONFIG_DIR"
+  local x_root x_ctl x_cfg x_log
+  x_root="$(xml_escape "$PLUGIN_ROOT")"
+  x_ctl="$(xml_escape "${PLUGIN_ROOT}/scripts/collie-ctl.sh")"
+  x_cfg="$(xml_escape "$CONFIG_DIR")"
+  x_log="$(xml_escape "${CONFIG_DIR}/collie.log")"
+  cat > "$AGENT_FILE" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>${AGENT_LABEL}</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>${x_ctl}</string>
+        <string>_exec-bridge</string>
+    </array>
+    <key>WorkingDirectory</key>
+    <string>${x_root}</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HERDR_PLUGIN_CONFIG_DIR</key>
+        <string>${x_cfg}</string>
+    </dict>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <dict>
+        <key>SuccessfulExit</key>
+        <false/>
+    </dict>
+    <key>ThrottleInterval</key>
+    <integer>5</integer>
+    <key>StandardOutPath</key>
+    <string>${x_log}</string>
+    <key>StandardErrorPath</key>
+    <string>${x_log}</string>
+</dict>
+</plist>
+EOF
+  # launchd refuses to bootstrap a world-writable plist, whatever the umask left behind.
+  chmod 644 "$AGENT_FILE"
+}
+
+# The process launchd supervises. `exec` is load-bearing: launchd watches the pid it spawned, so the
+# bridge must replace this shell — otherwise KeepAlive guards a wrapper and a crashed bridge looks
+# alive. .env is already sourced above; these exports mirror the unit's Environment= lines.
+cmd_exec_bridge() {
+  [ -n "$BUN" ] || { echo "error: bun not found on PATH" >&2; exit 1; }
+  export COLLIE_PORT="$PORT"
+  export HERDR_SOCKET_PATH="$SOCKET"
+  export HERDR_PLUGIN_CONFIG_DIR="$CONFIG_DIR"
+  exec "$BUN" run "${PLUGIN_ROOT}/bridge/index.ts"
+}
+
 cmd_start() {
   ensure_build || true
   if have_systemd; then
     write_unit
     systemctl --user enable --now "$UNIT"
     echo "bridge started (systemd --user: ${UNIT})"
+  elif have_launchd; then
+    write_agent
+    stop_pidfile_process   # release the port if this install predates launchd support
+    # Bootout first so `start` is idempotent: bootstrap on a loaded label errors, and quietly running a
+    # second bridge is the failure this branch removes. `enable` undoes a previous `stop`.
+    launchctl bootout "$(launchd_target)" 2>/dev/null || true
+    launchctl enable "$(launchd_target)" 2>/dev/null || true
+    launchctl bootstrap "$(launchd_domain)" "$AGENT_FILE"
+    echo "bridge started (launchd: ${AGENT_LABEL})"
   else
     # Fallback: background process with a pidfile (e.g. macOS without lingering systemd).
     mkdir -p "$CONFIG_DIR"
@@ -266,17 +397,22 @@ cmd_start() {
 cmd_stop() {
   if have_systemd; then
     systemctl --user disable --now "$UNIT" 2>/dev/null || true
-  elif [ -f "${CONFIG_DIR}/collie.pid" ]; then
-    kill "$(cat "${CONFIG_DIR}/collie.pid")" 2>/dev/null || true
-    rm -f "${CONFIG_DIR}/collie.pid"
+  elif have_launchd; then
+    # bootout stops it now; `disable` is what makes that survive a login, since RunAtLoad would
+    # otherwise bring it back. Together they are systemd's `disable --now`.
+    launchctl disable "$(launchd_target)" 2>/dev/null || true
+    launchctl bootout "$(launchd_target)" 2>/dev/null || true
+    stop_pidfile_process
+  else
+    stop_pidfile_process
   fi
   echo "bridge stopped"
 }
 
 cmd_restart() { cmd_stop; cmd_start; }
 
-# Tear the service down completely (the inverse of `start`): stop + disable it, remove the
-# systemd --user unit, remove Collie's tailscale serve mapping, and drop the pidfile. Deliberately leaves your
+# Tear the service down completely (the inverse of `start`): stop + disable it, remove the service
+# definition, remove Collie's tailscale serve mapping, and drop the pidfile. Deliberately leaves your
 # config (${CONFIG_DIR}/.env) and the on-disk checkout in place — `uninstall` removes only what
 # `start` created. To remove the plugin registration too, run `herdr plugin uninstall herdr.collie`
 # (or, for a linked clone, just delete the checkout).
@@ -287,9 +423,15 @@ cmd_uninstall() {
     rm -f "$UNIT_FILE"
     systemctl --user daemon-reload 2>/dev/null || true
     systemctl --user reset-failed "$UNIT" 2>/dev/null || true
+  elif have_launchd; then
+    # Plist first: while it is on disk an enabled label is one login from loading again.
+    rm -f "$AGENT_FILE"
+    # cmd_stop's `disable` is a record in launchd's per-user database and outlives the plist, so clear
+    # it or a reinstall inherits a disabled label. `enable` resets that state; it can't delete the row.
+    launchctl enable "$(launchd_target)" 2>/dev/null || true
   fi
   rm -f "${CONFIG_DIR}/collie.pid"
-  echo "✓ uninstalled: service stopped & disabled, systemd unit removed, Collie's tailscale serve mapping removed"
+  echo "✓ uninstalled: service stopped & disabled, service definition removed, Collie's tailscale serve mapping removed"
   echo "  kept: ${CONFIG_DIR}/.env and the checkout — delete those to remove every trace"
 }
 
@@ -632,6 +774,7 @@ case "${1:-}" in
   uninstall) cmd_uninstall ;;
   update)  cmd_update ;;
   _apply-update) cmd_apply_update ;;  # internal: second half of `update`, run post-pull
+  _exec-bridge) cmd_exec_bridge ;;    # internal: the process the launchd agent supervises
   build)   cmd_build ;;
   serve)   cmd_serve; echo "open: $(bridge_url)" ;;
   unserve) cmd_unserve ;;

--- a/scripts/collie-ctl.sh
+++ b/scripts/collie-ctl.sh
@@ -371,15 +371,34 @@ cmd_start() {
     echo "bridge started (systemd --user: ${UNIT})"
   elif have_launchd; then
     write_agent
-    stop_pidfile_process   # release the port if this install predates launchd support
+    # Release the port if this install predates launchd support. The old bridge drains async, so the
+    # new one can still lose a race for the port — it exits nonzero and KeepAlive brings it back
+    # after ThrottleInterval, so the migration self-heals; `start` may just warn once on the way.
+    stop_pidfile_process
     # Bootout first so `start` is idempotent: bootstrap on a loaded label errors, and quietly running a
     # second bridge is the failure this branch removes. `enable` undoes a previous `stop`.
     launchctl bootout "$(launchd_target)" 2>/dev/null || true
     launchctl enable "$(launchd_target)" 2>/dev/null || true
-    launchctl bootstrap "$(launchd_domain)" "$AGENT_FILE"
+    # `bootout` does not promise to wait for teardown, and the bridge drains connections before it
+    # exits — bootstrapping into that window fails with "Bootstrap failed: 5: Input/output error",
+    # and under set -e that ends `start` with the bridge DOWN: the outage this branch exists to
+    # remove, on the path (`restart`, and so `update`) an operator hits most. Retry across the
+    # window. A real refusal still surfaces — EIO is also what launchd returns when `gui/<uid>`
+    # doesn't exist at all, which is why the give-up message names that case.
+    local attempt
+    for attempt in 1 2 3; do
+      if launchctl bootstrap "$(launchd_domain)" "$AGENT_FILE"; then break; fi
+      if [ "$attempt" -eq 3 ]; then
+        echo "error: launchctl bootstrap failed — if this Mac has no console login, gui/$(id -u)" >&2
+        echo "       does not exist; log in once (the agent has RunAtLoad and comes up with it)." >&2
+        exit 1
+      fi
+      sleep 1
+    done
     echo "bridge started (launchd: ${AGENT_LABEL})"
   else
-    # Fallback: background process with a pidfile (e.g. macOS without lingering systemd).
+    # Fallback for a host with neither supervisor (macOS now takes the launchd branch above, so in
+    # practice: a Linux box with no user systemd instance, or a BSD): background process + pidfile.
     mkdir -p "$CONFIG_DIR"
     [ -n "$BUN" ] || { echo "error: bun not found" >&2; exit 1; }
     HERDR_SOCKET_PATH="$SOCKET" COLLIE_PORT="$PORT" HERDR_PLUGIN_CONFIG_DIR="$CONFIG_DIR" \

--- a/scripts/collie-ctl.test.sh
+++ b/scripts/collie-ctl.test.sh
@@ -39,6 +39,16 @@ setup_case() {
 exit 1
 EOF
   chmod +x "${BIN_DIR}/systemctl"
+  # A fake `launchctl` shadowing the real one on the scratch PATH. Without this a macOS run of this
+  # suite would bootstrap a job into the developer's own gui/<uid> domain — pointed at a temp dir the
+  # suite then deletes, so it crash-loops after the test "passes". Records argv for assertions.
+  LAUNCHCTL_CALLS="${CASE_DIR}/launchctl.calls"
+  cat > "${BIN_DIR}/launchctl" <<EOF
+#!/bin/sh
+echo "\$@" >> "$LAUNCHCTL_CALLS"
+exit 0
+EOF
+  chmod +x "${BIN_DIR}/launchctl"
 }
 
 run_ctl() {
@@ -311,6 +321,7 @@ export PATH="$BIN_DIR:$BASE_PATH"
 source "$CTL"
 ensure_build() { return 0; }
 have_systemd() { return 1; }
+have_launchd() { return 1; }   # pin the unsupervised nohup fallback, which is what this asserts
 BUN=/bin/true
 cmd_serve() { echo "error: simulated serve failure" >&2; return 1; }
 print_status_banner() { echo "BANNER"; }
@@ -319,6 +330,160 @@ EOF
   bash "$harness" > "${CASE_DIR}/start.out" 2>&1 ||
     fail "a failing cmd_serve aborted cmd_start"
   assert_contains "$(cat "${CASE_DIR}/start.out")" 'BANNER'
+}
+
+# macOS parity: `start` installs and bootstraps a launchd agent instead of falling through to the
+# unsupervised nohup path, `stop` boots it out, and `uninstall` removes the plist.
+#
+# The load-bearing assertion is the negative one. launchd has no `EnvironmentFile=`, so the obvious
+# port bakes the sourced .env into the plist's EnvironmentVariables — but .env is mode 600 and may hold
+# COLLIE_VAPID_PRIVATE while the plist has to stay readable, so that would copy a Web Push signing key
+# into a readable file. The seeded secret must appear nowhere in the plist.
+#
+# `have_launchd` is stubbed rather than left to `uname`: CI runs ubuntu-latest, where it is false, and
+# a test that silently skips the branch it exists to cover is worse than no test.
+test_launchd_agent_lifecycle() {
+  setup_case launchd-agent
+  cat > "${CONFIG_DIR}/.env" <<'EOF'
+COLLIE_PORT=8787
+COLLIE_VAPID_PRIVATE=super-secret-signing-key
+EOF
+  local plist="${HOME_DIR}/Library/LaunchAgents/herdr.collie.plist"
+  local kill_calls="${CASE_DIR}/kill.calls"
+  printf '4242\n' > "${CONFIG_DIR}/collie.pid"
+
+  local harness="${CASE_DIR}/start-stop.sh"
+  cat > "$harness" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+export HOME="$HOME_DIR"
+export HERDR_PLUGIN_CONFIG_DIR="$CONFIG_DIR"
+export PATH="$BIN_DIR:$BASE_PATH"
+source "$CTL"
+ensure_build() { return 0; }
+have_systemd() { return 1; }
+have_launchd() { return 0; }
+BUN=/bin/true
+cmd_serve() { return 0; }
+print_status_banner() { echo "BANNER"; }
+kill() { printf '%s\n' "\$*" >> "$kill_calls"; }
+# Stand in for the process table: 4242 is still our bridge, 4243 is whatever recycled that pid.
+ps() {
+  case " \$* " in
+    *" 4242 "*) echo "/opt/homebrew/bin/bun run /x/bridge/index.ts" ;;
+    *" 4243 "*) echo "/Applications/Something.app/Contents/MacOS/Something" ;;
+  esac
+}
+cmd_start
+cmd_stop
+# A pid the OS has recycled to an unrelated process must NOT be signalled — but the stale record
+# still has to go, or it would be re-examined on every future start.
+printf '4243\n' > "${CONFIG_DIR}/collie.pid"
+stop_pidfile_process
+[ -e "${CONFIG_DIR}/collie.pid" ] && exit 81
+# Invalid pidfile contents are removed but must never reach the kill builtin.
+printf '%s\n' 'not-a-pid' > "${CONFIG_DIR}/collie.pid"
+stop_pidfile_process
+EOF
+  bash "$harness" > "${CASE_DIR}/launchd.out" 2>&1 ||
+    fail "cmd_start/cmd_stop failed on the launchd path"
+
+  [ -f "$plist" ] || fail "start did not write a LaunchAgent plist"
+  [ ! -e "${CONFIG_DIR}/collie.pid" ] || fail "launchd migration left the legacy pidfile behind"
+  # Exactly one signal, to the pid that was still the bridge. 4243 (recycled to something else) and
+  # the malformed record must not appear — a stale pidfile must not kill an unrelated process.
+  assert_eq "$(cat "$kill_calls")" '-- 4242'
+  local body; body="$(cat "$plist")"
+  assert_contains "$body" '<string>_exec-bridge</string>'
+  assert_contains "$body" '<key>RunAtLoad</key>'
+  assert_contains "$body" '<key>SuccessfulExit</key>'
+  assert_contains "$body" "<string>${CONFIG_DIR}</string>"
+  case "$body" in
+    *super-secret-signing-key*)
+      fail "the plist leaked a .env value — secrets must stay in the mode-600 .env" ;;
+  esac
+
+  # Structural validity, where the tooling exists. A plist launchd cannot parse means the agent
+  # silently never starts, and none of the substring assertions above would notice. `plutil` is
+  # macOS-only, so this no-ops on the ubuntu CI runner and covers every macOS dev machine.
+  if command -v plutil >/dev/null 2>&1; then
+    plutil -lint "$plist" >/dev/null || fail "the generated plist is not a valid property list"
+  fi
+
+  local calls; calls="$(cat "$LAUNCHCTL_CALLS")"
+  assert_contains "$calls" "bootstrap gui/$(id -u) ${plist}"
+  assert_contains "$calls" "bootout gui/$(id -u)/herdr.collie"
+  assert_contains "$calls" "disable gui/$(id -u)/herdr.collie"
+
+  # `start` must be idempotent: bootstrap on an already-loaded label errors, so it boots out first.
+  assert_eq "$(grep -c '^bootout ' <<<"$calls")" 2
+
+  # Truncate first: `start` already recorded an `enable`, so asserting on the whole log would pass
+  # whether or not `uninstall` clears the override itself.
+  : > "$LAUNCHCTL_CALLS"
+
+  local teardown="${CASE_DIR}/uninstall.sh"
+  cat > "$teardown" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+export HOME="$HOME_DIR"
+export HERDR_PLUGIN_CONFIG_DIR="$CONFIG_DIR"
+export PATH="$BIN_DIR:$BASE_PATH"
+source "$CTL"
+have_systemd() { return 1; }
+have_launchd() { return 0; }
+cmd_unserve() { return 0; }
+cmd_uninstall
+EOF
+  bash "$teardown" > "${CASE_DIR}/uninstall.out" 2>&1 || fail "cmd_uninstall failed on the launchd path"
+  [ ! -f "$plist" ] || fail "uninstall left the LaunchAgent plist behind"
+  # The `disable` cmd_stop wrote outlives the plist, so uninstall must clear it — otherwise a later
+  # reinstall inherits a disabled label whose `start` only recovers by re-enabling.
+  local teardown_calls; teardown_calls="$(cat "$LAUNCHCTL_CALLS")"
+  assert_contains "$teardown_calls" "enable gui/$(id -u)/herdr.collie"
+  assert_eq "$(grep -c '^enable ' <<<"$teardown_calls")" 1
+}
+
+# The banner's launchd line, which is what `status` actually shows an operator. Split out because the
+# lifecycle test stubs print_status_banner, so nothing there reads this — a first cut printed the pid
+# twice ("active (pid 123)123") and every lifecycle assertion still passed.
+test_launchd_status_line() {
+  setup_case launchd-status
+  local harness="${CASE_DIR}/status.sh"
+  cat > "$harness" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+export HOME="$HOME_DIR"
+export HERDR_PLUGIN_CONFIG_DIR="$CONFIG_DIR"
+export PATH="$BIN_DIR:$BASE_PATH"
+source "$CTL"
+have_systemd() { return 1; }
+have_launchd() { return 0; }
+bridge_ready() { return 0; }
+collie_version() { echo "test"; }
+bridge_url() { echo "https://host.example"; }
+
+# Loaded and running: launchd prints a pid line.
+launchctl() { [ "\$1" = print ] && printf '\tstate = running\n\tpid = 4242\n' || return 0; }
+print_status_banner
+
+# Loaded but not running: same output minus the pid.
+launchctl() { [ "\$1" = print ] && printf '\tstate = waiting\n' || return 0; }
+print_status_banner
+
+# Not loaded at all: \`launchctl print\` fails.
+launchctl() { [ "\$1" = print ] && return 1 || return 0; }
+print_status_banner
+EOF
+  bash "$harness" > "${CASE_DIR}/status.out" 2>&1 || fail "print_status_banner failed on the launchd path"
+  local out; out="$(cat "${CASE_DIR}/status.out")"
+  assert_contains "$out" 'launchd (herdr.collie) · active (pid 4242)'
+  assert_contains "$out" 'launchd (herdr.collie) · loaded, not running'
+  assert_contains "$out" 'launchd (herdr.collie) · not loaded'
+  # The pid must appear exactly once on its line — not "active (pid 4242)4242".
+  case "$out" in
+    *'4242)4242'*) fail "banner printed the pid twice" ;;
+  esac
 }
 
 # A bun that reports only how it was found: its own path, and the PATH it inherited.
@@ -415,6 +580,8 @@ test_missing_tailscale_cli
 test_state_delete_failures
 test_adopts_preexisting_collie_mount
 test_serve_failure_does_not_abort_start
+test_launchd_agent_lifecycle
+test_launchd_status_line
 test_bun_resolution
 test_non_absolute_bun_never_reaches_path
 test_missing_bun_still_reports

--- a/scripts/collie-ctl.test.sh
+++ b/scripts/collie-ctl.test.sh
@@ -486,6 +486,66 @@ EOF
   esac
 }
 
+# `bootout` doesn't promise to wait for the job to finish tearing down, and the bridge drains
+# connections on SIGTERM — so `restart` (and therefore `update`) can reach `bootstrap` while the old
+# job is still going, which launchd answers with "Bootstrap failed: 5: Input/output error". Unretried
+# under set -e that leaves the bridge DOWN, which is the outage the whole launchd branch removes.
+# `sleep` is stubbed out, so this asserts the retry without paying for it.
+test_launchd_bootstrap_retries() {
+  setup_case launchd-bootstrap-retry
+  # A launchctl whose `bootstrap` fails until it has been called more than $1 times.
+  install_flaky_launchctl() {
+    cat > "${BIN_DIR}/launchctl" <<EOF
+#!/bin/sh
+echo "\$@" >> "$LAUNCHCTL_CALLS"
+[ "\$1" = bootstrap ] || exit 0
+n=\$(cat "${CASE_DIR}/bootstrap.count" 2>/dev/null || echo 0)
+n=\$((n + 1)); echo "\$n" > "${CASE_DIR}/bootstrap.count"
+[ "\$n" -gt $1 ] && exit 0
+echo "Bootstrap failed: 5: Input/output error" >&2
+exit 5
+EOF
+    chmod +x "${BIN_DIR}/launchctl"
+    rm -f "${CASE_DIR}/bootstrap.count" "$LAUNCHCTL_CALLS"
+  }
+
+  local harness="${CASE_DIR}/retry.sh"
+  cat > "$harness" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+export HOME="$HOME_DIR"
+export HERDR_PLUGIN_CONFIG_DIR="$CONFIG_DIR"
+export PATH="$BIN_DIR:$BASE_PATH"
+source "$CTL"
+ensure_build() { return 0; }
+have_systemd() { return 1; }
+have_launchd() { return 0; }
+BUN=/bin/true
+sleep() { :; }   # the backoff is the point; waiting for it is not
+cmd_serve() { return 0; }
+print_status_banner() { echo "BANNER"; }
+cmd_start
+EOF
+
+  # Transient: the window closes on the second try, and `start` reports success like any other.
+  install_flaky_launchctl 1
+  bash "$harness" > "${CASE_DIR}/retry.out" 2>&1 || fail "start gave up on a transient bootstrap failure"
+  assert_contains "$(cat "${CASE_DIR}/retry.out")" 'bridge started (launchd: herdr.collie)'
+  assert_eq "$(grep -c '^bootstrap ' "$LAUNCHCTL_CALLS")" 2
+
+  # Permanent: EIO is also how launchd reports "gui/<uid> doesn't exist" on a Mac with no console
+  # login. Three tries, then fail loudly — a `start` that silently left nothing running would be
+  # worse than the crash.
+  install_flaky_launchctl 99
+  if bash "$harness" > "${CASE_DIR}/retry-fail.out" 2>&1; then
+    fail "start reported success though bootstrap never succeeded"
+  fi
+  local out; out="$(cat "${CASE_DIR}/retry-fail.out")"
+  assert_contains "$out" 'error: launchctl bootstrap failed'
+  assert_contains "$out" 'no console login'
+  assert_eq "$(grep -c '^bootstrap ' "$LAUNCHCTL_CALLS")" 3
+}
+
 # A bun that reports only how it was found: its own path, and the PATH it inherited.
 install_fake_bun() {
   local target="$1" calls="$2"
@@ -582,6 +642,7 @@ test_adopts_preexisting_collie_mount
 test_serve_failure_does_not_abort_start
 test_launchd_agent_lifecycle
 test_launchd_status_line
+test_launchd_bootstrap_retries
 test_bun_resolution
 test_non_absolute_bun_never_reaches_path
 test_missing_bun_still_reports


### PR DESCRIPTION
Closes #55.

**Adds a launchd LaunchAgent on macOS**, so the bridge starts at login and restarts on failure —
parity with the `systemd --user` unit. `have_systemd()` is false there, so `start` fell through to an
unsupervised `nohup` process.

`start` / `stop` / `uninstall` / `status` branch systemd → launchd → nohup. `write_agent()` mirrors
`write_unit()`.

**Tests:** every case now gets a fake `launchctl` on the scratch PATH — without it a macOS run
bootstrapped a real job into your own `gui/<uid>` domain. `have_launchd` is stubbed rather than
detected, since CI is ubuntu-latest.

Verified on macOS 26.5.2.
