### PR TITLE
fix(ctl): update the checkout in whatever shape Herdr installed it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to Collie are recorded here. The format follows
 `version` in `herdr-plugin.toml`, `package.json`, and `web/package.json` (enforced by
 `scripts/check-version.sh`). See [`CLAUDE.md`](./CLAUDE.md) → *Versioning* for the bump policy.
 
+## [0.23.1] - 2026-08-03
+
+### Fixed
+
+- `update` now works in a `herdr plugin install` checkout — it is detached and shallow, so `git pull --ff-only` could never run there (#63) (aeeddcd)
+- `update` no longer re-links a Herdr-managed checkout, which would re-register it as local and block `herdr plugin install` (aeeddcd)
+
 ## [0.23.0] - 2026-08-03
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -365,15 +365,16 @@ below as `invoke <cmd>`). The ones you'll actually use:
 | **Status** — the *Collie is running* banner + URLs | `collie-ctl.sh status` | `invoke status` |
 | **URL** — print the tailnet URL | `collie-ctl.sh url` | `invoke url` |
 | **Version** — the running version (`0.x.y+sha`) | `collie-ctl.sh version` | `invoke version` |
-| **Update** — `git pull` + rebuild + restart | `collie-ctl.sh update` | `invoke update` |
+| **Update** — advance the checkout + rebuild + restart | `collie-ctl.sh update` | `invoke update` |
 | **Uninstall** — remove the service; keep `.env` + checkout | `collie-ctl.sh uninstall` | `invoke uninstall` |
 | **Logs** — tail the journal / log file | `collie-ctl.sh logs` | — (script only) |
 
 `start` and `status` end with the **Collie is running** banner — annotated line by line in
 [First run](#first-run--what-youll-see). Its version comes from the *served* bundle stamp, so it's
 the authoritative "what's running" — note `herdr plugin list --json` shows a different value cached
-at `plugin link` time; `update` re-links automatically so that self-heals (to force it:
-`herdr plugin link "$(pwd)"`). **Through a Herdr action you get Herdr's JSON envelope, not the
+at `plugin link` time; for a linked clone `update` re-links automatically so that self-heals (to
+force it: `herdr plugin link "$(pwd)"`), and on Herdr ≥0.8.0 the manifest is re-read from disk
+anyway. **Through a Herdr action you get Herdr's JSON envelope, not the
 banner** — the human-readable output is the action's *captured stdout*, read with
 `herdr plugin log list --plugin herdr.collie` (or run the control script directly to see it inline).
 `build` · `serve` · `unserve` are script-only too.
@@ -392,7 +393,7 @@ Collie registers these actions in `herdr-plugin.toml`; invoke any with
 | `status` | Bridge status | The *Collie is running* banner — readiness ✓/⚠, version, URLs |
 | `url` | Show bridge URL | Print the tailnet URL |
 | `version` | Show version | Print the running version (`0.x.y+sha`) |
-| `update` | Update plugin | `git pull --ff-only` + rebuild + restart |
+| `update` | Update plugin | Advance the checkout (pull, or fetch + re-detach) + rebuild + restart |
 | `uninstall` | Uninstall web bridge (remove service) | Tear down the service (keeps `.env` + checkout) |
 
 ## Manage & update
@@ -426,10 +427,28 @@ does the lot:
 scripts/collie-ctl.sh update    # or: herdr plugin action invoke update --plugin herdr.collie
 ```
 
-It `git pull --ff-only`s, rebuilds the UI, restarts the bridge (re-execing itself, so it's safe even
-when the pull rewrites the script), and **re-links the plugin so Herdr picks up any new actions and
-the new version** (older releases skipped this, which is why a freshly added action could return
-`plugin_action_not_found` until a manual re-link). Confirm via the footer build stamp.
+It advances the checkout, rebuilds the UI and restarts the bridge (re-execing itself, so it's safe
+even when the update rewrites the script). Confirm via the footer build stamp.
+
+How it advances depends on how you installed, because `herdr plugin install` does **not** clone — it
+`git fetch --depth 1` + `checkout --detach`es, leaving a detached, shallow checkout:
+
+- **Linked clone** — `git pull --ff-only` on your branch, then **re-links the plugin** so Herdr picks
+  up any new actions and the new version.
+- **`herdr plugin install`** — fetches the default-branch tip and re-detaches onto it (`--force`, so a
+  lockfile the build rewrote can't wedge the next update). It deliberately does **not** re-link:
+  linking would re-register the plugin as a local path, and Herdr then refuses
+  `herdr plugin install` — the reinstall you'd need if this checkout ever breaks.
+
+> **Installed before 0.23.1?** `update` couldn't run in a `herdr plugin install` checkout at all
+> ([#63](https://github.com/AltanS/collie/issues/63)) — it died with *"You are not currently on a
+> branch"*. Get the fix in with one reinstall, then `update` works from there on:
+> ```bash
+> herdr plugin install AltanS/collie --yes
+> herdr plugin action invoke restart --plugin herdr.collie
+> ```
+> Your `.env` and serve state live outside the checkout, so they survive. If you pinned a version
+> with `--ref`, keep using `herdr plugin install --ref …` — `update` always goes to the latest.
 
 By hand: frontend (`web/`) → `collie-ctl.sh build` (live, no restart — served from disk); backend
 (`bridge/`) → `systemctl --user restart collie`. Run `scripts/install-hooks.sh` once to enable the

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,6 +1,6 @@
 id = "herdr.collie"
 name = "Collie"
-version = "0.23.0"
+version = "0.23.1"
 min_herdr_version = "0.7.0"
 description = "Mobile web UI to monitor and reply to your agent herd, served over Tailscale"
 platforms = ["linux", "macos"]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "collie",
-  "version": "0.23.0",
+  "version": "0.23.1",
   "private": true,
   "license": "MIT",
   "description": "Collie — a mobile web UI to monitor and reply to your Herdr agent herd over Tailscale",

--- a/scripts/collie-ctl.sh
+++ b/scripts/collie-ctl.sh
@@ -476,13 +476,53 @@ cmd_uninstall() {
   echo "  kept: ${CONFIG_DIR}/.env and the checkout — delete those to remove every trace"
 }
 
+# True when the checkout has no branch — which is exactly how `herdr plugin install` leaves it.
+# Herdr's installer is `git init` + `git fetch --depth 1 origin HEAD` + `git checkout --detach
+# FETCH_HEAD`, so a turnkey install is detached AND shallow with no remote-tracking refs, while a
+# `git clone` + `herdr plugin link` dev checkout sits on a branch. ONE predicate decides both how we
+# advance the checkout and whether we re-link (below); two detections would eventually disagree.
+is_managed_checkout() {
+  ! git -C "$PLUGIN_ROOT" symbolic-ref -q HEAD >/dev/null 2>&1
+}
+
+# Advance the checkout to the newest upstream commit, in whichever shape it was installed.
+# `git pull --ff-only` alone was the bug in #63: with no branch there is nothing to pull into, so
+# every turnkey install failed with "You are not currently on a branch" and could never self-update.
+update_checkout() {
+  if ! git -C "$PLUGIN_ROOT" rev-parse --git-dir >/dev/null 2>&1; then
+    echo "error: ${PLUGIN_ROOT} is not a git checkout — refresh it with:" >&2
+    echo "       herdr plugin install AltanS/collie --yes" >&2
+    return 1
+  fi
+  if ! is_managed_checkout; then
+    echo "updating Collie (git pull --ff-only)…"
+    git -C "$PLUGIN_ROOT" pull --ff-only
+    return
+  fi
+  # Detached: re-detach onto the default branch tip the same way Herdr got us here. `--depth 1` only
+  # when we are ALREADY shallow, so an update never truncates the history of a full clone someone
+  # happens to have detached. `--force` because cmd_build runs `bun install`, which can rewrite the
+  # TRACKED lockfiles: a plain checkout would then refuse on the dirty tree and re-break the very
+  # update path this fixes. Discarding local edits here matches Herdr's own refresh semantics — its
+  # reinstall replaces the managed checkout wholesale.
+  echo "updating Collie (Herdr-managed checkout: fetch + detach onto origin HEAD)…"
+  if [ "$(git -C "$PLUGIN_ROOT" rev-parse --is-shallow-repository)" = true ]; then
+    git -C "$PLUGIN_ROOT" fetch --depth 1 origin HEAD
+  else
+    git -C "$PLUGIN_ROOT" fetch origin HEAD
+  fi
+  # -q: without it checkout warns "you are leaving 1 commit behind" on every single update — true,
+  # alarming, and useless here, since the commit we leave is the release we just replaced.
+  git -C "$PLUGIN_ROOT" checkout -q --detach --force FETCH_HEAD
+  echo "→ now at $(git -C "$PLUGIN_ROOT" log -1 --format='%h %s')"
+}
+
 # Update to the latest release. Collie is a link-mode Herdr plugin, so the checkout on disk IS the
-# plugin (Herdr has no `plugin update`) — this is the turnkey refresh: pull, rebuild the UI, restart
-# the backend. The pull can rewrite THIS script, and bash reads scripts by byte offset, so we re-exec
-# the freshly-pulled copy (via the internal `_apply-update` step) to run build + restart.
+# plugin (Herdr has no `plugin update`) — this is the turnkey refresh: advance the checkout, rebuild
+# the UI, restart the backend. That can rewrite THIS script, and bash reads scripts by byte offset,
+# so we re-exec the fresh copy (via the internal `_apply-update` step) to run build + restart.
 cmd_update() {
-  echo "updating Collie (git pull --ff-only)…"
-  git -C "$PLUGIN_ROOT" pull --ff-only
+  update_checkout
   exec bash "${PLUGIN_ROOT}/scripts/collie-ctl.sh" _apply-update
 }
 
@@ -491,8 +531,19 @@ cmd_update() {
 # `herdr plugin list` shows the old version, until a re-link. Re-link here so `update` self-heals it.
 # Best-effort: never fails the update (Herdr may be down, or this may be a non-link install) — it just
 # prints how to do it by hand.
+#
+# NEVER re-link a Herdr-MANAGED checkout: `plugin link` re-registers the plugin with
+# `source.kind = local`, after which Herdr REFUSES `plugin install` ("already linked from a local
+# path") — taking away the reinstall that is the operator's only other way to refresh. The cache this
+# heals is an old-Herdr artifact anyway; Herdr ≥0.8.0 re-reads the manifest from disk on every
+# registry refresh, so a managed install learns new actions without us. The price on older Herdr:
+# never rename an action or move this script — those users invoke the cached definition.
 refresh_registry() {
   command -v herdr >/dev/null || return 0
+  if is_managed_checkout; then
+    echo "note: Herdr-managed install — registry left alone (re-linking would block \`herdr plugin install\`)"
+    return 0
+  fi
   if herdr plugin link "$PLUGIN_ROOT" >/dev/null 2>&1; then
     echo "herdr registry refreshed (re-linked) — new actions are invokable now"
   else

--- a/scripts/collie-ctl.test.sh
+++ b/scripts/collie-ctl.test.sh
@@ -648,6 +648,146 @@ EOF
   assert_contains "$(cat "${CASE_DIR}/build.out")" 'bun not found'
 }
 
+# ── update: the checkout can be in either of the two shapes Collie is installed in ───────────────
+#
+# `herdr plugin install` does NOT clone: it runs `git init` + `git fetch --depth 1 origin HEAD` +
+# `git checkout --detach FETCH_HEAD`, so the plugin lives in a detached, shallow checkout with no
+# remote-tracking refs. `git pull --ff-only` cannot work there ("You are not currently on a branch"),
+# which is issue #63 — the turnkey install could never self-update. These stage both shapes for real,
+# against a local origin, and drive the actual git logic.
+git_q() { git -c user.name=collie-test -c user.email=test@example.invalid "$@"; }
+
+# A local origin plus the two checkout shapes. Echoes nothing; sets ORIGIN_DIR.
+stage_origin() {
+  ORIGIN_DIR="${CASE_DIR}/origin"
+  mkdir -p "$ORIGIN_DIR"
+  git_q -C "$ORIGIN_DIR" init -q -b main
+  echo "v1" > "${ORIGIN_DIR}/VERSION"
+  echo "lock-v1" > "${ORIGIN_DIR}/bun.lock"
+  git_q -C "$ORIGIN_DIR" add -A
+  git_q -C "$ORIGIN_DIR" commit -qm "first"
+}
+
+# One more upstream commit, so an update has something to move to.
+advance_origin() {
+  echo "v2" > "${ORIGIN_DIR}/VERSION"
+  git_q -C "$ORIGIN_DIR" add -A
+  git_q -C "$ORIGIN_DIR" commit -qm "second"
+}
+
+# Run update_checkout() against an arbitrary checkout, with the control script's own PLUGIN_ROOT
+# repointed at it (sourcing computes PLUGIN_ROOT from BASH_SOURCE, so it must be overridden after).
+run_update_checkout() {
+  local root="$1" harness="${CASE_DIR}/update-harness.sh"
+  cat > "$harness" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+export HOME="$HOME_DIR"
+export HERDR_PLUGIN_CONFIG_DIR="$CONFIG_DIR"
+export PATH="$BIN_DIR:$BASE_PATH"
+source "$CTL"
+PLUGIN_ROOT="$root"
+update_checkout
+EOF
+  bash "$harness" 2>&1
+}
+
+# The #63 regression: a Herdr-managed checkout must advance — even with a tracked file dirtied by the
+# build (`bun install` can rewrite the committed lockfiles), which a plain checkout would refuse on,
+# re-breaking update permanently. It must stay detached and stay shallow.
+test_update_advances_a_herdr_managed_checkout() {
+  setup_case update-managed
+  stage_origin
+  local root="${CASE_DIR}/managed"
+  mkdir -p "$root"
+  # Verbatim what herdr's plugin_install does (src/cli/plugin.rs, git_checkout).
+  git_q -C "$root" init -q
+  git_q -C "$root" remote add origin "$ORIGIN_DIR"
+  git_q -C "$root" fetch -q --depth 1 origin HEAD
+  git_q -C "$root" checkout -q --detach FETCH_HEAD
+  advance_origin
+  echo "rewritten-by-bun-install" > "${root}/bun.lock"
+
+  local out; out="$(run_update_checkout "$root")" || fail "update_checkout failed: $out"
+  assert_contains "$out" "Herdr-managed checkout"
+  assert_eq "$(git -C "$root" rev-parse HEAD)" "$(git -C "$ORIGIN_DIR" rev-parse HEAD)"
+  assert_eq "$(cat "${root}/VERSION")" "v2"
+  assert_eq "$(cat "${root}/bun.lock")" "lock-v1"   # --force discarded the build's rewrite
+  assert_eq "$(git -C "$root" rev-parse --is-shallow-repository)" "true"
+  git -C "$root" symbolic-ref -q HEAD >/dev/null 2>&1 &&
+    fail "managed checkout should still be detached"
+  # Idempotent: a second update with nothing new upstream is a no-op, not an error.
+  run_update_checkout "$root" >/dev/null || fail "second update_checkout failed"
+}
+
+# The other shape — a dev clone linked with `herdr plugin link`. It is on a branch, so it must still
+# fast-forward, keep its branch, and keep its full history (no --depth truncation).
+test_update_fast_forwards_a_linked_clone() {
+  setup_case update-linked
+  stage_origin
+  advance_origin
+  local root="${CASE_DIR}/clone"
+  git_q clone -q "$ORIGIN_DIR" "$root"
+  git_q -C "$ORIGIN_DIR" commit -q --allow-empty -m "third"
+
+  local out; out="$(run_update_checkout "$root")" || fail "update_checkout failed: $out"
+  assert_contains "$out" "git pull --ff-only"
+  assert_eq "$(git -C "$root" rev-parse HEAD)" "$(git -C "$ORIGIN_DIR" rev-parse HEAD)"
+  assert_eq "$(git -C "$root" symbolic-ref --short HEAD)" "main"
+  assert_eq "$(git -C "$root" rev-list --count HEAD)" "3"
+  assert_eq "$(git -C "$root" rev-parse --is-shallow-repository)" "false"
+}
+
+# A checkout that isn't a git repo at all (a copied tree) must fail with the reinstall command, not a
+# raw git error about a missing origin.
+test_update_reports_a_non_git_checkout() {
+  setup_case update-non-git
+  local root="${CASE_DIR}/plain"; mkdir -p "$root"
+  set +e
+  local out; out="$(run_update_checkout "$root")"; local rc=$?
+  set -e
+  [ "$rc" -ne 0 ] || fail "update_checkout on a non-git tree reported success"
+  assert_contains "$out" "herdr plugin install AltanS/collie"
+}
+
+# `herdr plugin link` re-registers the plugin as source.kind=local, and Herdr then REFUSES
+# `herdr plugin install` — which is the only other way a managed install can be refreshed. So the
+# re-link must fire for a linked clone and never for a managed checkout.
+test_registry_refresh_skips_a_managed_checkout() {
+  setup_case update-relink
+  local calls="${CASE_DIR}/herdr.calls"
+  cat > "${BIN_DIR}/herdr" <<EOF
+#!/bin/sh
+echo "\$@" >> "$calls"
+exit 0
+EOF
+  chmod +x "${BIN_DIR}/herdr"
+  stage_origin
+  local managed="${CASE_DIR}/managed" clone="${CASE_DIR}/clone"
+  mkdir -p "$managed"
+  git_q -C "$managed" init -q
+  git_q -C "$managed" remote add origin "$ORIGIN_DIR"
+  git_q -C "$managed" fetch -q --depth 1 origin HEAD
+  git_q -C "$managed" checkout -q --detach FETCH_HEAD
+  git_q clone -q "$ORIGIN_DIR" "$clone"
+
+  local harness="${CASE_DIR}/relink-harness.sh"
+  cat > "$harness" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+export HOME="$HOME_DIR"
+export HERDR_PLUGIN_CONFIG_DIR="$CONFIG_DIR"
+export PATH="$BIN_DIR:$BASE_PATH"
+source "$CTL"
+PLUGIN_ROOT="\$1"
+refresh_registry
+EOF
+  assert_contains "$(bash "$harness" "$managed")" "registry left alone"
+  [ ! -s "$calls" ] || fail "re-linked a Herdr-managed checkout (would block \`herdr plugin install\`)"
+  bash "$harness" "$clone" > /dev/null
+  assert_contains "$(cat "$calls")" "plugin link ${clone}"
+}
+
 test_tailscale_cutovers_and_collisions
 test_missing_tailscale_cli
 test_state_delete_failures
@@ -659,5 +799,9 @@ test_launchd_bootstrap_retries
 test_bun_resolution
 test_non_absolute_bun_never_reaches_path
 test_missing_bun_still_reports
+test_update_advances_a_herdr_managed_checkout
+test_update_fast_forwards_a_linked_clone
+test_update_reports_a_non_git_checkout
+test_registry_refresh_skips_a_managed_checkout
 
 echo "collie-ctl lifecycle tests: passed"

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "collie-web",
-  "version": "0.23.0",
+  "version": "0.23.1",
   "private": true,
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Fixes #63.

## The bug

`herdr plugin install` does **not** clone. It runs (herdrdev/herdr, `src/cli/plugin.rs:835-859`):

```
git init && git remote add origin <url>
git fetch --depth 1 origin HEAD      # or the --ref
git checkout --detach FETCH_HEAD
```

So a turnkey install lives in a **detached, shallow** checkout with zero remote-tracking refs, and
`collie-ctl.sh update`'s `git pull --ff-only` has no branch to pull into:

```
You are not currently on a branch.
Please specify which branch you want to merge with.
```

That line is unchanged since 0.1.0 — **the turnkey install has never been able to self-update**,
while `bridge/update.ts` (which reads tags over the GitHub API, not local git) kept telling those
users a new release was out.

## The fix

One predicate — `git symbolic-ref -q HEAD` — decides both halves:

- **On a branch** (clone + `herdr plugin link`): `git pull --ff-only`, unchanged.
- **Detached** (`herdr plugin install`): fetch the default-branch tip and re-detach onto it, the way
  Herdr got there. `--depth 1` **only when already shallow**, so an update never truncates a full
  clone someone happened to detach. `--force` because `cmd_build` runs bare `bun install`, which can
  rewrite the *tracked* `bun.lock` / `web/bun.lock` — a plain checkout would then refuse on the dirty
  tree and re-break update permanently, the exact failure class of #63.

The same predicate gates `refresh_registry`: `herdr plugin link` re-registers the plugin with
`source.kind = local`, after which Herdr **refuses** `herdr plugin install` ("already linked from a
local path") — taking away the reinstall that is a managed install's only other way to refresh. The
re-link stays for linked clones; Herdr ≥0.8.0 re-reads the manifest from disk on every registry
refresh (`reload_manifests`), so managed installs learn new actions without it. Price on older
Herdr: **never rename an action or move `collie-ctl.sh`** — those users invoke the cached definition.

## Verification

Four new cases in `scripts/collie-ctl.test.sh` (which had no `update` coverage), each staging a real
local origin and the real checkout shapes:

- managed checkout advances, stays detached + shallow, survives a build-dirtied lockfile, idempotent
- linked clone fast-forwards, keeps its branch and its full history
- a non-git tree fails with the reinstall command, not a raw git error
- the re-link fires for a clone and never for a managed checkout

Negative control: with the old `git pull --ff-only` body restored, the managed test fails with the
reporter's exact stderr. End-to-end against the real repo — a checkout staged exactly as Herdr does
at the reporter's `v0.21.0`, with a dirtied `bun.lock` — goes 0.21.0 → 0.23.0, still detached, still
shallow, lockfile clean.

## Note for existing GitHub installs

The fix ships *inside* the checkout, so it can't repair the copy that's already broken. Those users
need one reinstall to get it, after which `update` works from there on:

```bash
herdr plugin install AltanS/collie --yes
herdr plugin action invoke restart --plugin herdr.collie
```

README documents this, plus the `--ref`-pinned case (`update` always goes to latest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)