### PR TITLE
feat: add OMP and Firstmate dashboard support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,6 +44,18 @@ COLLIE_SUBMIT_KEYS=Enter
 # discovery, identical to the pre-multi-session behaviour.
 # COLLIE_MULTI_SESSION=on
 
+# --- Agent history and Firstmate (optional) ---
+# OMP history is discovered under ~/.omp/agent/sessions by default.
+# COLLIE_OMP_ROOT=/home/you/.omp/agent/sessions
+#
+# Enable the semantic Firstmate dashboard by pointing at its operational home. The bridge resolves
+# this directory once at startup and runs only its executable bin/fm-bearings-snapshot.sh.
+# COLLIE_FIRSTMATE_HOME=/home/you/workspace/firstmate
+# COLLIE_FIRSTMATE_REFRESH_MS=30000
+# Live GitHub PR/check enrichment is off by default. Enabling it uses Firstmate's bounded gh queries.
+# COLLIE_FIRSTMATE_INCLUDE_PRS=off
+# COLLIE_FIRSTMATE_PR_REFRESH_MS=120000
+
 # --- Security ---
 # If set, requests must carry a matching Tailscale-User-Login header (from `tailscale serve`).
 # COLLIE_TRUSTED_USER=you@example.com

--- a/README.md
+++ b/README.md
@@ -300,6 +300,24 @@ The bridge reads `.env` only at startup — after any edit, `scripts/collie-ctl.
 `COLLIE_SERVE_MODE=http` (Headscale / `.internal` domains; read by the control script when it runs
 `tailscale serve`).
 
+### OMP history and Firstmate
+
+OMP panes get conversation history automatically from `~/.omp/agent/sessions`. Set
+`COLLIE_OMP_ROOT` only when OMP stores sessions elsewhere.
+
+The semantic Firstmate dashboard is opt-in:
+
+```bash
+COLLIE_FIRSTMATE_HOME=/home/you/workspace/firstmate
+COLLIE_FIRSTMATE_INCLUDE_PRS=off
+```
+
+`COLLIE_FIRSTMATE_HOME` must be an existing absolute directory containing the executable
+`bin/fm-bearings-snapshot.sh`. Collie runs that fixed read-only snapshot command, keeps task text,
+decisions, gates, delivery state and verified live Herdr endpoints, and withholds Firstmate paths and
+actions from the browser. Set `COLLIE_FIRSTMATE_INCLUDE_PRS=on` to add bounded live GitHub PR/check
+enrichment. Restart Collie after changing either setting.
+
 **Custom domain or reverse proxy?** See
 [Variant C](#variant-c--reverse-proxy-as-the-only-front-door-no-tailscale) for the full reverse-proxy
 front-door setup. The one rule to know here: Collie is same-origin only. A plain `tailscale serve` on

--- a/bridge/config.test.ts
+++ b/bridge/config.test.ts
@@ -1,4 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, realpathSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { defaultSocketPath, loadConfig } from "./config.ts";
@@ -16,6 +18,7 @@ const KEYS = [
   "COLLIE_TRANSCRIPT",
   "COLLIE_TRANSCRIPT_ROOT",
   "COLLIE_CODEX_ROOT",
+  "COLLIE_OMP_ROOT",
   "COLLIE_PI_ROOT",
   // Each harness's own home var participates in journal-root resolution, so the suite must own them
   // too — otherwise a developer with CODEX_HOME set gets different results than CI.
@@ -33,12 +36,17 @@ const KEYS = [
   "COLLIE_STATE_DIR",
   "COLLIE_MULTI_SESSION",
   "COLLIE_SKIP_SERVE",
+  "COLLIE_FIRSTMATE_HOME",
+  "COLLIE_FIRSTMATE_REFRESH_MS",
+  "COLLIE_FIRSTMATE_INCLUDE_PRS",
+  "COLLIE_FIRSTMATE_PR_REFRESH_MS",
   "HERDR_SOCKET_PATH",
   "HERDR_PLUGIN_STATE_DIR",
   "COLLIE_HERDR_DIAL",
 ];
 
 let saved: Record<string, string | undefined>;
+const tempDirs: string[] = [];
 
 beforeEach(() => {
   saved = {};
@@ -54,6 +62,7 @@ afterEach(() => {
     if (v === undefined) delete process.env[k];
     else process.env[k] = v;
   }
+  while (tempDirs.length) rmSync(tempDirs.pop()!, { recursive: true, force: true });
 });
 
 describe("loadConfig", () => {
@@ -67,6 +76,7 @@ describe("loadConfig", () => {
     // Transcript history defaults ON — it's the only scrollback a Claude pane can ever have.
     expect(cfg.transcript).toBe(true);
     expect(cfg.journalRoots.claude).toEndWith("/.claude/projects");
+    expect(cfg.journalRoots.omp).toEndWith("/.omp/agent/sessions");
     expect(cfg.submitKeys).toEqual(["Enter"]);
     expect(cfg.trustedUser).toBe("");
     expect(cfg.allowedOrigins).toEqual([]);
@@ -148,10 +158,13 @@ describe("loadConfig", () => {
     expect(cfg.journalRoots.pi).toBe("/srv/pi/sessions");
   });
 
-  test("an explicit COLLIE_* root beats the harness's home var", () => {
+  test("explicit COLLIE_* roots override harness defaults and home vars", () => {
     process.env.CODEX_HOME = "/srv/codex";
     process.env.COLLIE_CODEX_ROOT = "/elsewhere/rollouts";
-    expect(loadConfig().journalRoots.codex).toBe("/elsewhere/rollouts");
+    process.env.COLLIE_OMP_ROOT = "/srv/omp/sessions";
+    const cfg = loadConfig();
+    expect(cfg.journalRoots.codex).toBe("/elsewhere/rollouts");
+    expect(cfg.journalRoots.omp).toBe("/srv/omp/sessions");
   });
 
   test("reads the per-device auth header and allowlist", () => {
@@ -239,6 +252,35 @@ describe("loadConfig", () => {
     process.env.COLLIE_HERDR_DIAL = "carrier-pigeon";
     expect(loadConfig().dialMode).toBe("auto");
   });
+  test("keeps Firstmate omitted by default and resolves its independent refresh settings", () => {
+    expect(loadConfig()).toMatchObject({
+      firstmateHome: "",
+      firstmateRefreshMs: 30_000,
+      firstmateIncludePrs: false,
+      firstmatePrRefreshMs: 120_000,
+    });
+
+    const home = mkdtempSync(join(tmpdir(), "collie-firstmate-"));
+    tempDirs.push(home);
+    process.env.COLLIE_FIRSTMATE_HOME = home;
+    process.env.COLLIE_FIRSTMATE_REFRESH_MS = "45000";
+    process.env.COLLIE_FIRSTMATE_INCLUDE_PRS = "yes";
+    process.env.COLLIE_FIRSTMATE_PR_REFRESH_MS = "180000";
+    expect(loadConfig()).toMatchObject({
+      firstmateHome: realpathSync(home),
+      firstmateRefreshMs: 45_000,
+      firstmateIncludePrs: true,
+      firstmatePrRefreshMs: 180_000,
+    });
+  });
+
+  test("rejects a relative or missing Firstmate home at startup", () => {
+    process.env.COLLIE_FIRSTMATE_HOME = "relative/firstmate";
+    expect(loadConfig().firstmateHome).toBe("");
+    process.env.COLLIE_FIRSTMATE_HOME = join(tmpdir(), "collie-firstmate-does-not-exist");
+    expect(loadConfig().firstmateHome).toBe("");
+  });
+
 });
 
 // Pure — both platform branches are testable from any host (expectations use join() so the

--- a/bridge/config.ts
+++ b/bridge/config.ts
@@ -1,5 +1,6 @@
+import { realpathSync, statSync } from "node:fs";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { isAbsolute, join } from "node:path";
 
 import type { DialMode } from "./dial.ts";
 import type { JournalRoots } from "./journal/registry.ts";
@@ -69,6 +70,23 @@ function envBool(name: string, fallback: boolean): boolean {
   if (["on", "1", "true", "yes"].includes(v)) return true;
   console.warn(`[config] ${name}="${raw}" is not a boolean — using default ${fallback}`);
   return fallback;
+}
+
+function trustedHome(name: string): string {
+  const raw = (process.env[name] ?? "").trim();
+  if (!raw) return "";
+  if (!isAbsolute(raw)) {
+    console.warn(`[config] ${name} must be an absolute path — disabling Firstmate`);
+    return "";
+  }
+  try {
+    const resolved = realpathSync(raw);
+    if (!statSync(resolved).isDirectory()) throw new Error("not a directory");
+    return resolved;
+  } catch {
+    console.warn(`[config] ${name} does not resolve to an existing directory — disabling Firstmate`);
+    return "";
+  }
 }
 
 export interface Config {
@@ -177,6 +195,14 @@ export interface Config {
    * and per-device auth ({@link deviceHeader}) becomes the way to gate writes (README → Variant C).
    */
   skipServe: boolean;
+  /** Trusted, startup-resolved Firstmate home. Empty disables the optional dashboard. */
+  firstmateHome: string;
+  /** Local bearings refresh cadence. */
+  firstmateRefreshMs: number;
+  /** Whether live GitHub PR enrichment is enabled. */
+  firstmateIncludePrs: boolean;
+  /** Separate live PR refresh cadence. */
+  firstmatePrRefreshMs: number;
 }
 
 /**
@@ -223,6 +249,7 @@ export function loadConfig(): Config {
       codex:
         process.env.COLLIE_CODEX_ROOT ??
         join(process.env.CODEX_HOME ?? join(homedir(), ".codex"), "sessions"),
+      omp: process.env.COLLIE_OMP_ROOT ?? join(homedir(), ".omp", "agent", "sessions"),
       pi:
         process.env.COLLIE_PI_ROOT ??
         join(process.env.PI_CODING_AGENT_DIR ?? join(homedir(), ".pi", "agent"), "sessions"),
@@ -239,5 +266,9 @@ export function loadConfig(): Config {
     stateDir,
     multiSession: envBool("COLLIE_MULTI_SESSION", true),
     skipServe: envBool("COLLIE_SKIP_SERVE", false),
+    firstmateHome: trustedHome("COLLIE_FIRSTMATE_HOME"),
+    firstmateRefreshMs: envInt("COLLIE_FIRSTMATE_REFRESH_MS", 30_000, { min: 1000 }),
+    firstmateIncludePrs: envBool("COLLIE_FIRSTMATE_INCLUDE_PRS", false),
+    firstmatePrRefreshMs: envInt("COLLIE_FIRSTMATE_PR_REFRESH_MS", 120_000, { min: 1000 }),
   };
 }

--- a/bridge/firstmate.test.ts
+++ b/bridge/firstmate.test.ts
@@ -108,6 +108,23 @@ describe("bearings normalization", () => {
     expect(JSON.stringify(normalized)).not.toContain("artifact");
   });
 
+  test("redacts absolute paths from every allowlisted display field", () => {
+    const normalized = normalizeBearings(bearings({
+      in_flight: [{ id: "TRA-1", kind: "task", state: "working", doing: "Inspect /Users/alice/private/run.sh" }],
+      decisions_open: [{ id: "TRA-2", summary: "Choose path=/private/tmp/decision", owner: "(main)" }],
+      gates: [{ id: "TRA-3", title: "Waiting on C:\\Users\\alice\\gate", blocked_by: "TRA-2", reason: "read ~/secret", owner: "(main)" }],
+      landed: [{ id: "TRA-4", what: "Delivered /home/alice/output", owner: "(main)" }],
+      prs: "checked /var/tmp/result",
+      candidate_prs: [{ num: "42", repo: "owner/repo", task: "TRA-1", url: "https://github.com/owner/repo/pull/42", review: "read /opt/review", mergeable: "MERGEABLE", checks: "passing" }],
+    }), true);
+
+    const output = JSON.stringify(normalized);
+    expect(output).toContain("[path]");
+    for (const leaked of ["/Users/alice", "/private/tmp", "C:\\Users\\alice", "~/secret", "/home/alice", "/var/tmp", "/opt/review"]) {
+      expect(output).not.toContain(leaked);
+    }
+  });
+
   test("rejects the wrong schema or malformed required rows and caps row counts", () => {
     expect(normalizeBearings(bearings({ schema: "fm-bearings.v2" }), false)).toBeNull();
     expect(normalizeBearings(bearings({ home: "/LEAK_SENTINEL/home" }), false)).toBeNull();
@@ -176,6 +193,7 @@ describe("FirstmateProvider", () => {
     release(bearings());
     await first;
     expect(subject.status()).toMatchObject({ state: "ready", prState: "disabled" });
+    expect(subject.status()).not.toHaveProperty("home");
     await subject.refreshBase();
     expect(subject.status().state).toBe("stale");
     await subject.refreshBase();

--- a/bridge/firstmate.test.ts
+++ b/bridge/firstmate.test.ts
@@ -110,19 +110,47 @@ describe("bearings normalization", () => {
 
   test("redacts absolute paths from every allowlisted display field", () => {
     const normalized = normalizeBearings(bearings({
-      in_flight: [{ id: "TRA-1", kind: "task", state: "working", doing: "Inspect /Users/alice/private/run.sh" }],
-      decisions_open: [{ id: "TRA-2", summary: "Choose path=/private/tmp/decision", owner: "(main)" }],
-      gates: [{ id: "TRA-3", title: "Waiting on C:\\Users\\alice\\gate", blocked_by: "TRA-2", reason: "read ~/secret", owner: "(main)" }],
-      landed: [{ id: "TRA-4", what: "Delivered /home/alice/output", owner: "(main)" }],
+      in_flight: [{ id: "TRA-1", kind: "task", state: "working", doing: "Inspect </Users/alice/.ssh/config> then https://docs.example/path and docs/setup.md" }],
+      decisions_open: [{ id: "TRA-2", summary: "Choose,/private/tmp/decision then inspect./Users/alice/dot", owner: "(main)" }],
+      gates: [{ id: "TRA-3", title: "Waiting,\\\\server\\share and-C:\\Users\\alice\\gate", blocked_by: "TRA-2", reason: "write >/private/tmp/result, read \"/Users/Alice Smith/secret\", and,~/secret", owner: "(main)" }],
+      landed: [{ id: "TRA-4", what: "artifact_/home/alice/output", owner: "(main)" }],
       prs: "checked /var/tmp/result",
-      candidate_prs: [{ num: "42", repo: "owner/repo", task: "TRA-1", url: "https://github.com/owner/repo/pull/42", review: "read /opt/review", mergeable: "MERGEABLE", checks: "passing" }],
+      candidate_prs: [{ num: "42", repo: "owner/repo", task: "TRA-1", url: "https://github.com/owner/repo/pull/42", review: "run&&/opt/review", mergeable: "MERGEABLE", checks: "passing" }],
     }), true);
+    expect(normalized!.inFlight[0]!.doing).toBe("Inspect <[path]");
+    expect(normalized!.gates[0]!.reason).toBe("write >[path]");
 
     const output = JSON.stringify(normalized);
     expect(output).toContain("[path]");
-    for (const leaked of ["/Users/alice", "/private/tmp", "C:\\Users\\alice", "~/secret", "/home/alice", "/var/tmp", "/opt/review"]) {
+    for (const leaked of ["/Users/alice", "/private/tmp", "\\\\server\\share", "C:\\Users\\alice", "/Users/Alice Smith", "Smith/secret", "~/secret", "/home/alice", "/var/tmp", "/opt/review"]) {
       expect(output).not.toContain(leaked);
     }
+
+    const unquotedSpaces = normalizeBearings(bearings({
+      in_flight: [{ id: "TRA-1", kind: "task", state: "working", doing: "Inspect /Users/alice/Secret Project/O'Brien/client-list.csv" }],
+      gates: [
+        { id: "TRA-3", title: "Gate", blocked_by: "TRA-2", reason: "Read C:\\Program Files\\Acme\\secret.txt", owner: "(main)" },
+        { id: "TRA-4", title: "Gate", blocked_by: "TRA-2", reason: "Read /Users/alice/reports/Q1,final/client.csv", owner: "(main)" },
+      ],
+    }), false);
+    expect(unquotedSpaces!.inFlight[0]!.doing).toBe("Inspect [path]");
+    expect(unquotedSpaces!.gates[0]!.reason).toBe("Read [path]");
+    expect(unquotedSpaces!.gates[1]!.reason).toBe("Read [path]");
+
+    const safeReferences = normalizeBearings(bearings({
+      in_flight: [{ id: "TRA-1", kind: "task", state: "working", doing: "See https://docs.example/path and docs/setup.md, ./scripts/test.sh, ../src/x" }],
+    }), false);
+    expect(safeReferences!.inFlight[0]!.doing).toBe(
+      "See https://docs.example/path and docs/setup.md, ./scripts/test.sh, ../src/x",
+    );
+  });
+
+  test("bounds malformed quoted path input before redaction", () => {
+    const malicious = `"/${"\\".repeat(10_000)}`;
+    const normalized = normalizeBearings(bearings({
+      in_flight: [{ id: "TRA-1", kind: "task", state: "working", doing: malicious }],
+    }), false);
+    expect(normalized!.inFlight[0]!.doing).toBe("\"[path]");
   });
 
   test("rejects the wrong schema or malformed required rows and caps row counts", () => {

--- a/bridge/firstmate.test.ts
+++ b/bridge/firstmate.test.ts
@@ -1,0 +1,266 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  FirstmateProvider,
+  normalizeBearings,
+  ProcessFirstmateRunner,
+  resolveEndpoints,
+  type FirstmateRunner,
+} from "./firstmate.ts";
+import type { SessionRegistry } from "./sessions.ts";
+
+const tempDirs: string[] = [];
+afterEach(() => {
+  while (tempDirs.length) rmSync(tempDirs.pop()!, { recursive: true, force: true });
+  delete process.env.COLLIE_LEAK_SENTINEL;
+});
+
+function bearings(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    schema: "fm-bearings.v1",
+    home: "workspace/firstmate",
+    generated: "2026-07-30T10:00:00Z",
+    in_flight: [{ id: "TRA-1", kind: "task", state: "working", doing: "Implement bridge" }],
+    decisions_open: [{ id: "TRA-2", key: "x", verb: "hold", summary: "Choose path", owner: "(main)" }],
+    gates: [{ id: "TRA-3", title: "Waiting", blocked_by: "TRA-2", reason: "decision", owner: "(main)" }],
+    landed: [{ id: "TRA-4", what: "Delivered", artifact: "/secret/report", owner: "(main)" }],
+    endpoints: [{ id: "TRA-1", backend: "herdr", target: "default:pane:1", exists: true, agent: "alive" }],
+    prs: "checked (1 repo, 1 open)",
+    candidate_prs: [{ num: "42", repo: "owner/repo", task: "TRA-1", url: "https://github.com/owner/repo/pull/42", review: "APPROVED", mergeable: "MERGEABLE", checks: "passing" }],
+    paths: [{ id: "TRA-1", worktree: "/LEAK_SENTINEL/worktree" }],
+    actions: [{ id: "TRA-1", steer: "run /LEAK_SENTINEL/action" }],
+    credentials: [{ token: "LEAK_SENTINEL_CREDENTIAL" }],
+    ...overrides,
+  };
+}
+
+class QueueRunner implements FirstmateRunner {
+  calls: boolean[] = [];
+  constructor(private readonly values: Array<unknown | Promise<unknown>>) {}
+  run(includePrs: boolean): Promise<unknown> {
+    this.calls.push(includePrs);
+    const value = this.values.shift();
+    return value instanceof Promise ? value : Promise.resolve(value);
+  }
+}
+
+function provider(runner: FirstmateRunner, includePrs = false): FirstmateProvider {
+  return new FirstmateProvider({
+    home: "/trusted/firstmate",
+    refreshMs: 30_000,
+    includePrs,
+    prRefreshMs: 120_000,
+    runner,
+  });
+}
+
+function executable(script: string): string {
+  const home = mkdtempSync(join(tmpdir(), "collie-firstmate-runner-"));
+  tempDirs.push(home);
+  const bin = join(home, "bin");
+  mkdirSync(bin);
+  const path = join(bin, "fm-bearings-snapshot.sh");
+  writeFileSync(path, `#!/bin/sh\n${script}\n`);
+  chmodSync(path, 0o700);
+  return home;
+}
+
+describe("ProcessFirstmateRunner", () => {
+  test("uses fixed argv, a minimal environment, and separate PR invocation", async () => {
+    process.env.COLLIE_LEAK_SENTINEL = "must-not-pass";
+    const home = executable(
+      `printf '{"args":"%s","leak":"%s","timeout":"%s","repos":"%s","limit":"%s"}' "$*" "\${COLLIE_LEAK_SENTINEL-unset}" "$FM_BEARINGS_PR_TIMEOUT" "$FM_BEARINGS_PR_REPOS" "$FM_BEARINGS_PR_LIMIT"`,
+    );
+    const runner = new ProcessFirstmateRunner(home);
+    const limits = { leak: "unset", timeout: "5", repos: "3", limit: "20" };
+    await expect(runner.run(false)).resolves.toEqual({ args: "--json --fields endpoints", ...limits });
+    await expect(runner.run(true)).resolves.toEqual({
+      args: "--json --fields endpoints --include-prs",
+      ...limits,
+    });
+  });
+
+  test("bounds stdout and hard-times out the process group", async () => {
+    const noisy = new ProcessFirstmateRunner(executable("printf 123456789"), { outputLimitBytes: 4 });
+    await expect(noisy.run(false)).rejects.toThrow("output-limit");
+
+    const slow = new ProcessFirstmateRunner(executable("sleep 5"), { timeoutMs: 20 });
+    await expect(slow.run(false)).rejects.toThrow("timeout");
+  });
+
+  test("rejects a missing or non-executable fixed script", async () => {
+    const home = mkdtempSync(join(tmpdir(), "collie-firstmate-missing-"));
+    tempDirs.push(home);
+    await expect(new ProcessFirstmateRunner(home).run(false)).rejects.toThrow("not-executable");
+  });
+});
+
+describe("bearings normalization", () => {
+  test("strictly allowlists bounded semantic fields and drops leak sentinels", () => {
+    const normalized = normalizeBearings(bearings(), false);
+    expect(normalized).not.toBeNull();
+    expect(normalized!.landed).toEqual([{ id: "TRA-4", what: "Delivered", owner: "(main)" }]);
+    expect(normalized!.prs).toEqual([]);
+    expect(JSON.stringify(normalized)).not.toContain("LEAK_SENTINEL");
+    expect(JSON.stringify(normalized)).not.toContain("artifact");
+  });
+
+  test("rejects the wrong schema or malformed required rows and caps row counts", () => {
+    expect(normalizeBearings(bearings({ schema: "fm-bearings.v2" }), false)).toBeNull();
+    expect(normalizeBearings(bearings({ home: "/LEAK_SENTINEL/home" }), false)).toBeNull();
+    expect(normalizeBearings(bearings({ gates: [{ id: "missing-fields" }] }), false)).toBeNull();
+    const many = Array.from({ length: 80 }, (_, index) => ({
+      id: `T-${index}`,
+      kind: "task",
+      state: "working",
+      doing: "work",
+    }));
+    expect(normalizeBearings(bearings({ in_flight: many }), false)!.inFlight).toHaveLength(50);
+  });
+
+  test("accepts a valid empty semantic snapshot", () => {
+    const normalized = normalizeBearings(bearings({
+      in_flight: [],
+      decisions_open: [],
+      gates: [],
+      landed: [],
+      endpoints: [],
+    }), false);
+    expect(normalized).toMatchObject({
+      inFlight: [],
+      decisions: [],
+      gates: [],
+      landed: [],
+      prs: [],
+    });
+  });
+
+  test("normalizes only verified GitHub PR URLs and the closed checks enum", () => {
+    expect(normalizeBearings(bearings(), true)!.prs).toEqual([{
+      number: "42",
+      repo: "owner/repo",
+      task: "TRA-1",
+      url: "https://github.com/owner/repo/pull/42",
+      review: "APPROVED",
+      mergeable: "MERGEABLE",
+      checks: "passing",
+    }]);
+    expect(normalizeBearings(bearings(), true)!.prSummary).toBe("checked (1 repo, 1 open)");
+    expect(normalizeBearings(bearings({ prs: 42 }), true)).toBeNull();
+    expect(normalizeBearings(bearings({ prs: 42 }), false)).not.toBeNull();
+    const unknown = bearings({
+      candidate_prs: [{ num: "7", repo: "o/r", task: "T", url: "https://github.com/o/r/pull/7", review: "none", mergeable: "UNKNOWN", checks: "surprise" }],
+    });
+    expect(normalizeBearings(unknown, true)!.prs[0]!.checks).toBe("unknown");
+    const hostile = bearings({
+      candidate_prs: [{ num: "7", repo: "o/r", task: "T", url: "https://github.com/attacker/repo/pull/7", review: "none", mergeable: "UNKNOWN", checks: "none" }],
+    });
+    expect(normalizeBearings(hostile, true)).toBeNull();
+  });
+});
+
+describe("FirstmateProvider", () => {
+  test("is single-flight, transitions loading to ready, then stale, then recovers", async () => {
+    let release!: (value: unknown) => void;
+    const pending = new Promise<unknown>((resolve) => { release = resolve; });
+    const runner = new QueueRunner([pending, { bad: true }, bearings()]);
+    const subject = provider(runner);
+    expect(subject.status()).toEqual({ state: "loading" });
+    const first = subject.refreshBase();
+    const duplicate = subject.refreshBase();
+    expect(first).toBe(duplicate);
+    expect(runner.calls).toEqual([false]);
+    release(bearings());
+    await first;
+    expect(subject.status()).toMatchObject({ state: "ready", prState: "disabled" });
+    await subject.refreshBase();
+    expect(subject.status().state).toBe("stale");
+    await subject.refreshBase();
+    expect(subject.status().state).toBe("ready");
+  });
+
+  test("reports a bounded cold failure and retains base plus last-good PRs on PR failure", async () => {
+    const cold = provider(new QueueRunner([{ bad: true }]));
+    await cold.refreshBase();
+    expect(cold.status()).toEqual({ state: "unavailable", reason: "invalid-output" });
+
+    const runner = new QueueRunner([bearings(), bearings(), { bad: true }, bearings({ prs: "checked (1 repo, 0 open)", candidate_prs: [] })]);
+    const subject = provider(runner, true);
+    await subject.refreshBase();
+    expect(subject.status()).toMatchObject({ state: "ready", prState: "loading", prs: [] });
+    await subject.refreshPrs();
+    expect(subject.status()).toMatchObject({
+      state: "ready",
+      prState: "ready",
+      prSummary: "checked (1 repo, 1 open)",
+      prs: [{ number: "42" }],
+    });
+    await subject.refreshPrs();
+    expect(subject.status()).toMatchObject({
+      state: "ready",
+      prState: "stale",
+      prSummary: "checked (1 repo, 1 open)",
+      prs: [{ number: "42" }],
+    });
+    expect(runner.calls).toEqual([false, true, true]);
+    await subject.refreshPrs();
+    expect(subject.status()).toMatchObject({
+      state: "ready",
+      prState: "ready",
+      prSummary: "checked (1 repo, 0 open)",
+      prs: [],
+    });
+  });
+
+  test("reports a cold PR failure without making the current base unavailable", async () => {
+    const subject = provider(new QueueRunner([bearings(), { bad: true }]), true);
+    await subject.refreshBase();
+    await subject.refreshPrs();
+    expect(subject.status()).toMatchObject({
+      state: "ready",
+      prState: "unavailable",
+      prs: [],
+    });
+  });
+});
+
+describe("live endpoint resolution", () => {
+  test("splits on the first colon and links only registry-verified Herdr panes", () => {
+    const registry = {
+      get(name?: string) {
+        if (name !== "default") return undefined;
+        return {
+          name: "default",
+          engine: {
+            current: () => ({
+              bridge: "connected",
+              agents: [{ paneId: "pane:1" }],
+              shellPanes: [],
+            }),
+          },
+        };
+      },
+    } as unknown as SessionRegistry;
+    const resolved = resolveEndpoints([
+      { id: "good", backend: "herdr", target: "default:pane:1" },
+      { id: "wrong-backend", backend: "omp", target: "default:pane:1" },
+      { id: "dead-pane", backend: "herdr", target: "default:missing" },
+      { id: "unknown-session", backend: "herdr", target: "other:pane:1" },
+      { id: "malformed", backend: "herdr", target: "no-colon" },
+    ], registry);
+    expect([...resolved.entries()]).toEqual([["good", { session: "default", paneId: "pane:1" }]]);
+  });
+
+  test("keeps unresolved tasks visible but unlinked in provider status", async () => {
+    const subject = provider(new QueueRunner([bearings()]));
+    await subject.refreshBase();
+    const registry = { get: () => undefined } as unknown as SessionRegistry;
+    expect(subject.status(registry)).toMatchObject({
+      inFlight: [{ id: "TRA-1" }],
+    });
+    expect((subject.status(registry) as { inFlight: Array<{ endpoint?: unknown }> }).inFlight[0]!.endpoint).toBeUndefined();
+  });
+});

--- a/bridge/firstmate.ts
+++ b/bridge/firstmate.ts
@@ -68,12 +68,22 @@ function plainBoundedString(value: unknown, max = MAX_TEXT): string | null {
   return clean.slice(0, max);
 }
 
+function redactAbsolutePaths(value: string): string {
+  const quoted = value.replace(
+    /(["'`])(?:[A-Za-z]:[\\/]|~[\\/]|[\\/]{1,2})(?:\\.|(?!\\|\1).)*\1/g,
+    "$1[path]$1",
+  );
+  return quoted.replace(
+    /https?:\/\/[^\s)\]}>;,|&<"'`]+|(^|[^A-Za-z0-9.])(?:[A-Za-z]:[\\/]|~[\\/]|[\\/]{1,2}).*/gi,
+    (match, boundary: string | undefined) =>
+      /^https?:\/\//i.test(match) ? match : `${boundary ?? ""}[path]`,
+  );
+}
+
 function boundedString(value: unknown, max = MAX_TEXT): string | null {
-  const clean = plainBoundedString(value, Number.MAX_SAFE_INTEGER);
+  const clean = plainBoundedString(value, max);
   if (clean === null) return null;
-  return clean
-    .replace(/(^|[\s(\[{:;="'`])(?:[A-Za-z]:[\\/]|~[\\/]|[\\/]{1,2})[^\s)\]}>;,]*/g, "$1[path]")
-    .slice(0, max);
+  return redactAbsolutePaths(clean).slice(0, max);
 }
 
 function githubPullUrl(value: unknown): string | null {

--- a/bridge/firstmate.ts
+++ b/bridge/firstmate.ts
@@ -27,7 +27,6 @@ interface EndpointCandidate {
 }
 
 interface BearingsData {
-  home: string;
   generatedAt: string;
   inFlight: FirstmateInFlight[];
   decisions: FirstmateDecision[];
@@ -63,10 +62,18 @@ function record(value: unknown): Record<string, unknown> | null {
     : null;
 }
 
-function boundedString(value: unknown, max = MAX_TEXT): string | null {
+function plainBoundedString(value: unknown, max = MAX_TEXT): string | null {
   if (typeof value !== "string") return null;
   const clean = value.replace(/\s+/g, " ").trim();
   return clean.slice(0, max);
+}
+
+function boundedString(value: unknown, max = MAX_TEXT): string | null {
+  const clean = plainBoundedString(value, Number.MAX_SAFE_INTEGER);
+  if (clean === null) return null;
+  return clean
+    .replace(/(^|[\s(\[{:;="'`])(?:[A-Za-z]:[\\/]|~[\\/]|[\\/]{1,2})[^\s)\]}>;,]*/g, "$1[path]")
+    .slice(0, max);
 }
 
 function githubPullUrl(value: unknown): string | null {
@@ -106,8 +113,8 @@ function normalizeList<T>(value: unknown, normalize: (row: Record<string, unknow
 export function normalizeBearings(value: unknown, includePrs: boolean): BearingsData | null {
   const root = record(value);
   if (!root || root.schema !== "fm-bearings.v1") return null;
-  const home = boundedString(root.home, 120);
-  const generatedAt = boundedString(root.generated, 64);
+  const home = plainBoundedString(root.home, 120);
+  const generatedAt = plainBoundedString(root.generated, 64);
   if (
     !home ||
     !generatedAt ||
@@ -185,7 +192,7 @@ export function normalizeBearings(value: unknown, includePrs: boolean): Bearings
     prs = normalized;
   }
 
-  return { home, generatedAt, inFlight, decisions, gates, landed, prs, prSummary, endpoints };
+  return { generatedAt, inFlight, decisions, gates, landed, prs, prSummary, endpoints };
 }
 
 interface ProcessRunnerLimits {
@@ -377,7 +384,6 @@ export class FirstmateProvider {
         : (this.prSucceeded ? "ready" : "loading");
     return {
       state,
-      home: this.base.home,
       generatedAt: this.base.generatedAt,
       inFlight: this.base.inFlight.map(attach),
       decisions: this.base.decisions.map(attach),

--- a/bridge/firstmate.ts
+++ b/bridge/firstmate.ts
@@ -1,0 +1,415 @@
+import { spawn } from "node:child_process";
+import { realpathSync, statSync } from "node:fs";
+import { join, sep } from "node:path";
+
+import type { SessionRegistry } from "./sessions.ts";
+import type {
+  FirstmateChecks,
+  FirstmateDecision,
+  FirstmateGate,
+  FirstmateInFlight,
+  FirstmateLanded,
+  FirstmatePullRequest,
+  FirstmateStatus,
+  FirstmateUnavailableReason,
+} from "./types.ts";
+
+const COMMAND_TIMEOUT_MS = 20_000;
+const OUTPUT_LIMIT_BYTES = 512 * 1024;
+const MAX_ROWS = 50;
+const MAX_ID = 120;
+const MAX_TEXT = 240;
+
+interface EndpointCandidate {
+  id: string;
+  backend: string;
+  target: string;
+}
+
+interface BearingsData {
+  home: string;
+  generatedAt: string;
+  inFlight: FirstmateInFlight[];
+  decisions: FirstmateDecision[];
+  gates: FirstmateGate[];
+  landed: FirstmateLanded[];
+  prs: FirstmatePullRequest[];
+  prSummary: string | null;
+  endpoints: EndpointCandidate[];
+}
+
+class FirstmateRunError extends Error {
+  constructor(readonly reason: FirstmateUnavailableReason) {
+    super(reason);
+  }
+}
+
+export interface FirstmateRunner {
+  run(includePrs: boolean): Promise<unknown>;
+  stop?(): void;
+}
+
+interface FirstmateProviderOptions {
+  home: string;
+  refreshMs: number;
+  includePrs: boolean;
+  prRefreshMs: number;
+  runner?: FirstmateRunner;
+}
+
+function record(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function boundedString(value: unknown, max = MAX_TEXT): string | null {
+  if (typeof value !== "string") return null;
+  const clean = value.replace(/\s+/g, " ").trim();
+  return clean.slice(0, max);
+}
+
+function githubPullUrl(value: unknown): string | null {
+  if (typeof value !== "string" || value.length > 300) return null;
+  try {
+    const url = new URL(value);
+    if (
+      url.protocol !== "https:" ||
+      url.hostname.toLowerCase() !== "github.com" ||
+      !/^\/[^/]+\/[^/]+\/pull\/\d+\/?$/.test(url.pathname) ||
+      url.username ||
+      url.password ||
+      url.search ||
+      url.hash
+    ) return null;
+    return url.toString();
+  } catch {
+    return null;
+  }
+}
+
+function normalizeList<T>(value: unknown, normalize: (row: Record<string, unknown>) => T | null): T[] | null {
+  const input = Array.isArray(value) ? value.slice(0, MAX_ROWS) : null;
+  if (!input) return null;
+  const output: T[] = [];
+  for (const value of input) {
+    const item = record(value);
+    if (!item) return null;
+    const normalized = normalize(item);
+    if (!normalized) return null;
+    output.push(normalized);
+  }
+  return output;
+}
+
+/** Strictly projects the allowlisted fm-bearings.v1 fields; no source paths or actions survive. */
+export function normalizeBearings(value: unknown, includePrs: boolean): BearingsData | null {
+  const root = record(value);
+  if (!root || root.schema !== "fm-bearings.v1") return null;
+  const home = boundedString(root.home, 120);
+  const generatedAt = boundedString(root.generated, 64);
+  if (
+    !home ||
+    !generatedAt ||
+    !/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,3})?Z$/.test(generatedAt) ||
+    !Number.isFinite(Date.parse(generatedAt))
+  ) return null;
+  if (/^(?:[A-Za-z]:[\\/]|[\\/])/.test(home) || home.split(/[\\/]/).includes("..")) return null;
+
+  const inFlight = normalizeList(root.in_flight, (item) => {
+    const id = boundedString(item.id, MAX_ID);
+    const kind = boundedString(item.kind, 40);
+    const state = boundedString(item.state, 40);
+    const doing = boundedString(item.doing);
+    return id && kind && state && doing !== null ? { id, kind, state, doing } : null;
+  });
+  const decisions = normalizeList(root.decisions_open, (item) => {
+    const id = boundedString(item.id, MAX_ID);
+    const summary = boundedString(item.summary);
+    const owner = boundedString(item.owner, MAX_ID);
+    return id && summary && owner ? { id, summary, owner } : null;
+  });
+  const gates = normalizeList(root.gates, (item) => {
+    const id = boundedString(item.id, MAX_ID);
+    const title = boundedString(item.title);
+    const blockedBy = boundedString(item.blocked_by);
+    const reason = boundedString(item.reason);
+    const owner = boundedString(item.owner, MAX_ID);
+    return id && title && blockedBy && reason && owner ? { id, title, blockedBy, reason, owner } : null;
+  });
+  const landed = normalizeList(root.landed, (item) => {
+    const id = boundedString(item.id, MAX_ID);
+    const what = boundedString(item.what);
+    const owner = boundedString(item.owner, MAX_ID);
+    return id && what && owner ? { id, what, owner } : null;
+  });
+  const endpoints = normalizeList(root.endpoints, (item) => {
+    const id = boundedString(item.id, MAX_ID);
+    const backend = boundedString(item.backend, 40);
+    const target = boundedString(item.target, 200);
+    return id && backend && target ? { id, backend, target } : null;
+  });
+  if (!inFlight || !decisions || !gates || !landed || !endpoints) return null;
+
+  let prs: FirstmatePullRequest[] = [];
+  let prSummary: string | null = null;
+  if (includePrs) {
+    prSummary = boundedString(root.prs, 160);
+    if (prSummary === null) return null;
+    const normalized = normalizeList(root.candidate_prs, (item) => {
+      const number = boundedString(item.num, 20);
+      const repo = boundedString(item.repo, 120);
+      const task = boundedString(item.task, MAX_ID);
+      const rawUrl = githubPullUrl(item.url);
+      const url =
+        number &&
+        repo &&
+        /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(repo) &&
+        rawUrl &&
+        new URL(rawUrl).pathname.replace(/\/$/, "").toLowerCase() ===
+          `/${repo}/pull/${number}`.toLowerCase()
+          ? rawUrl
+          : null;
+      const reviewRaw = boundedString(item.review, 40);
+      const review = reviewRaw === "" ? "none" : reviewRaw;
+      const mergeable = boundedString(item.mergeable, 40);
+      const rawChecks = boundedString(item.checks, 20);
+      const checks: FirstmateChecks = ["none", "pending", "passing", "failing"].includes(rawChecks ?? "")
+        ? (rawChecks as FirstmateChecks)
+        : "unknown";
+      return number && /^\d+$/.test(number) && repo && task && url && review && mergeable
+        ? { number, repo, task, url, review, mergeable, checks }
+        : null;
+    });
+    if (!normalized) return null;
+    prs = normalized;
+  }
+
+  return { home, generatedAt, inFlight, decisions, gates, landed, prs, prSummary, endpoints };
+}
+
+interface ProcessRunnerLimits {
+  timeoutMs?: number;
+  outputLimitBytes?: number;
+}
+
+export class ProcessFirstmateRunner implements FirstmateRunner {
+  private readonly command: string | null;
+  private readonly home: string;
+  private readonly timeoutMs: number;
+  private readonly outputLimitBytes: number;
+  private readonly terminateActive = new Set<() => void>();
+
+  constructor(home: string, limits: ProcessRunnerLimits = {}) {
+    this.timeoutMs = limits.timeoutMs ?? COMMAND_TIMEOUT_MS;
+    this.outputLimitBytes = limits.outputLimitBytes ?? OUTPUT_LIMIT_BYTES;
+    try {
+      const resolvedHome = realpathSync(home);
+      if (!statSync(resolvedHome).isDirectory()) throw new Error("not a directory");
+      const command = realpathSync(join(resolvedHome, "bin", "fm-bearings-snapshot.sh"));
+      const info = statSync(command);
+      const contained = command.startsWith(resolvedHome.endsWith(sep) ? resolvedHome : `${resolvedHome}${sep}`);
+      this.home = resolvedHome;
+      this.command = contained && info.isFile() && (info.mode & 0o111) !== 0 ? command : null;
+    } catch {
+      this.home = home;
+      this.command = null;
+    }
+  }
+
+  run(includePrs: boolean): Promise<unknown> {
+    if (!this.command) return Promise.reject(new FirstmateRunError("not-executable"));
+    const args = ["--json", "--fields", "endpoints", ...(includePrs ? ["--include-prs"] : [])];
+    const env: NodeJS.ProcessEnv = {};
+    for (const name of ["HOME", "PATH", "TMPDIR", "LANG", "LC_ALL", "XDG_CONFIG_HOME", "GH_CONFIG_DIR"]) {
+      if (process.env[name] !== undefined) env[name] = process.env[name];
+    }
+    env.FM_BEARINGS_PR_TIMEOUT = "5";
+    env.FM_BEARINGS_PR_REPOS = "3";
+    env.FM_BEARINGS_PR_LIMIT = "20";
+
+    return new Promise((resolve, reject) => {
+      const child = spawn(this.command!, args, {
+        cwd: this.home,
+        detached: process.platform !== "win32",
+        env,
+        shell: false,
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+      const output: Buffer[] = [];
+      let stdoutBytes = 0;
+      let stderrBytes = 0;
+      let settled = false;
+
+      const terminate = () => {
+        if (child.pid && process.platform !== "win32") {
+          try { process.kill(-child.pid, "SIGTERM"); } catch { child.kill("SIGTERM"); }
+          setTimeout(() => {
+            if (child.exitCode !== null || child.signalCode !== null) return;
+            try { process.kill(-child.pid!, "SIGKILL"); } catch { child.kill("SIGKILL"); }
+          }, 100).unref();
+        } else child.kill("SIGTERM");
+      };
+      this.terminateActive.add(terminate);
+      const fail = (reason: FirstmateUnavailableReason) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timeout);
+        terminate();
+        reject(new FirstmateRunError(reason));
+      };
+      const timeout = setTimeout(() => fail("timeout"), this.timeoutMs);
+      timeout.unref();
+
+      child.stdout.on("data", (chunk: Buffer) => {
+        stdoutBytes += chunk.length;
+        if (stdoutBytes > this.outputLimitBytes) return fail("output-limit");
+        output.push(chunk);
+      });
+      child.stderr.on("data", (chunk: Buffer) => {
+        stderrBytes += chunk.length;
+        if (stderrBytes > this.outputLimitBytes) fail("output-limit");
+      });
+      child.on("error", () => fail("command-failed"));
+      child.on("close", (code) => {
+        this.terminateActive.delete(terminate);
+        if (settled) return;
+        settled = true;
+        clearTimeout(timeout);
+        if (code !== 0) return reject(new FirstmateRunError("command-failed"));
+        try {
+          resolve(JSON.parse(Buffer.concat(output).toString("utf8")));
+        } catch {
+          reject(new FirstmateRunError("invalid-output"));
+        }
+      });
+    });
+  }
+  stop(): void {
+    for (const terminate of this.terminateActive) terminate();
+    this.terminateActive.clear();
+  }
+}
+
+export class FirstmateProvider {
+  private base: BearingsData | null = null;
+  private prs: FirstmatePullRequest[] = [];
+  private prSucceeded = false;
+  private prFailed = false;
+  private prSummary: string | null = null;
+  private failure: FirstmateUnavailableReason | null = null;
+  private baseFlight: Promise<void> | null = null;
+  private prFlight: Promise<void> | null = null;
+  private baseTimer: ReturnType<typeof setInterval> | null = null;
+  private prTimer: ReturnType<typeof setInterval> | null = null;
+  private readonly runner: FirstmateRunner;
+
+  constructor(private readonly options: FirstmateProviderOptions) {
+    this.runner = options.runner ?? new ProcessFirstmateRunner(options.home);
+  }
+
+  start(): void {
+    if (this.baseTimer) return;
+    void this.refreshBase();
+    this.baseTimer = setInterval(() => void this.refreshBase(), this.options.refreshMs);
+    this.baseTimer.unref();
+    if (this.options.includePrs) {
+      void this.refreshPrs();
+      this.prTimer = setInterval(() => void this.refreshPrs(), this.options.prRefreshMs);
+      this.prTimer.unref();
+    }
+  }
+
+  stop(): void {
+    if (this.baseTimer) clearInterval(this.baseTimer);
+    if (this.prTimer) clearInterval(this.prTimer);
+    this.baseTimer = null;
+    this.runner.stop?.();
+    this.prTimer = null;
+  }
+
+  refreshBase(): Promise<void> {
+    if (this.baseFlight) return this.baseFlight;
+    this.baseFlight = this.runner.run(false).then((value) => {
+      const normalized = normalizeBearings(value, false);
+      if (!normalized) throw new FirstmateRunError("invalid-output");
+      this.base = normalized;
+      this.failure = null;
+    }).catch((error: unknown) => {
+      this.failure = error instanceof FirstmateRunError ? error.reason : "command-failed";
+    }).finally(() => {
+      this.baseFlight = null;
+    });
+    return this.baseFlight;
+  }
+
+  refreshPrs(): Promise<void> {
+    if (!this.options.includePrs) return Promise.resolve();
+    if (this.prFlight) return this.prFlight;
+    this.prFlight = this.runner.run(true).then((value) => {
+      const normalized = normalizeBearings(value, true);
+      if (!normalized) throw new FirstmateRunError("invalid-output");
+      this.prs = normalized.prs;
+      this.prSummary = normalized.prSummary;
+      this.prSucceeded = true;
+      this.prFailed = false;
+    }).catch(() => {
+      this.prFailed = true;
+      // PR enrichment is independent: retain the last good PR cache and base freshness.
+    }).finally(() => {
+      this.prFlight = null;
+    });
+    return this.prFlight;
+  }
+
+  status(registry?: SessionRegistry): FirstmateStatus {
+    if (!this.base) return this.failure ? { state: "unavailable", reason: this.failure } : { state: "loading" };
+    const state = this.failure ? "stale" : "ready";
+    const endpoints = registry ? resolveEndpoints(this.base.endpoints, registry) : new Map<string, { session: string; paneId: string }>();
+    const attach = <T extends { id: string }>(item: T): T & { endpoint?: { session: string; paneId: string } } => {
+      const endpoint = endpoints.get(item.id);
+      return endpoint ? { ...item, endpoint } : item;
+    };
+    const prState = !this.options.includePrs
+      ? "disabled"
+      : this.prFailed
+        ? (this.prSucceeded ? "stale" : "unavailable")
+        : (this.prSucceeded ? "ready" : "loading");
+    return {
+      state,
+      home: this.base.home,
+      generatedAt: this.base.generatedAt,
+      inFlight: this.base.inFlight.map(attach),
+      decisions: this.base.decisions.map(attach),
+      gates: this.base.gates.map(attach),
+      landed: this.base.landed,
+      prState,
+      ...(this.prSummary !== null ? { prSummary: this.prSummary } : {}),
+      prs: this.prs.map((pr) => {
+        const endpoint = endpoints.get(pr.task);
+        return endpoint ? { ...pr, endpoint } : pr;
+      }),
+    };
+  }
+}
+
+export function resolveEndpoints(
+  candidates: EndpointCandidate[],
+  registry: SessionRegistry,
+): Map<string, { session: string; paneId: string }> {
+  const resolved = new Map<string, { session: string; paneId: string }>();
+  for (const candidate of candidates) {
+    if (candidate.backend !== "herdr") continue;
+    const colon = candidate.target.indexOf(":");
+    if (colon <= 0 || colon === candidate.target.length - 1) continue;
+    const session = candidate.target.slice(0, colon);
+    const paneId = candidate.target.slice(colon + 1);
+    const runtime = registry.get(session);
+    if (!runtime || runtime.name !== session) continue;
+    const snapshot = runtime.engine.current();
+    if (snapshot.bridge !== "connected") continue;
+    if (![...snapshot.agents, ...snapshot.shellPanes].some((pane) => pane.paneId === paneId)) continue;
+    resolved.set(candidate.id, { session, paneId });
+  }
+  return resolved;
+}

--- a/bridge/index.ts
+++ b/bridge/index.ts
@@ -7,6 +7,7 @@ import { AuditLog, fileAuditAppender } from "./audit.ts";
 import { loadConfig } from "./config.ts";
 import { EventPoker } from "./event-poker.ts";
 import { DEFAULT_TIMEOUT_MS, HerdrClient } from "./herdr-client.ts";
+import { FirstmateProvider } from "./firstmate.ts";
 import { NotificationCoordinator, makeNotifySink, type NotifyClock } from "./notifications.ts";
 import { NotifyPrefsStore } from "./notify-prefs.ts";
 import { Push } from "./push.ts";
@@ -203,13 +204,34 @@ const sweepTimer = setInterval(() => {
 }, SWEEP_INTERVAL_MS);
 sweepTimer.unref();
 
-const server = startServer({ cfg, registry, push, snooze, notifyPrefs, updateMonitor, audit, activity });
+const firstmate = cfg.firstmateHome
+  ? new FirstmateProvider({
+      home: cfg.firstmateHome,
+      refreshMs: cfg.firstmateRefreshMs,
+      includePrs: cfg.firstmateIncludePrs,
+      prRefreshMs: cfg.firstmatePrRefreshMs,
+    })
+  : undefined;
+firstmate?.start();
+
+const server = startServer({
+  cfg,
+  registry,
+  push,
+  snooze,
+  notifyPrefs,
+  updateMonitor,
+  audit,
+  activity,
+  firstmate,
+});
 
 const shutdown = async () => {
   console.log("\n[bridge] shutting down");
   // Stop accepting new connections and let in-flight requests drain briefly (non-forced stop)
   // before we tear down the poll loops and exit.
   await server.stop();
+  firstmate?.stop();
   clearInterval(refreshTimer);
   registry.disposeAll();
   // Writes are debounced, so the last few seconds of "you looked at this" live only in memory —

--- a/bridge/journal/omp.test.ts
+++ b/bridge/journal/omp.test.ts
@@ -91,6 +91,11 @@ describe("parseOmpTranscript", () => {
       JSON.stringify({ type: "model_change", id: "model", model: "provider/model" }),
       JSON.stringify({ type: "service_tier_change", id: "service", serviceTier: "priority" }),
       JSON.stringify({ type: "custom_message", id: "wrong-content", display: true, content: { text: "no" } }),
+      notice("", "empty id"),
+      notice("x".repeat(101), "long id"),
+      JSON.stringify({ type: "custom_message", content: "missing id", display: true, timestamp }),
+      notice("duplicate", "first duplicate"),
+      notice("duplicate", "second duplicate"),
     ];
 
     expect(parseOmpTranscript(rows.join("\n"))).toEqual([
@@ -100,6 +105,19 @@ describe("parseOmpTranscript", () => {
         role: "note",
         parts: [{ kind: "text", text: "shown" }],
       },
+    ]);
+  });
+
+  test("drops injected developer, system, and unknown message roles", () => {
+    const rows = [
+      message("developer", { role: "developer", content: [{ type: "text", text: "internal policy" }] }),
+      message("system", { role: "system", content: [{ type: "text", text: "hidden system prompt" }] }),
+      message("unknown", { role: "custom", content: [{ type: "text", text: "unknown role" }] }),
+      speech("user", "user", "operator text"),
+    ];
+
+    expect(parseOmpTranscript(rows.join("\n")).map(({ uuid, role }) => [uuid, role])).toEqual([
+      ["user", "user"],
     ]);
   });
 

--- a/bridge/journal/omp.test.ts
+++ b/bridge/journal/omp.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, realpath, rm, symlink } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { ompJournal, parseOmpTranscript } from "./omp.ts";
+
+const SID = "019fb2b1-3060-7000-a086-4e7b785fd895";
+const OUTSIDE_SID = "ffffffff-1111-2222-3333-444444444444";
+const timestamp = "2026-07-30T11:03:04.544Z";
+
+const message = (id: string, body: Record<string, unknown>) =>
+  JSON.stringify({ type: "message", id, parentId: "p0", timestamp, message: body });
+
+const speech = (id: string, role: "user" | "assistant", text: string) =>
+  message(id, { role, content: [{ type: "text", text }] });
+
+const notice = (id: string, content: string, display: boolean | undefined = true) =>
+  JSON.stringify({
+    type: "custom_message",
+    customType: "advisor",
+    content,
+    ...(display === undefined ? {} : { display }),
+    id,
+    timestamp,
+  });
+
+const title = () => JSON.stringify({ type: "title", v: 1, title: "OMP session", source: "auto" });
+const session = () =>
+  JSON.stringify({ type: "session", version: 3, id: SID, timestamp, cwd: "/repo" });
+
+describe("parseOmpTranscript", () => {
+  test("keeps ordinary v3 speech, tools, and visible notices in original log order", () => {
+    const entries = parseOmpTranscript(
+      [
+        // OMP can rewrite the title into the first physical row, before the v3 session header.
+        title(),
+        session(),
+        speech("user-1", "user", "start"),
+        notice("note-1", "\u001b[33mcheck this\u001b[0m"),
+        message("assistant-1", {
+          role: "assistant",
+          content: [
+            { type: "thinking", thinking: "considering" },
+            { type: "toolCall", id: "call-1", name: "read", arguments: { path: "/repo/a.ts" } },
+          ],
+        }),
+        notice("hidden-1", "must stay hidden", false),
+        message("result-1", {
+          role: "toolResult",
+          toolCallId: "call-1",
+          toolName: "read",
+          content: [{ type: "text", text: "contents" }],
+        }),
+        notice("note-2", "finished"),
+      ].join("\n"),
+    );
+
+    expect(entries.map(({ uuid, role }) => [uuid, role])).toEqual([
+      ["user-1", "user"],
+      ["note-1", "note"],
+      ["assistant-1", "assistant"],
+      ["note-2", "note"],
+    ]);
+    expect(entries[1]!.parts).toEqual([{ kind: "text", text: "check this" }]);
+    expect(entries[2]!.parts).toEqual([
+      { kind: "thinking", text: "considering" },
+      {
+        kind: "tool",
+        name: "read",
+        summary: "/repo/a.ts",
+        result: { text: "contents" },
+      },
+    ]);
+  });
+
+  test("renders only display:true custom_message rows", () => {
+    const rows = [
+      notice("visible", "shown"),
+      notice("false", "hidden false", false),
+      JSON.stringify({ type: "custom_message", customType: "advisor", content: "hidden missing", id: "missing", timestamp }),
+      JSON.stringify({
+        type: "custom",
+        customType: "tool_execution_start",
+        content: "control row",
+        display: true,
+        id: "control",
+        timestamp,
+      }),
+      JSON.stringify({ type: "credential_pin", id: "credential", provider: "openai", hash: "secret" }),
+      JSON.stringify({ type: "model_change", id: "model", model: "provider/model" }),
+      JSON.stringify({ type: "service_tier_change", id: "service", serviceTier: "priority" }),
+      JSON.stringify({ type: "custom_message", id: "wrong-content", display: true, content: { text: "no" } }),
+    ];
+
+    expect(parseOmpTranscript(rows.join("\n"))).toEqual([
+      {
+        uuid: "visible",
+        ts: timestamp,
+        role: "note",
+        parts: [{ kind: "text", text: "shown" }],
+      },
+    ]);
+  });
+
+  test("skips malformed partial rows without losing later messages or notices", () => {
+    expect(
+      parseOmpTranscript(
+        ['{"type":"custom_message","display":tr', speech("user", "user", "hello"), notice("note", "ready")].join(
+          "\n",
+        ),
+      ).map(({ uuid, role }) => [uuid, role]),
+    ).toEqual([
+      ["user", "user"],
+      ["note", "note"],
+    ]);
+  });
+
+  test("a real id resembling the placeholder namespace remains an ordinary turn", () => {
+    const entries = parseOmpTranscript(
+      [
+        speech("__collie_omp_note__1", "user", "ordinary"),
+        notice("notice", "visible"),
+      ].join("\n"),
+    );
+    expect(entries.map(({ uuid, role }) => [uuid, role])).toEqual([
+      ["__collie_omp_note__1", "user"],
+      ["notice", "note"],
+    ]);
+  });
+
+  test("bounds visible notice text through the shared v3 text limits", () => {
+    const [entry] = parseOmpTranscript(notice("large", "x".repeat(100_000)));
+    const part = entry?.parts[0];
+    expect(entry?.role).toBe("note");
+    expect(part).toMatchObject({ kind: "text", truncated: true });
+    expect(part?.kind === "text" ? part.text.length : 0).toBeLessThan(100_000);
+  });
+
+  test("adapter identifies itself exactly as Herdr's omp agent", () => {
+    expect(ompJournal("/sessions").agent).toBe("omp");
+  });
+});
+
+describe("OMP source — id and path refs stay inside COLLIE_OMP_ROOT", () => {
+  async function fixture() {
+    const base = await mkdtemp(join(tmpdir(), "collie-omp-"));
+    const root = join(base, "sessions");
+    const project = join(root, "-repo-");
+    await mkdir(project, { recursive: true });
+    const log = join(project, `2026-07-30T11-03-04-544Z_${SID}.jsonl`);
+    await Bun.write(log, [title(), session(), speech("user", "user", "hi")].join("\n"));
+    const outside = join(base, `outside_${OUTSIDE_SID}.jsonl`);
+    await Bun.write(outside, speech("secret", "user", "secret"));
+    const sneaky = join(project, `2026-07-30T11-03-05-544Z_${OUTSIDE_SID}.jsonl`);
+    await symlink(outside, sneaky);
+    return { base, root, log, outside, sneaky };
+  }
+
+  test("resolves both contained path refs and the v3 id suffix", async () => {
+    const { base, root, log } = await fixture();
+    const source = ompJournal(root).source;
+    const canonicalLog = await realpath(log);
+    expect(await source.resolve({ kind: "path", value: log })).toBe(canonicalLog);
+    expect(await source.resolve({ kind: "id", value: SID })).toBe(canonicalLog);
+    await rm(base, { recursive: true, force: true });
+  });
+
+  test("rejects direct and symlink escapes for both ref kinds", async () => {
+    const { base, root, outside, sneaky } = await fixture();
+    const source = ompJournal(root).source;
+    expect(await source.resolve({ kind: "path", value: outside })).toBeNull();
+    expect(await source.resolve({ kind: "path", value: sneaky })).toBeNull();
+    expect(await source.resolve({ kind: "id", value: OUTSIDE_SID })).toBeNull();
+    await rm(base, { recursive: true, force: true });
+  });
+});

--- a/bridge/journal/omp.ts
+++ b/bridge/journal/omp.ts
@@ -14,20 +14,33 @@ interface OmpRow {
   timestamp?: unknown;
   display?: unknown;
   content?: unknown;
+  message?: unknown;
+}
+
+function ompRow(value: unknown): OmpRow | null {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return null;
+  return {
+    type: "type" in value ? value.type : undefined,
+    id: "id" in value ? value.id : undefined,
+    timestamp: "timestamp" in value ? value.timestamp : undefined,
+    display: "display" in value ? value.display : undefined,
+    content: "content" in value ? value.content : undefined,
+    message: "message" in value ? value.message : undefined,
+  };
 }
 
 /** Parse OMP v3 JSONL into oldest-first turns. PURE — no fs, no clock. */
 export function parseOmpTranscript(text: string): TranscriptEntry[] {
   const lines = text.split("\n");
   const rows: Array<OmpRow | null> = [];
-  const ids = new Set<string>();
+  const idCounts = new Map<string, number>();
 
   for (const line of lines) {
     try {
       const value = JSON.parse(line) as unknown;
-      const row = value !== null && typeof value === "object" ? (value as OmpRow) : null;
+      const row = ompRow(value);
       rows.push(row);
-      if (row && typeof row.id === "string") ids.add(row.id);
+      if (row && typeof row.id === "string") idCounts.set(row.id, (idCounts.get(row.id) ?? 0) + 1);
     } catch {
       // A live append or tail window can leave a partial line. Keep it unchanged so the shared
       // parser applies its normal malformed-row handling.
@@ -42,19 +55,35 @@ export function parseOmpTranscript(text: string): TranscriptEntry[] {
 
   const normalized = lines.map((line, index) => {
     const row = rows[index];
+    if (row?.type === "message") {
+      const message = row.message;
+      if (
+        message === null ||
+        typeof message !== "object" ||
+        Array.isArray(message) ||
+        !("role" in message)
+      ) return "";
+      const role = message.role;
+      if (role !== "user" && role !== "assistant" && role !== "toolResult") return "";
+    }
+
     if (
       row?.type !== "custom_message" ||
       row.display !== true ||
       typeof row.content !== "string" ||
-      row.content.trim() === ""
+      row.content.trim() === "" ||
+      typeof row.id !== "string" ||
+      row.id.length === 0 ||
+      row.id.length > 100 ||
+      idCounts.get(row.id) !== 1
     ) {
       return line;
     }
 
     let placeholder = `__collie_omp_note__${index}`;
-    while (ids.has(placeholder)) placeholder += "_";
-    ids.add(placeholder);
-    notes.set(placeholder, typeof row.id === "string" ? row.id : `omp-note-${index}`);
+    while (idCounts.has(placeholder)) placeholder += "_";
+    idCounts.set(placeholder, 1);
+    notes.set(placeholder, row.id);
     return JSON.stringify({
       type: "message",
       id: placeholder,

--- a/bridge/journal/omp.ts
+++ b/bridge/journal/omp.ts
@@ -1,0 +1,79 @@
+// OMP's journal adapter.
+//
+// OMP persists the same version-3 JSONL message grammar as pi, including per-row ids and separate
+// toolResult rows. Its only renderable extension is `custom_message`: rows explicitly marked
+// `display: true` are notices the operator saw in the TUI and remain notes in their original log
+// position. All other OMP bookkeeping is left for the shared v3 parser to ignore.
+
+import { parsePiTranscript, PiTranscriptSource } from "./pi.ts";
+import type { JournalAdapter, TranscriptEntry } from "./types.ts";
+
+interface OmpRow {
+  type?: unknown;
+  id?: unknown;
+  timestamp?: unknown;
+  display?: unknown;
+  content?: unknown;
+}
+
+/** Parse OMP v3 JSONL into oldest-first turns. PURE — no fs, no clock. */
+export function parseOmpTranscript(text: string): TranscriptEntry[] {
+  const lines = text.split("\n");
+  const rows: Array<OmpRow | null> = [];
+  const ids = new Set<string>();
+
+  for (const line of lines) {
+    try {
+      const value = JSON.parse(line) as unknown;
+      const row = value !== null && typeof value === "object" ? (value as OmpRow) : null;
+      rows.push(row);
+      if (row && typeof row.id === "string") ids.add(row.id);
+    } catch {
+      // A live append or tail window can leave a partial line. Keep it unchanged so the shared
+      // parser applies its normal malformed-row handling.
+      rows.push(null);
+    }
+  }
+
+  // Turn visible notices into otherwise ordinary v3 messages before using the established parser.
+  // Placeholder ids are checked against every real row id, so no log-controlled id can masquerade
+  // as one of our notices when parsed entries are converted back to notes.
+  const notes = new Map<string, string>();
+
+  const normalized = lines.map((line, index) => {
+    const row = rows[index];
+    if (
+      row?.type !== "custom_message" ||
+      row.display !== true ||
+      typeof row.content !== "string" ||
+      row.content.trim() === ""
+    ) {
+      return line;
+    }
+
+    let placeholder = `__collie_omp_note__${index}`;
+    while (ids.has(placeholder)) placeholder += "_";
+    ids.add(placeholder);
+    notes.set(placeholder, typeof row.id === "string" ? row.id : `omp-note-${index}`);
+    return JSON.stringify({
+      type: "message",
+      id: placeholder,
+      timestamp: typeof row.timestamp === "string" ? row.timestamp : "",
+      message: { role: "user", content: [{ type: "text", text: row.content }] },
+    });
+  });
+
+  return parsePiTranscript(normalized.join("\n")).map((entry): TranscriptEntry => {
+    const originalId = notes.get(entry.uuid);
+    return originalId === undefined ? entry : { ...entry, uuid: originalId, role: "note" };
+  });
+}
+
+/** OMP's source layout and session refs are the contained pi v3 layout. */
+export function ompJournal(root: string): JournalAdapter {
+  return {
+    agent: "omp",
+    source: new PiTranscriptSource(root),
+    parse: parseOmpTranscript,
+  };
+}

--- a/bridge/journal/registry.test.ts
+++ b/bridge/journal/registry.test.ts
@@ -6,11 +6,11 @@ import { adapterFor, buildJournalRegistry, journalAgents } from "./registry.ts";
 // two properties that keep it from rotting: keys come from the adapters themselves, and a hostile
 // agent name can't resolve to something that isn't an adapter.
 
-const roots = { claude: "/c", codex: "/x", pi: "/p" };
+const roots = { claude: "/c", codex: "/x", omp: "/o", pi: "/p" };
 
 describe("buildJournalRegistry", () => {
-  test("serves the three verified harnesses", () => {
-    expect(journalAgents(buildJournalRegistry(roots))).toEqual(["claude", "codex", "pi"]);
+  test("serves the four verified harnesses", () => {
+    expect(journalAgents(buildJournalRegistry(roots))).toEqual(["claude", "codex", "omp", "pi"]);
   });
 
   test("every key IS its adapter's own agent string — the map can't drift from the adapters", () => {
@@ -22,7 +22,7 @@ describe("buildJournalRegistry", () => {
 describe("adapterFor", () => {
   const registry = buildJournalRegistry(roots);
 
-  test.each(["claude", "codex", "pi"])("resolves %s", (agent) => {
+  test.each(["claude", "codex", "omp", "pi"])("resolves %s", (agent) => {
     expect(adapterFor(registry, agent)?.agent).toBe(agent);
   });
 

--- a/bridge/journal/registry.ts
+++ b/bridge/journal/registry.ts
@@ -12,6 +12,7 @@
 
 import { claudeJournal } from "./claude.ts";
 import { codexJournal } from "./codex.ts";
+import { ompJournal } from "./omp.ts";
 import { piJournal } from "./pi.ts";
 import type { JournalAdapter } from "./types.ts";
 
@@ -21,6 +22,8 @@ export interface JournalRoots {
   claude: string;
   /** Codex's `$CODEX_HOME/sessions`. */
   codex: string;
+  /** OMP's `~/.omp/agent/sessions`. */
+  omp: string;
   /** pi's `$PI_CODING_AGENT_DIR/sessions`. */
   pi: string;
 }
@@ -32,7 +35,12 @@ export interface JournalRoots {
  * never drift from the adapter it points at — the same guarantee the frontend registry gives.
  */
 export function buildJournalRegistry(roots: JournalRoots): Record<string, JournalAdapter> {
-  const adapters = [claudeJournal(roots.claude), codexJournal(roots.codex), piJournal(roots.pi)];
+  const adapters = [
+    claudeJournal(roots.claude),
+    codexJournal(roots.codex),
+    ompJournal(roots.omp),
+    piJournal(roots.pi),
+  ];
   return Object.fromEntries(adapters.map((a) => [a.agent, a]));
 }
 

--- a/bridge/server.test.ts
+++ b/bridge/server.test.ts
@@ -9,6 +9,7 @@ import {
   deviceAuth,
   guard,
   historyParams,
+  firstmateSnapshotField,
   isHostAllowed,
   isReservedAuthPath,
   keysPane,
@@ -46,7 +47,12 @@ function cfg(overrides: Partial<Config> = {}): Config {
     notifyDelayMs: 30_000,
     readLines: 200,
     transcript: true,
-    journalRoots: { claude: "/tmp/claude-projects", codex: "/nope/codex", pi: "/nope/pi" },
+    journalRoots: {
+      claude: "/tmp/claude-projects",
+      codex: "/nope/codex",
+      omp: "/nope/omp",
+      pi: "/nope/pi",
+    },
     submitKeys: ["Enter"],
     trustedUser: "",
     deviceHeader: "",
@@ -59,12 +65,26 @@ function cfg(overrides: Partial<Config> = {}): Config {
     stateDir: "/tmp/state",
     multiSession: true,
     skipServe: false,
+    firstmateHome: "",
+    firstmateRefreshMs: 30_000,
+    firstmateIncludePrs: false,
+    firstmatePrRefreshMs: 120_000,
     ...overrides,
   };
 }
 
+describe("optional Firstmate snapshot field", () => {
+  test("is absent when unconfigured and additive when configured", () => {
+    expect(firstmateSnapshotField(undefined)).toEqual({});
+    expect(firstmateSnapshotField({ state: "loading" })).toEqual({
+      firstmate: { state: "loading" },
+    });
+  });
+});
+
 describe("checkAccess — same-origin / CSRF gate", () => {
   test("allows a request with no Origin header (same-origin GET)", () => {
+
     expect(checkAccess(req({ host: "collie.example.ts.net" }), cfg())).toEqual({ ok: true });
   });
 

--- a/bridge/server.ts
+++ b/bridge/server.ts
@@ -5,6 +5,7 @@ import type { ActivityLedger } from "./activity.ts";
 import type { AuditLog } from "./audit.ts";
 import type { Config } from "./config.ts";
 import type { HerdrClient, PaneRead } from "./herdr-client.ts";
+import type { FirstmateProvider } from "./firstmate.ts";
 import { computeEtag, gzipJsonResponse, notModified } from "./http-cache.ts";
 import type { NotifyPrefs, NotifyPrefsStore } from "./notify-prefs.ts";
 import {
@@ -27,6 +28,7 @@ import type {
   BridgeConfig,
   CreateResponse,
   DeviceAuth,
+  FirstmateStatus,
   PaneHistoryResponse,
   PaneReadResponse,
   SnapshotResponse,
@@ -141,8 +143,9 @@ export function startServer(opts: {
   updateMonitor: UpdateMonitor;
   audit: AuditLog;
   activity: ActivityLedger;
+  firstmate?: FirstmateProvider;
 }) {
-  const { cfg, registry, push, snooze, notifyPrefs, updateMonitor, audit, activity } = opts;
+  const { cfg, registry, push, snooze, notifyPrefs, updateMonitor, audit, activity, firstmate } = opts;
   // One journal registry + store for the process. The store's cache is keyed by absolute path, so
   // sharing it across herdr sessions AND across harnesses is correct — two sessions can front panes
   // whose agents write into the same root. Which harnesses have journals at all is decided in
@@ -195,6 +198,7 @@ export function startServer(opts: {
             bridge,
             // Only report device state when the feature is on, so an off deployment sends nothing new.
             ...(device.enforced ? { device } : {}),
+            ...firstmateSnapshotField(firstmate?.status(registry)),
             // The one place a pane leaves the bridge: the session ref is stripped to a presence flag
             // here, so an agent-reported filesystem path never reaches a browser (see toPaneWire).
             // The flag is computed against the registry, so a harness Herdr detects but Collie has no
@@ -396,6 +400,12 @@ export function startServer(opts: {
   for (const w of startupWarnings(cfg)) console.warn(w);
 
   return server;
+}
+
+export function firstmateSnapshotField(
+  status: FirstmateStatus | undefined,
+): { firstmate?: FirstmateStatus } {
+  return status ? { firstmate: status } : {};
 }
 
 /**

--- a/bridge/types.ts
+++ b/bridge/types.ts
@@ -160,11 +160,85 @@ export interface DeviceAuth {
 
 // ── REST response shapes (the browser polls these; see server.ts) ──────────────
 
+export interface FirstmateEndpoint {
+  session: string;
+  paneId: string;
+}
+
+export interface FirstmateDecision {
+  id: string;
+  summary: string;
+  owner: string;
+  endpoint?: FirstmateEndpoint;
+}
+
+export interface FirstmateInFlight {
+  id: string;
+  kind: string;
+  state: string;
+  doing: string;
+  endpoint?: FirstmateEndpoint;
+}
+
+export interface FirstmateGate {
+  id: string;
+  title: string;
+  blockedBy: string;
+  reason: string;
+  owner: string;
+  endpoint?: FirstmateEndpoint;
+}
+
+export interface FirstmateLanded {
+  id: string;
+  what: string;
+  owner: string;
+}
+
+export type FirstmateChecks = "none" | "pending" | "passing" | "failing" | "unknown";
+
+export interface FirstmatePullRequest {
+  number: string;
+  repo: string;
+  task: string;
+  url: string;
+  review: string;
+  mergeable: string;
+  checks: FirstmateChecks;
+  endpoint?: FirstmateEndpoint;
+}
+
+export type FirstmateUnavailableReason =
+  | "not-executable"
+  | "timeout"
+  | "output-limit"
+  | "command-failed"
+  | "invalid-output";
+
+interface FirstmateData {
+  home: string;
+  generatedAt: string;
+  inFlight: FirstmateInFlight[];
+  decisions: FirstmateDecision[];
+  gates: FirstmateGate[];
+  landed: FirstmateLanded[];
+  prs: FirstmatePullRequest[];
+  prState: "disabled" | "loading" | "ready" | "stale" | "unavailable";
+  prSummary?: string;
+}
+
+export type FirstmateStatus =
+  | { state: "loading" }
+  | { state: "unavailable"; reason: FirstmateUnavailableReason }
+  | ({ state: "ready" | "stale" } & FirstmateData);
+
 /** GET /api/snapshot — the current herd view. */
 export interface SnapshotResponse {
   bridge: BridgeStatus;
   /** Per-device authorisation for the requesting client; absent when the feature is off. */
   device?: DeviceAuth;
+  /** Semantic Firstmate fleet view; absent when the trusted home is not configured. */
+  firstmate?: FirstmateStatus;
   /** Agent-bearing panes, triage-sorted (the home list). */
   agents: PaneWire[];
   /** Bare shell panes (no agent) — surfaced so freshly-created tabs/spaces are reachable. */

--- a/bridge/types.ts
+++ b/bridge/types.ts
@@ -216,7 +216,6 @@ export type FirstmateUnavailableReason =
   | "invalid-output";
 
 interface FirstmateData {
-  home: string;
   generatedAt: string;
   inFlight: FirstmateInFlight[];
   decisions: FirstmateDecision[];

--- a/scripts/journal-probe.test.ts
+++ b/scripts/journal-probe.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from "bun:test";
+
+import { refFor } from "./journal-probe.ts";
+
+const path = "/sessions/project/2026-07-30T11-03-04-544Z_019fb2b1-3060-7000-a086-4e7b785fd895.jsonl";
+
+describe("journal probe session refs", () => {
+  test.each(["omp", "pi"])("uses Herdr's path ref for %s", (agent) => {
+    expect(refFor(agent, path)).toEqual({ kind: "path", value: path });
+  });
+
+  test("derives id refs for UUID-based harnesses", () => {
+    expect(refFor("claude", path)).toEqual({
+      kind: "id",
+      value: "019fb2b1-3060-7000-a086-4e7b785fd895",
+    });
+    expect(refFor("claude", "/sessions/subagent.jsonl")).toBeNull();
+  });
+});

--- a/scripts/journal-probe.ts
+++ b/scripts/journal-probe.ts
@@ -61,9 +61,9 @@ const MAX_CANDIDATES = 12;
 /**
  * Rebuild the session ref Herdr would have reported for this log, per harness.
  *
- * This is the part worth probing: each adapter's resolve() is a different strategy (Claude scans flat
- * project dirs, Codex walks date partitions, pi takes the path straight), and each derives from a
- * differently-shaped filename.
+ * This is the part worth probing: Claude scans flat project dirs, Codex walks date partitions, and
+ * the Pi and OMP adapters resolve the reported path directly. Their differently-shaped filenames
+ * exercise both id- and path-based refs.
  */
 export function refFor(agent: string, path: string): AgentSessionRef | null {
   const file = path.slice(path.lastIndexOf("/") + 1).replace(/\.jsonl$/, "");

--- a/scripts/journal-probe.ts
+++ b/scripts/journal-probe.ts
@@ -65,10 +65,10 @@ const MAX_CANDIDATES = 12;
  * project dirs, Codex walks date partitions, pi takes the path straight), and each derives from a
  * differently-shaped filename.
  */
-function refFor(agent: string, path: string): AgentSessionRef | null {
+export function refFor(agent: string, path: string): AgentSessionRef | null {
   const file = path.slice(path.lastIndexOf("/") + 1).replace(/\.jsonl$/, "");
   const uuid = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/i.exec(file)?.[0];
-  if (agent === "pi") return { kind: "path", value: path };
+  if (agent === "pi" || agent === "omp") return { kind: "path", value: path };
   return uuid ? { kind: "id", value: uuid } : null;
 }
 
@@ -135,17 +135,19 @@ async function probe(adapter: JournalAdapter, root: string): Promise<"ok" | "emp
   return "fail";
 }
 
-const cfg = loadConfig();
-const registry = buildJournalRegistry(cfg.journalRoots);
-// Keyed lookup rather than a cast: JournalRoots is a closed shape on purpose (adding a harness
-// should be a type error here until its root is wired), so widen it explicitly.
-const roots = new Map<string, string>(Object.entries(cfg.journalRoots));
+async function main(): Promise<number> {
+  const cfg = loadConfig();
+  const registry = buildJournalRegistry(cfg.journalRoots);
+  const roots = new Map<string, string>(Object.entries(cfg.journalRoots));
 
-console.log("journal adapters — probing real logs\n");
-const results = await Promise.all(
-  Object.entries(registry).map(([agent, adapter]) => probe(adapter, roots.get(agent) ?? "")),
-);
-const failed = results.filter((r) => r === "fail").length;
-const ok = results.filter((r) => r === "ok").length;
-console.log(`\n${ok} ok, ${results.length - ok - failed} with no logs, ${failed} failed`);
-process.exit(failed > 0 ? 1 : 0);
+  console.log("journal adapters — probing real logs\n");
+  const results = await Promise.all(
+    Object.entries(registry).map(([agent, adapter]) => probe(adapter, roots.get(agent) ?? "")),
+  );
+  const failed = results.filter((result) => result === "fail").length;
+  const ok = results.filter((result) => result === "ok").length;
+  console.log(`\n${ok} ok, ${results.length - ok - failed} with no logs, ${failed} failed`);
+  return failed;
+}
+
+if (import.meta.main) process.exit(await main());

--- a/web/src/components/firstmate-overview.test.tsx
+++ b/web/src/components/firstmate-overview.test.tsx
@@ -1,0 +1,249 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { FirstmateOverview } from "./firstmate-overview";
+import type { FirstmateStatus, SessionSummary } from "@/lib/types";
+
+const primary: SessionSummary = {
+  name: "default",
+  isPrimary: true,
+  reachable: true,
+  agents: 1,
+  working: 0,
+  blocked: 0,
+};
+const other: SessionSummary = {
+  name: "collie-demo",
+  isPrimary: false,
+  reachable: true,
+  agents: 1,
+  working: 0,
+  blocked: 0,
+};
+const sessions: SessionSummary[] = [primary, other];
+
+type ReadyFirstmate = Extract<FirstmateStatus, { state: "ready" | "stale" }>;
+
+function ready(over: Partial<Omit<ReadyFirstmate, "state">> = {}, state: "ready" | "stale" = "ready"): FirstmateStatus {
+  return {
+    state,
+    home: "click-web-terminal",
+    generatedAt: new Date().toISOString(),
+    decisions: [],
+    inFlight: [],
+    gates: [],
+    landed: [],
+    prs: [],
+    prState: "ready",
+    ...over,
+  };
+}
+
+const headingTexts = () =>
+  screen.getAllByRole("heading").map((el) => el.textContent?.toLowerCase() ?? "");
+
+describe("FirstmateOverview — absence and cold states", () => {
+  it("renders nothing when firstmate is absent (feature not configured)", () => {
+    const { container } = render(
+      <FirstmateOverview firstmate={undefined} sessions={sessions} onOpen={vi.fn()} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("shows a compact loading line, no sections", () => {
+    render(<FirstmateOverview firstmate={{ state: "loading" }} sessions={sessions} onOpen={vi.fn()} />);
+    expect(screen.getByText(/loading firstmate/i)).toBeInTheDocument();
+    expect(screen.queryAllByRole("heading")).toHaveLength(0);
+  });
+
+  it("shows a bounded, friendly line for an unavailable feed — never the raw reason", () => {
+    render(
+      <FirstmateOverview
+        firstmate={{ state: "unavailable", reason: "command-failed" }}
+        sessions={sessions}
+        onOpen={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/firstmate couldn.t produce a report/i)).toBeInTheDocument();
+    expect(screen.queryByText(/command-failed/)).not.toBeInTheDocument();
+    expect(screen.queryAllByRole("heading")).toHaveLength(0);
+  });
+
+  it("says so, compactly, when the feed is ready but the fleet is quiet", () => {
+    render(<FirstmateOverview firstmate={ready()} sessions={sessions} onOpen={vi.fn()} />);
+    expect(screen.getByText("Nothing to report")).toBeInTheDocument();
+    expect(screen.queryAllByRole("heading")).toHaveLength(0);
+  });
+});
+
+describe("FirstmateOverview — populated sections", () => {
+  function populated(state: "ready" | "stale" = "ready"): FirstmateStatus {
+    return ready(
+      {
+        decisions: [
+          {
+            id: "d1",
+            summary: "Pick a migration strategy",
+            owner: "damian",
+            endpoint: { session: "default", paneId: "w1:p1" },
+          },
+        ],
+        inFlight: [{ id: "f1", kind: "ship", state: "running", doing: "Implementing the dashboard" }],
+        gates: [
+          { id: "g1", title: "CI required checks", blockedBy: "lint", reason: "failing", owner: "ci" },
+        ],
+        prs: [
+          {
+            number: "42",
+            repo: "click-web-terminal",
+            task: "Firstmate dashboard",
+            url: "https://github.com/org/repo/pull/42",
+            review: "approved",
+            mergeable: "clean",
+            checks: "passing",
+            endpoint: { session: "collie-demo", paneId: "w2:p1" },
+          },
+        ],
+        landed: [{ id: "l1", what: "Shipped the OMP journal", owner: "damian" }],
+      },
+      state,
+    );
+  }
+
+  it("renders every section in the contracted order: Needs you, In flight, Gates, PRs, Delivered", () => {
+    render(<FirstmateOverview firstmate={populated()} sessions={sessions} onOpen={vi.fn()} />);
+    expect(headingTexts()).toEqual(["needs you(1)", "in flight(1)", "gates(1)", "prs(1)", "delivered(1)"]);
+  });
+
+  it("omits a section with no members rather than an empty heading", () => {
+    const data = populated();
+    if (data.state === "ready") data.gates = [];
+    render(<FirstmateOverview firstmate={data} sessions={sessions} onOpen={vi.fn()} />);
+    expect(headingTexts()).toEqual(["needs you(1)", "in flight(1)", "prs(1)", "delivered(1)"]);
+  });
+
+  it("shows every row's content as plain text — the fleet summary, not chrome", () => {
+    render(<FirstmateOverview firstmate={populated()} sessions={sessions} onOpen={vi.fn()} />);
+    expect(screen.getByText("Pick a migration strategy")).toBeInTheDocument();
+    expect(screen.getByText("Implementing the dashboard")).toBeInTheDocument();
+    expect(screen.getByText("CI required checks")).toBeInTheDocument();
+    expect(screen.getByText("Shipped the OMP journal")).toBeInTheDocument();
+  });
+
+  it("navigates a verified endpoint via panePath's session convention (primary → undefined)", async () => {
+    const user = userEvent.setup();
+    const onOpen = vi.fn();
+    render(<FirstmateOverview firstmate={populated()} sessions={sessions} onOpen={onOpen} />);
+    await user.click(screen.getByText("Pick a migration strategy"));
+    expect(onOpen).toHaveBeenCalledWith("w1:p1", undefined);
+  });
+
+  it("navigates a non-primary endpoint with its session name", async () => {
+    const user = userEvent.setup();
+    const onOpen = vi.fn();
+    render(<FirstmateOverview firstmate={populated()} sessions={sessions} onOpen={onOpen} />);
+    await user.click(screen.getByText("Firstmate dashboard"));
+    expect(onOpen).toHaveBeenCalledWith("w2:p1", "collie-demo");
+  });
+
+  it("leaves an unresolved task visible but unlinked — no button, no click target", () => {
+    render(<FirstmateOverview firstmate={populated()} sessions={sessions} onOpen={vi.fn()} />);
+    const row = screen.getByText("CI required checks");
+    expect(row.closest("button")).toBeNull();
+  });
+
+  it("renders the PR's bridge-verified GitHub URL as a real external link", () => {
+    render(<FirstmateOverview firstmate={populated()} sessions={sessions} onOpen={vi.fn()} />);
+    const link = screen.getByRole("link", { name: /open pr #42 on github/i });
+    expect(link).toHaveAttribute("href", "https://github.com/org/repo/pull/42");
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", expect.stringContaining("noopener"));
+  });
+
+  it("tags a stale feed as stale, visibly, without hiding its data", () => {
+    render(<FirstmateOverview firstmate={populated("stale")} sessions={sessions} onOpen={vi.fn()} />);
+    expect(screen.getByRole("status")).toHaveTextContent(/stale/i);
+    expect(screen.getByText("Pick a migration strategy")).toBeInTheDocument();
+  });
+});
+
+describe("FirstmateOverview — PR enrichment state (independent of the base feed)", () => {
+  it("stays 'Nothing to report' when PR enrichment is disabled and the fleet is otherwise quiet", () => {
+    render(
+      <FirstmateOverview
+        firstmate={ready({ prState: "disabled" })}
+        sessions={sessions}
+        onOpen={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("Nothing to report")).toBeInTheDocument();
+    expect(screen.queryByText(/prs/i)).not.toBeInTheDocument();
+  });
+
+  it("shows PRs as checking, not as a confirmed 'no open PRs', while enrichment is loading", () => {
+    render(
+      <FirstmateOverview
+        firstmate={ready({ prState: "loading" })}
+        sessions={sessions}
+        onOpen={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("PRs")).toBeInTheDocument();
+    expect(screen.getByText(/checking prs/i)).toBeInTheDocument();
+    expect(screen.queryByText(/no open prs/i)).not.toBeInTheDocument();
+    expect(screen.queryByText("Nothing to report")).not.toBeInTheDocument();
+  });
+
+  it("shows a fixed line, never subprocess detail, while enrichment is unavailable", () => {
+    render(
+      <FirstmateOverview
+        firstmate={ready({ prState: "unavailable" })}
+        sessions={sessions}
+        onOpen={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("PRs")).toBeInTheDocument();
+    expect(screen.getByText(/couldn.t check prs/i)).toBeInTheDocument();
+    expect(screen.queryByText("Nothing to report")).not.toBeInTheDocument();
+  });
+
+  it("shows the bridge's PR check summary even when there are currently zero open PRs", () => {
+    render(
+      <FirstmateOverview
+        firstmate={ready({ prState: "ready", prSummary: "checked 1 repo, 0 open" })}
+        sessions={sessions}
+        onOpen={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("PRs")).toBeInTheDocument();
+    expect(screen.getByText("checked 1 repo, 0 open")).toBeInTheDocument();
+    expect(screen.queryByText("Nothing to report")).not.toBeInTheDocument();
+  });
+
+  it("tags stale PR enrichment independently of the base feed's own (fresh) state", () => {
+    render(
+      <FirstmateOverview
+        firstmate={ready({
+          prState: "stale",
+          prs: [
+            {
+              number: "7",
+              repo: "click-web-terminal",
+              task: "Fix flaky test",
+              url: "https://github.com/org/repo/pull/7",
+              review: "pending",
+              mergeable: "clean",
+              checks: "pending",
+            },
+          ],
+        })}
+        sessions={sessions}
+        onOpen={vi.fn()}
+      />,
+    );
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+    expect(screen.getByText("PRs")).toBeInTheDocument();
+    expect(screen.getByText("stale")).toBeInTheDocument();
+    expect(screen.getByText("#7 · click-web-terminal")).toBeInTheDocument();
+  });
+});

--- a/web/src/components/firstmate-overview.test.tsx
+++ b/web/src/components/firstmate-overview.test.tsx
@@ -27,7 +27,6 @@ type ReadyFirstmate = Extract<FirstmateStatus, { state: "ready" | "stale" }>;
 function ready(over: Partial<Omit<ReadyFirstmate, "state">> = {}, state: "ready" | "stale" = "ready"): FirstmateStatus {
   return {
     state,
-    home: "click-web-terminal",
     generatedAt: new Date().toISOString(),
     decisions: [],
     inFlight: [],
@@ -154,15 +153,27 @@ describe("FirstmateOverview — populated sections", () => {
 
   it("renders the PR's bridge-verified GitHub URL as a real external link", () => {
     render(<FirstmateOverview firstmate={populated()} sessions={sessions} onOpen={vi.fn()} />);
-    const link = screen.getByRole("link", { name: /open pr #42 on github/i });
+    const link = screen.getByRole("link", { name: /open pr #42 in click-web-terminal on github/i });
     expect(link).toHaveAttribute("href", "https://github.com/org/repo/pull/42");
     expect(link).toHaveAttribute("target", "_blank");
     expect(link).toHaveAttribute("rel", expect.stringContaining("noopener"));
   });
 
+  it("distinguishes equal PR numbers from different repositories", () => {
+    const data = populated();
+    if (data.state !== "ready" && data.state !== "stale") throw new Error("expected ready data");
+    data.prs = [
+      { ...data.prs[0]!, repo: "owner/a", url: "https://github.com/owner/a/pull/42" },
+      { ...data.prs[0]!, repo: "owner/b", url: "https://github.com/owner/b/pull/42" },
+    ];
+    render(<FirstmateOverview firstmate={data} sessions={sessions} onOpen={vi.fn()} />);
+    expect(screen.getByRole("link", { name: /open pr #42 in owner\/a on github/i })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /open pr #42 in owner\/b on github/i })).toBeInTheDocument();
+  });
+
   it("tags a stale feed as stale, visibly, without hiding its data", () => {
     render(<FirstmateOverview firstmate={populated("stale")} sessions={sessions} onOpen={vi.fn()} />);
-    expect(screen.getByRole("status")).toHaveTextContent(/stale/i);
+    expect(screen.getAllByRole("status").some((status) => status.textContent === "stale")).toBe(true);
     expect(screen.getByText("Pick a migration strategy")).toBeInTheDocument();
   });
 });
@@ -192,6 +203,7 @@ describe("FirstmateOverview — PR enrichment state (independent of the base fee
     expect(screen.getByText(/checking prs/i)).toBeInTheDocument();
     expect(screen.queryByText(/no open prs/i)).not.toBeInTheDocument();
     expect(screen.queryByText("Nothing to report")).not.toBeInTheDocument();
+    expect(screen.getByRole("status")).toHaveTextContent("Checking pull requests");
   });
 
   it("shows a fixed line, never subprocess detail, while enrichment is unavailable", () => {
@@ -205,6 +217,7 @@ describe("FirstmateOverview — PR enrichment state (independent of the base fee
     expect(screen.getByText("PRs")).toBeInTheDocument();
     expect(screen.getByText(/couldn.t check prs/i)).toBeInTheDocument();
     expect(screen.queryByText("Nothing to report")).not.toBeInTheDocument();
+    expect(screen.getByRole("status")).toHaveTextContent("Pull request check unavailable");
   });
 
   it("shows the bridge's PR check summary even when there are currently zero open PRs", () => {
@@ -218,6 +231,8 @@ describe("FirstmateOverview — PR enrichment state (independent of the base fee
     expect(screen.getByText("PRs")).toBeInTheDocument();
     expect(screen.getByText("checked 1 repo, 0 open")).toBeInTheDocument();
     expect(screen.queryByText("Nothing to report")).not.toBeInTheDocument();
+    expect(screen.getByRole("status")).toHaveTextContent("Pull request check complete: checked 1 repo, 0 open");
+    expect(screen.getByText("checked 1 repo, 0 open")).toHaveClass("break-words");
   });
 
   it("tags stale PR enrichment independently of the base feed's own (fresh) state", () => {
@@ -241,9 +256,23 @@ describe("FirstmateOverview — PR enrichment state (independent of the base fee
         onOpen={vi.fn()}
       />,
     );
-    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+    expect(screen.getByRole("status")).toHaveTextContent("Pull request data stale");
     expect(screen.getByText("PRs")).toBeInTheDocument();
     expect(screen.getByText("stale")).toBeInTheDocument();
     expect(screen.getByText("#7 · click-web-terminal")).toBeInTheDocument();
+  });
+
+  it("keeps a stale warning visible when the last good PR cache was empty", () => {
+    render(
+      <FirstmateOverview
+        firstmate={ready({ prState: "stale", prs: [] })}
+        sessions={sessions}
+        onOpen={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("PRs")).toBeInTheDocument();
+    expect(screen.getByText("stale")).toBeInTheDocument();
+    expect(screen.getByRole("status")).toHaveTextContent("Pull request data stale");
+    expect(screen.queryByText("Nothing to report")).not.toBeInTheDocument();
   });
 });

--- a/web/src/components/firstmate-overview.tsx
+++ b/web/src/components/firstmate-overview.tsx
@@ -1,0 +1,359 @@
+import type { ReactNode } from "react";
+import { AlertCircle, Check, ChevronRight, ExternalLink, Loader2 } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { Card } from "@/components/ui/card";
+import { SectionHeader } from "@/components/section-header";
+import { SectionLabel } from "@/components/ui/section-label";
+import { timeAgo } from "@/lib/format";
+import type {
+  FirstmateChecks,
+  FirstmateEndpoint,
+  FirstmateStatus,
+  FirstmateUnavailableReason,
+  SessionSummary,
+} from "@/lib/types";
+
+interface FirstmateOverviewProps {
+  firstmate: FirstmateStatus | undefined;
+  sessions: readonly SessionSummary[];
+  onOpen: (paneId: string, session: string | undefined) => void;
+}
+
+const UNAVAILABLE_COPY: Record<FirstmateUnavailableReason, string> = {
+  "not-executable": "Firstmate isn't set up on this host.",
+  timeout: "Firstmate didn't respond in time.",
+  "output-limit": "Firstmate's report was too large to read.",
+  "command-failed": "Firstmate couldn't produce a report.",
+  "invalid-output": "Firstmate's report couldn't be read.",
+};
+
+const CHECKS_DOT: Record<FirstmateChecks, string> = {
+  passing: "bg-status-done",
+  failing: "bg-status-blocked",
+  pending: "bg-status-working",
+  none: "bg-status-idle",
+  unknown: "bg-status-unknown",
+};
+
+const CHECKS_LABEL: Record<FirstmateChecks, string> = {
+  passing: "Checks passing",
+  failing: "Checks failing",
+  pending: "Checks pending",
+  none: "No checks",
+  unknown: "Checks unknown",
+};
+
+function resolveSession(session: string, sessions: readonly SessionSummary[]): string | undefined {
+  const match = sessions.find((s) => s.name === session);
+  return match?.isPrimary ? undefined : session;
+}
+
+function TaskRow({
+  primary,
+  secondary,
+  badge,
+  tone,
+  endpoint,
+  sessions,
+  onOpen,
+  external,
+}: {
+  primary: ReactNode;
+  secondary?: ReactNode;
+  badge?: ReactNode;
+  tone: "attention" | "flat";
+  endpoint?: FirstmateEndpoint;
+  sessions: readonly SessionSummary[];
+  onOpen: (paneId: string, session: string | undefined) => void;
+  external?: { href: string; label: string };
+}) {
+  const Shell = tone === "attention" ? Card : "div";
+  const shell = (
+    <Shell
+      className={cn(
+        tone === "attention"
+          ? "flex-row items-center gap-2 rounded-xl px-3 py-2.5 shadow-sm"
+          : "flex flex-row items-center gap-2 px-2.5 py-2.5",
+      )}
+    >
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-sm font-medium">{primary}</p>
+        {secondary && <div className="truncate text-xs text-muted-foreground">{secondary}</div>}
+      </div>
+      {badge}
+      {endpoint && <ChevronRight className="size-3.5 shrink-0 text-muted-foreground" aria-hidden />}
+    </Shell>
+  );
+
+  return (
+    <div className="flex items-center gap-1">
+      {endpoint ? (
+        <button
+          type="button"
+          onClick={() => onOpen(endpoint.paneId, resolveSession(endpoint.session, sessions))}
+          className="min-w-0 flex-1 text-left transition-transform active:scale-[0.99]"
+        >
+          {shell}
+        </button>
+      ) : (
+        <div className="min-w-0 flex-1">{shell}</div>
+      )}
+      {external && (
+        <a
+          href={external.href}
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label={external.label}
+          className="flex shrink-0 items-center justify-center rounded-md p-2 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+        >
+          <ExternalLink className="size-3.5" aria-hidden />
+        </a>
+      )}
+    </div>
+  );
+}
+
+interface SectionSpec {
+  key: string;
+  label: string;
+  dot?: string;
+  accent?: boolean;
+  tone: "attention" | "flat";
+  rows: { key: string; node: ReactNode }[];
+  note?: ReactNode;
+  summary?: string;
+  tag?: ReactNode;
+}
+
+function buildSections(
+  data: Extract<FirstmateStatus, { state: "ready" | "stale" }>,
+  sessions: readonly SessionSummary[],
+  onOpen: (paneId: string, session: string | undefined) => void,
+): SectionSpec[] {
+  const prRows = data.prs.map((pr) => ({
+    key: `${pr.repo}#${pr.number}`,
+    node: (
+      <TaskRow
+        primary={`#${pr.number} · ${pr.repo}`}
+        secondary={
+          <>
+            <span className="block truncate">{pr.task}</span>
+            <span className="block truncate">
+              {pr.review} · {pr.mergeable}
+            </span>
+          </>
+        }
+        badge={
+          <span
+            className="flex shrink-0 items-center"
+            role="img"
+            aria-label={CHECKS_LABEL[pr.checks]}
+          >
+            <span className={cn("size-2 rounded-full", CHECKS_DOT[pr.checks])} aria-hidden />
+          </span>
+        }
+        tone="flat"
+        endpoint={pr.endpoint}
+        sessions={sessions}
+        onOpen={onOpen}
+        external={{ href: pr.url, label: `Open PR #${pr.number} on GitHub` }}
+      />
+    ),
+  }));
+
+  const prNote: ReactNode | undefined =
+    data.prState === "loading" ? (
+      <span className="flex items-center gap-2">
+        <Loader2 className="size-3.5 shrink-0 animate-spin" aria-hidden />
+        Checking PRs…
+      </span>
+    ) : data.prState === "unavailable" ? (
+      <span className="flex items-center gap-2">
+        <AlertCircle className="size-3.5 shrink-0" aria-hidden />
+        Firstmate couldn't check PRs.
+      </span>
+    ) : undefined;
+
+  const sections: SectionSpec[] = [
+    {
+      key: "decisions",
+      label: "Needs you",
+      dot: "bg-status-blocked",
+      accent: true,
+      tone: "attention",
+      rows: data.decisions.map((d) => ({
+        key: d.id,
+        node: (
+          <TaskRow
+            primary={d.summary}
+            secondary={`${d.id} · ${d.owner}`}
+            tone="attention"
+            endpoint={d.endpoint}
+            sessions={sessions}
+            onOpen={onOpen}
+          />
+        ),
+      })),
+    },
+    {
+      key: "inFlight",
+      label: "In flight",
+      dot: "bg-status-working",
+      tone: "flat",
+      rows: data.inFlight.map((t) => ({
+        key: t.id,
+        node: (
+          <TaskRow
+            primary={t.doing}
+            secondary={`${t.id} · ${t.kind} · ${t.state}`}
+            tone="flat"
+            endpoint={t.endpoint}
+            sessions={sessions}
+            onOpen={onOpen}
+          />
+        ),
+      })),
+    },
+    {
+      key: "gates",
+      label: "Gates",
+      dot: "bg-status-blocked",
+      tone: "attention",
+      rows: data.gates.map((g) => ({
+        key: g.id,
+        node: (
+          <TaskRow
+            primary={g.title}
+            secondary={`${g.id} · Blocked by ${g.blockedBy} — ${g.reason} · ${g.owner}`}
+            tone="attention"
+            endpoint={g.endpoint}
+            sessions={sessions}
+            onOpen={onOpen}
+          />
+        ),
+      })),
+    },
+  ];
+
+  sections.push({
+    key: "prs",
+    label: "PRs",
+    tone: "flat",
+    rows: prRows,
+    note: prNote,
+    summary: data.prSummary,
+    tag:
+      data.prState === "stale" ? (
+        <span className="rounded-full bg-status-working/15 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-status-working">
+          stale
+        </span>
+      ) : undefined,
+  });
+
+  sections.push({
+    key: "landed",
+    label: "Delivered",
+    dot: "bg-status-done",
+    tone: "flat",
+    rows: data.landed.map((l) => ({
+      key: l.id,
+      node: (
+        <TaskRow
+          primary={l.what}
+          secondary={`${l.id} · ${l.owner}`}
+          tone="flat"
+          sessions={sessions}
+          onOpen={onOpen}
+        />
+      ),
+    })),
+  });
+
+  return sections;
+}
+
+export function FirstmateOverview({ firstmate, sessions, onOpen }: FirstmateOverviewProps) {
+  if (!firstmate) return null;
+
+  if (firstmate.state === "loading") {
+    return (
+      <section className="flex flex-col gap-2 px-3 pt-4">
+        <p className="flex items-center gap-2 px-1 py-1 text-sm text-muted-foreground">
+          <Loader2 className="size-4 shrink-0 animate-spin" aria-hidden />
+          Loading Firstmate…
+        </p>
+      </section>
+    );
+  }
+
+  if (firstmate.state === "unavailable") {
+    return (
+      <section className="flex flex-col gap-2 px-3 pt-4">
+        <p className="flex items-center gap-2 px-1 py-1 text-sm text-muted-foreground">
+          <AlertCircle className="size-4 shrink-0" aria-hidden />
+          {UNAVAILABLE_COPY[firstmate.reason]}
+        </p>
+      </section>
+    );
+  }
+
+  const stale = firstmate.state === "stale";
+  const sections = buildSections(firstmate, sessions, onOpen).filter(
+    (s) => s.rows.length > 0 || s.note || s.summary,
+  );
+  const empty = sections.length === 0;
+
+  return (
+    <section className="flex flex-col gap-5 px-3 pt-4">
+      <div className="flex items-center justify-between gap-2 px-1">
+        <SectionLabel className="min-w-0 truncate">Firstmate · {firstmate.home}</SectionLabel>
+        <div className="flex shrink-0 items-center gap-2 text-[11px] text-muted-foreground">
+          {stale && (
+            <span
+              className="rounded-full bg-status-working/15 px-2 py-0.5 font-semibold uppercase tracking-wide text-status-working"
+              role="status"
+            >
+              stale
+            </span>
+          )}
+          <span className="tabular-nums">{timeAgo(Date.parse(firstmate.generatedAt))}</span>
+        </div>
+      </div>
+
+      {empty ? (
+        <p className="flex items-center gap-2 px-1 text-sm font-medium">
+          <Check className="size-5 shrink-0 text-status-done" aria-hidden />
+          Nothing to report
+        </p>
+      ) : (
+        sections.map((s) => (
+          <section key={s.key} className="flex flex-col gap-2">
+            <SectionHeader
+              label={s.label}
+              count={s.rows.length > 0 ? s.rows.length : undefined}
+              {...(s.dot ? { dot: s.dot } : {})}
+              {...(s.accent ? { accent: s.accent } : {})}
+              {...(s.tag ? { trailing: s.tag } : {})}
+            />
+            {s.summary && <p className="px-1 text-xs text-muted-foreground">{s.summary}</p>}
+            {(s.rows.length > 0 || s.note) && (
+              <div
+                className={cn(
+                  "flex flex-col",
+                  s.tone === "attention" ? "gap-2" : "divide-y divide-border/60",
+                )}
+              >
+                {s.rows.length > 0 ? (
+                  s.rows.map((r) => <div key={r.key}>{r.node}</div>)
+                ) : (
+                  <p className="px-2 py-2 text-xs text-muted-foreground">{s.note}</p>
+                )}
+              </div>
+            )}
+          </section>
+        ))
+      )}
+    </section>
+  );
+}

--- a/web/src/components/firstmate-overview.tsx
+++ b/web/src/components/firstmate-overview.tsx
@@ -157,7 +157,7 @@ function buildSections(
         endpoint={pr.endpoint}
         sessions={sessions}
         onOpen={onOpen}
-        external={{ href: pr.url, label: `Open PR #${pr.number} on GitHub` }}
+        external={{ href: pr.url, label: `Open PR #${pr.number} in ${pr.repo} on GitHub` }}
       />
     ),
   }));
@@ -300,14 +300,24 @@ export function FirstmateOverview({ firstmate, sessions, onOpen }: FirstmateOver
 
   const stale = firstmate.state === "stale";
   const sections = buildSections(firstmate, sessions, onOpen).filter(
-    (s) => s.rows.length > 0 || s.note || s.summary,
+    (section) => section.rows.length > 0 || section.note || section.summary || section.tag,
   );
   const empty = sections.length === 0;
+  const prStatus =
+    firstmate.prState === "disabled"
+      ? null
+      : firstmate.prState === "loading"
+        ? "Checking pull requests"
+        : firstmate.prState === "unavailable"
+          ? "Pull request check unavailable"
+          : firstmate.prState === "stale"
+            ? `Pull request data stale${firstmate.prSummary ? `: ${firstmate.prSummary}` : ""}`
+            : `Pull request check complete${firstmate.prSummary ? `: ${firstmate.prSummary}` : ""}`;
 
   return (
     <section className="flex flex-col gap-5 px-3 pt-4">
       <div className="flex items-center justify-between gap-2 px-1">
-        <SectionLabel className="min-w-0 truncate">Firstmate · {firstmate.home}</SectionLabel>
+        <SectionLabel>Firstmate</SectionLabel>
         <div className="flex shrink-0 items-center gap-2 text-[11px] text-muted-foreground">
           {stale && (
             <span
@@ -320,6 +330,11 @@ export function FirstmateOverview({ firstmate, sessions, onOpen }: FirstmateOver
           <span className="tabular-nums">{timeAgo(Date.parse(firstmate.generatedAt))}</span>
         </div>
       </div>
+      {prStatus && (
+        <span className="sr-only" role="status" aria-live="polite">
+          {prStatus}
+        </span>
+      )}
 
       {empty ? (
         <p className="flex items-center gap-2 px-1 text-sm font-medium">
@@ -336,7 +351,9 @@ export function FirstmateOverview({ firstmate, sessions, onOpen }: FirstmateOver
               {...(s.accent ? { accent: s.accent } : {})}
               {...(s.tag ? { trailing: s.tag } : {})}
             />
-            {s.summary && <p className="px-1 text-xs text-muted-foreground">{s.summary}</p>}
+            {s.summary && (
+              <p className="min-w-0 break-words px-1 text-xs text-muted-foreground">{s.summary}</p>
+            )}
             {(s.rows.length > 0 || s.note) && (
               <div
                 className={cn(

--- a/web/src/lib/loaders.ts
+++ b/web/src/lib/loaders.ts
@@ -20,6 +20,7 @@ import type {
   AgentView,
   BridgeStatus,
   DeviceAuth,
+  FirstmateStatus,
   PaneHistoryResponse,
   PaneReadResponse,
   SessionSummary,
@@ -63,6 +64,7 @@ export interface HomeData {
   bridge: BridgeStatus | undefined;
   /** Per-device authorisation; undefined when the feature is off or not yet known. */
   device: DeviceAuth | undefined;
+  firstmate?: FirstmateStatus;
   agents: AgentView[];
   shellPanes: AgentView[];
   workspaces: WorkspaceView[];
@@ -143,6 +145,7 @@ function toHomeData(snap: SnapshotResponse, session: string | undefined, error: 
   return {
     bridge: snap.bridge,
     device: snap.device,
+    firstmate: snap.firstmate,
     agents: snap.agents,
     shellPanes: snap.shellPanes ?? [],
     workspaces: snap.workspaces ?? [],
@@ -167,6 +170,7 @@ function staleHome(session: string | undefined): HomeData {
     : {
         bridge: undefined,
         device: undefined,
+        firstmate: undefined,
         agents: [],
         shellPanes: [],
         workspaces: [],

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -215,7 +215,6 @@ export type FirstmateUnavailableReason =
 export type FirstmatePrState = "disabled" | "loading" | "ready" | "stale" | "unavailable";
 
 interface FirstmateData {
-  home: string;
   generatedAt: string;
   inFlight: FirstmateInFlight[];
   decisions: FirstmateDecision[];

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -157,10 +157,85 @@ export interface UpdateInfo {
   checkedAt: number | null;
 }
 
+export interface FirstmateEndpoint {
+  session: string;
+  paneId: string;
+}
+
+export interface FirstmateDecision {
+  id: string;
+  summary: string;
+  owner: string;
+  endpoint?: FirstmateEndpoint;
+}
+
+export interface FirstmateInFlight {
+  id: string;
+  kind: string;
+  state: string;
+  doing: string;
+  endpoint?: FirstmateEndpoint;
+}
+
+export interface FirstmateGate {
+  id: string;
+  title: string;
+  blockedBy: string;
+  reason: string;
+  owner: string;
+  endpoint?: FirstmateEndpoint;
+}
+
+export interface FirstmateLanded {
+  id: string;
+  what: string;
+  owner: string;
+}
+
+export type FirstmateChecks = "none" | "pending" | "passing" | "failing" | "unknown";
+
+export interface FirstmatePullRequest {
+  number: string;
+  repo: string;
+  task: string;
+  url: string;
+  review: string;
+  mergeable: string;
+  checks: FirstmateChecks;
+  endpoint?: FirstmateEndpoint;
+}
+
+export type FirstmateUnavailableReason =
+  | "not-executable"
+  | "timeout"
+  | "output-limit"
+  | "command-failed"
+  | "invalid-output";
+
+export type FirstmatePrState = "disabled" | "loading" | "ready" | "stale" | "unavailable";
+
+interface FirstmateData {
+  home: string;
+  generatedAt: string;
+  inFlight: FirstmateInFlight[];
+  decisions: FirstmateDecision[];
+  gates: FirstmateGate[];
+  landed: FirstmateLanded[];
+  prs: FirstmatePullRequest[];
+  prState: FirstmatePrState;
+  prSummary?: string;
+}
+
+export type FirstmateStatus =
+  | { state: "loading" }
+  | { state: "unavailable"; reason: FirstmateUnavailableReason }
+  | ({ state: "ready" | "stale" } & FirstmateData);
+
 export interface SnapshotResponse {
   bridge: BridgeStatus;
   /** Per-device authorisation for the requesting client; absent when the feature is off. */
   device?: DeviceAuth;
+  firstmate?: FirstmateStatus;
   agents: AgentView[];
   shellPanes: AgentView[];
   workspaces: WorkspaceView[];

--- a/web/src/routes/home.test.tsx
+++ b/web/src/routes/home.test.tsx
@@ -1,0 +1,168 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { createMemoryRouter, RouterProvider } from "react-router";
+
+import { HomeRoute } from "./home";
+import { ROOT_ROUTE_ID, type HomeData } from "@/lib/loaders";
+import { panePath } from "@/lib/nav";
+import type { AgentView, FirstmateStatus, SessionSummary } from "@/lib/types";
+
+const sessions: SessionSummary[] = [
+  { name: "default", isPrimary: true, reachable: true, agents: 1, working: 0, blocked: 0 },
+  { name: "collie-demo", isPrimary: false, reachable: true, agents: 0, working: 0, blocked: 0 },
+];
+
+function agent(paneId: string, over: Partial<AgentView> = {}): AgentView {
+  return {
+    paneId,
+    workspaceId: "w1",
+    workspaceLabel: "webapp",
+    workspaceNumber: 1,
+    tabId: "w1:t1",
+    agent: "claude",
+    status: "working",
+    cwd: "/home/you/webapp",
+    focused: false,
+    ...over,
+  };
+}
+
+function homeData(over: Partial<HomeData> = {}): HomeData {
+  return {
+    bridge: "connected",
+    device: undefined,
+    firstmate: undefined,
+    agents: [],
+    shellPanes: [],
+    workspaces: [],
+    tabs: [],
+    sessions,
+    session: undefined,
+    snoozedUntil: null,
+    update: undefined,
+    error: false,
+    authError: false,
+    ...over,
+  };
+}
+
+function readyFirstmate(state: "ready" | "stale" = "ready"): FirstmateStatus {
+  return {
+    state,
+    home: "click-web-terminal",
+    generatedAt: new Date().toISOString(),
+    decisions: [
+      {
+        id: "d1",
+        summary: "Approve the release cut",
+        owner: "damian",
+        endpoint: { session: "collie-demo", paneId: "w2:p9" },
+      },
+    ],
+    inFlight: [],
+    gates: [],
+    landed: [],
+    prs: [],
+    prState: "disabled",
+  };
+}
+
+function makeRouter(data: HomeData) {
+  return createMemoryRouter(
+    [
+      {
+        id: ROOT_ROUTE_ID,
+        path: "/",
+        loader: () => data,
+        children: [
+          { index: true, element: <HomeRoute /> },
+          {
+            path: "pane/:paneId",
+            element: <div data-testid="pane-route" />,
+          },
+        ],
+      },
+    ],
+    { initialEntries: ["/"] },
+  );
+}
+
+function renderHome(data: HomeData) {
+  const router = makeRouter(data);
+  render(<RouterProvider router={router} />);
+  return router;
+}
+
+describe("HomeRoute — Firstmate composition", () => {
+  it("renders nothing from Firstmate when it is absent, but still renders the herd", async () => {
+    renderHome(homeData({ agents: [agent("w1:p1")] }));
+    expect(screen.queryByText(/firstmate/i)).not.toBeInTheDocument();
+    expect(await screen.findByText("webapp")).toBeInTheDocument();
+  });
+
+  it("shows Firstmate loading without hiding the agent list", async () => {
+    renderHome(homeData({ agents: [agent("w1:p1")], firstmate: { state: "loading" } }));
+    expect(await screen.findByText(/loading firstmate/i)).toBeInTheDocument();
+    expect(screen.getByText("webapp")).toBeInTheDocument();
+  });
+
+  it("shows Firstmate unavailable without hiding the agent list", async () => {
+    renderHome(
+      homeData({
+        agents: [agent("w1:p1")],
+        firstmate: { state: "unavailable", reason: "timeout" },
+      }),
+    );
+    expect(await screen.findByText(/didn.t respond in time/i)).toBeInTheDocument();
+    expect(screen.getByText("webapp")).toBeInTheDocument();
+  });
+
+  it("shows Firstmate's valid-empty state without hiding the agent list", async () => {
+    renderHome(
+      homeData({
+        agents: [agent("w1:p1")],
+        firstmate: {
+          state: "ready",
+          home: "click-web-terminal",
+          generatedAt: new Date().toISOString(),
+          decisions: [],
+          inFlight: [],
+          gates: [],
+          landed: [],
+          prs: [],
+          prState: "disabled",
+        },
+      }),
+    );
+    expect(await screen.findByText("Nothing to report")).toBeInTheDocument();
+    expect(screen.getByText("webapp")).toBeInTheDocument();
+  });
+
+  it("renders Firstmate above AgentList, never replacing it", async () => {
+    renderHome(homeData({ agents: [agent("w1:p1")], firstmate: readyFirstmate() }));
+    const decisionText = await screen.findByText(/approve the release cut/i);
+    const agentRow = await screen.findByText("webapp");
+    // DOCUMENT_POSITION_FOLLOWING on agentRow (relative to decisionText) means Firstmate comes first.
+    expect(
+      decisionText.compareDocumentPosition(agentRow) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
+  it("makes a stale feed visibly stale", async () => {
+    renderHome(homeData({ firstmate: readyFirstmate("stale") }));
+    expect(await screen.findByRole("status")).toHaveTextContent(/stale/i);
+  });
+
+  it("navigates a Firstmate task's endpoint via panePath(paneId, session)", async () => {
+    const user = userEvent.setup();
+    const router = makeRouter(homeData({ firstmate: readyFirstmate() }));
+    render(<RouterProvider router={router} />);
+
+    await user.click(await screen.findByText(/approve the release cut/i));
+
+    expect(await screen.findByTestId("pane-route")).toBeInTheDocument();
+    expect(router.state.location.pathname + router.state.location.search).toBe(
+      panePath("w2:p9", "collie-demo"),
+    );
+  });
+});

--- a/web/src/routes/home.test.tsx
+++ b/web/src/routes/home.test.tsx
@@ -49,7 +49,6 @@ function homeData(over: Partial<HomeData> = {}): HomeData {
 function readyFirstmate(state: "ready" | "stale" = "ready"): FirstmateStatus {
   return {
     state,
-    home: "click-web-terminal",
     generatedAt: new Date().toISOString(),
     decisions: [
       {
@@ -123,7 +122,6 @@ describe("HomeRoute — Firstmate composition", () => {
         agents: [agent("w1:p1")],
         firstmate: {
           state: "ready",
-          home: "click-web-terminal",
           generatedAt: new Date().toISOString(),
           decisions: [],
           inFlight: [],

--- a/web/src/routes/home.tsx
+++ b/web/src/routes/home.tsx
@@ -4,6 +4,7 @@ import { useNavigate, useRouteLoaderData } from "react-router";
 import { AppHeader, SettingsGear } from "@/components/app-header";
 import { SessionSwitcher } from "@/components/session-switcher";
 import { ReadOnlyBanner } from "@/components/read-only-banner";
+import { FirstmateOverview } from "@/components/firstmate-overview";
 import { AgentList } from "@/components/agent-list";
 import { SpaceOverview } from "@/components/space-overview";
 import { NewSpaceSheet } from "@/components/new-space-sheet";
@@ -55,6 +56,11 @@ export function HomeRoute() {
         <ReadOnlyBanner device={data.device} />
 
         <main className="flex-1">
+          <FirstmateOverview
+            firstmate={data.firstmate}
+            sessions={data.sessions}
+            onOpen={(paneId, session) => navigate(panePath(paneId, session))}
+          />
           {/* One list, every section, in triage order. It used to be split in two so "Needs you"
               could be hoisted above the spaces overview; with Spaces last there is nothing to
               straddle. */}


### PR DESCRIPTION
## Why

Collie already sees OMP panes through Herdr, but those panes had no journal history. Firstmate supervises the same Herdr fleet, but its semantic task, blocker, delivery, and PR state was unavailable in Collie's mobile UI.

## How

- add a first-class OMP journal adapter for OMP v3 JSONL, including user-visible `custom_message` notes
- reject internal developer/system rows and malformed notice cursors before reusing the Pi v3 parser
- add `COLLIE_OMP_ROOT` with the contained Pi transcript source for session resolution
- add an optional Firstmate provider configured by a startup-resolved trusted home
- execute only `bin/fm-bearings-snapshot.sh` with fixed argv, minimal environment, timeout, output caps, and bounded PR discovery
- strictly project `fm-bearings.v1` into an allowlisted DTO; remove home metadata and fail-closed redact absolute paths from display strings
- cross-check Firstmate task endpoints against Collie's live Herdr session registry before making rows navigable
- render Needs you, In flight, Gates, PRs/CI, and Delivered above the existing agent list, with explicit loading/unavailable/stale/valid-empty states and accessible PR status updates
- document OMP history and opt-in Firstmate configuration

## Verification

- `bun test bridge/journal/omp.test.ts bridge/journal/registry.test.ts bridge/config.test.ts bridge/firstmate.test.ts bridge/server.test.ts scripts/journal-probe.test.ts` — 144 passed
- `bun run typecheck` — passed
- `cd web && bun run test -- --run src/components/firstmate-overview.test.tsx src/routes/home.test.tsx` — 26 passed
- `cd web && bun run typecheck` — passed
- live journal probe — Claude, Codex, and OMP resolved and parsed; Pi correctly reported no installed logs
- live bridge snapshot — Firstmate ready, no `home` field in the browser DTO
- browser QA at 1440×900, 375×812, and 320×812 — fixed Firstmate header, Delivered above agents, real OMP history navigation, no horizontal overflow, no attributable console errors
- fix-mode PR audit — boundary/security, UI/accessibility, regression, artifacts, comments, test value/determinism, and code-slop reviews all PASS after remediation

## Configuration

Firstmate stays off unless `COLLIE_FIRSTMATE_HOME` points to an existing absolute directory containing executable `bin/fm-bearings-snapshot.sh`. Live PR checks stay off unless `COLLIE_FIRSTMATE_INCLUDE_PRS=on` (or another accepted truthy value).