### PR TITLE
fix(web): verify wrapped CJK drafts so the reply guard submits them

### DIFF
--- a/web/src/lib/reply-action.test.ts
+++ b/web/src/lib/reply-action.test.ts
@@ -57,6 +57,106 @@ describe("draftCarriesSend", () => {
   it("rejects an unrelated draft", () => {
     expect(draftCarriesSend("deploy to prod", "someone else's leftover")).toBe(false);
   });
+
+  it("accepts a CJK draft wrapped mid-run (the fold fabricates a space the send never had)", () => {
+    // A Japanese draft has no word boundaries, so the input box wraps it mid-run and the
+    // space-joined fold yields a space absent from the sent text. This stalled every wrapped
+    // Japanese reply: the guard never verified the text and withheld the submit key.
+    const sent = "これちなみに電池寿命的にはどうなんだろね。";
+    expect(draftCarriesSend(sent, "これちなみに電池寿命的にはどうなん だろね。")).toBe(true);
+    // A windowed (tail-only) slice of a wrapped CJK draft still matches.
+    expect(draftCarriesSend(sent, "電池寿命的にはどうなん だろね。")).toBe(true);
+    // An unrelated CJK remnant still fails.
+    expect(draftCarriesSend(sent, "別の誰かの下書きです、これは。")).toBe(false);
+  });
+
+  it("accepts mixed CJK/latin text wrapped at either kind of seam", () => {
+    // The case no language test could handle: ONE draft carrying both a genuine space (between
+    // "pull" and "request") and a fabricated one (wherever the box broke the CJK run).
+    const sent = "これは pull request のテストです";
+    expect(draftCarriesSend(sent, "これは pull request のテ ストです")).toBe(true); // mid-CJK break
+    expect(draftCarriesSend(sent, "これは pull request のテストです")).toBe(true); // at the space
+    expect(draftCarriesSend(sent, "これは pull request のテストです")).toBe(true); // no wrap at all
+  });
+
+  it("still rejects a draft that lost or altered a non-space character", () => {
+    // Only the WIDTH of a gap is unknowable — every visible character must still be there. A box
+    // showing text with a space genuinely missing is NOT our text and must not be verified.
+    expect(draftCarriesSend("deploy the app", "deploythe app")).toBe(false);
+    const sent = "これを実行して結果を教えてください";
+    expect(draftCarriesSend(sent, "これを実行して結果を")).toBe(true); // a prefix is a slice
+    expect(draftCarriesSend(sent, "これを実行させて結果を")).toBe(false); // an inserted char is not
+  });
+
+  it("still requires the visible runs to be contiguous in the send", () => {
+    // The relaxation must not degrade into a fuzzy "these words appear somewhere" match: whatever
+    // sits between two runs in the send has to be whitespace, or it isn't a contiguous slice.
+    expect(draftCarriesSend("deploy the app to prod", "deploy app")).toBe(false);
+    expect(draftCarriesSend("送信して、確認して", "送信して 確認して")).toBe(false);
+  });
+
+  it("only lets a gap the fold could have made collapse to nothing", () => {
+    // The fold's seam is always exactly one plain space. Any other whitespace was really on screen,
+    // so the send has to carry whitespace there too — otherwise the screen holds a different
+    // message. U+3000 between two CJK runs is the case that matters in Japanese.
+    expect(draftCarriesSend("危険実行してください", "危険　実行してください")).toBe(false);
+    expect(draftCarriesSend("危険　実行してください", "危険　実行してください")).toBe(true);
+    // A gap the fold cannot make is not loosened at all — it must appear in the send verbatim, so a
+    // full-width space on screen never verifies a half-width one in the send, or vice versa.
+    expect(draftCarriesSend("delete file now", "delete　file now")).toBe(false);
+    expect(draftCarriesSend("deploy the app now", "deploy  the app now")).toBe(false);
+    expect(draftCarriesSend("deploy  the app now", "deploy  the app now")).toBe(true);
+    // ...but a wrap AT that whitespace folds it down to the seam, and the seam still collapses —
+    // the tolerance is one-directional, keyed on what the DRAFT shows, not on what the send holds.
+    expect(draftCarriesSend("deploy  the app now", "deploy the app now")).toBe(true);
+    expect(draftCarriesSend("delete　file now", "delete file now")).toBe(true);
+    // A single space still collapses — that is the wrapped-CJK case the guard exists for.
+    expect(draftCarriesSend("これを実行してください", "これを実行 してください")).toBe(true);
+  });
+
+  it("counts the floor in visible characters, not UTF-16 code units", () => {
+    // A ZWJ family sequence is 11 code units but ONE character on screen. Counting code units let a
+    // single glyph clear the 8-character floor and pass as evidence that the message landed.
+    const family = "👨‍👩‍👧‍👦";
+    expect(draftCarriesSend(`please explain ${family} before proceeding`, family)).toBe(false);
+    expect(draftCarriesSend(`${family}${family}`, `${family}${family}`)).toBe(true); // whole send
+  });
+
+  it("requires the match to land on visible-character boundaries", () => {
+    // "👩‍👧‍👦" is a code-unit substring of "👨‍👩‍👧‍👦" while being a different character. Matching
+    // mid-character would let the screen show one emoji and verify as another.
+    expect(draftCarriesSend("👨‍👩‍👧‍👦", "👩‍👧‍👦")).toBe(false);
+    expect(draftCarriesSend("👨‍👩‍👧‍👦", "👨‍👩‍👧‍👦")).toBe(true);
+    // The END of the match is checked too, not just its start: "abcdefgh" stops inside the "h" +
+    // combining-acute cluster here, so it is not a slice of what we sent. Both sides are long
+    // enough that the floor is not what rejects it — the boundary check has to be doing the work.
+    expect(draftCarriesSend("abcdefgh́ then more", "abcdefgh")).toBe(false);
+    // A windowed tail that DOES start on a boundary is a legitimate slice and must still pass.
+    expect(draftCarriesSend("café opened wide", "é opened wide")).toBe(true);
+  });
+
+  it("checks every occurrence, not only the first", () => {
+    // The first "abcdefgh" here ends inside a combining cluster; the second is properly aligned.
+    // Bailing after one hit would stall a reply whose text is verifiably on screen.
+    expect(draftCarriesSend("abcdefgh́ then abcdefgh", "abcdefgh")).toBe(true);
+  });
+
+  it("does not let invisible controls pad the floor", () => {
+    // Segmenter calls each LRM its own cluster, so this is EIGHT clusters carrying FOUR readable
+    // characters — exactly enough to clear the floor while showing half of it. Four LRMs, not
+    // three: at three the string is seven clusters and the floor rejects it whatever we count.
+    const padded = "\u200EA\u200EB\u200EC\u200ED";
+    expect(draftCarriesSend(`prefix ${padded} suffix`, padded)).toBe(false);
+    // A control INSIDE a cluster still joins visible characters, so the emoji stays one character.
+    // Eight of them is exactly the floor, so this fails if a ZWJ cluster is counted as nothing.
+    const family = "👨‍👩‍👧‍👦";
+    expect(draftCarriesSend(`prefix ${family.repeat(8)} suffix`, family.repeat(8))).toBe(true);
+  });
+
+  it("treats regex metacharacters in the draft as literal text", () => {
+    expect(draftCarriesSend("run a.*b now", "run a.*b now")).toBe(true);
+    expect(draftCarriesSend("run axxb now", "run a.*b now")).toBe(false);
+  });
 });
 
 describe("sendGuardedReply", () => {

--- a/web/src/lib/reply-action.ts
+++ b/web/src/lib/reply-action.ts
@@ -40,24 +40,102 @@ export type ReplyOutcome =
 /** Minimum visible characters that must match before we believe the input box holds OUR text. */
 export const MIN_MATCH_CHARS = 8;
 
-/** extractInputDraft space-joins a wrapped draft, so compare on collapsed whitespace. */
-function collapse(s: string): string {
-  return s.replace(/\s+/g, " ").trim();
+const REGEXP_META = /[.*+?^${}()|[\]\\]/g;
+
+/** The exact gap extractInputDraft's fold inserts at a wrap seam: one plain space, always. Any
+ *  other gap on screen is whitespace the operator really typed, so `sent` must carry it too. */
+const FOLD_SEAM = " ";
+
+const GRAPHEMES = new Intl.Segmenter(undefined, { granularity: "grapheme" });
+
+/** A cluster nobody can see: whitespace, or formatting controls that render as nothing at all
+ *  (LRM/RLM, zero-width space, soft hyphen). A cluster that merely CONTAINS one still counts — the
+ *  ZWJ inside a family emoji is joining visible characters, not standing in for them. */
+const UNREADABLE = /^[\s\p{Default_Ignorable_Code_Point}]+$/u;
+
+/** Visible characters. The floor below is a claim about how much of the message is legible on
+ *  screen, so it must count what a reader counts — one emoji is one character, not the 11 UTF-16
+ *  code units a ZWJ family sequence happens to occupy, and an invisible control is not a character
+ *  at all however many of them are threaded through the text.
+ *
+ *  Segmenting the string AS GIVEN matters: stripping its spaces first can fuse the neighbours into
+ *  one cluster. "🇯 🇵" is two characters, but strip the space and the regional indicators pair into
+ *  the single flag "🇯🇵" — one character, and a floor half as high as it should be. */
+function visibleLength(s: string): number {
+  let n = 0;
+  for (const segment of GRAPHEMES.segment(s)) if (!UNREADABLE.test(segment.segment)) n += 1;
+  return n;
+}
+
+/** Every offset in `s` where one visible character ends and the next begins, plus both ends. A match
+ *  that starts or stops anywhere else has sliced a character in half — "👩‍👧‍👦" is a code-unit
+ *  substring of "👨‍👩‍👧‍👦", but it is a DIFFERENT character and must not verify as that one. */
+function characterBoundaries(s: string): Set<number> {
+  const bounds = new Set<number>([s.length]);
+  for (const segment of GRAPHEMES.segment(s)) bounds.add(segment.index);
+  return bounds;
 }
 
 /**
  * Whether the input box's visible draft is evidence that `sent` landed there. The box WINDOWS a long
- * draft and folds its wrapped lines with spaces, so exact equality is too strict — requiring the
- * visible draft to be a contiguous slice of what we typed is the strongest claim that survives
- * windowing. The length floor stops a short unrelated remnant ("y", "n", a placeholder) from passing
- * as a match; for a send shorter than the floor, the whole thing must be there.
+ * draft (only its tail is on screen) and FOLDS its wrapped lines together with a space, so exact
+ * equality is too strict — the strongest claim that survives both is that the draft's visible
+ * characters appear contiguously in what we typed.
+ *
+ * The fold is the subtle part. extractInputDraft joins the box's visual lines with a space, which
+ * restores a REAL space only when the box happened to wrap at a word boundary; wrapping mid-run (CJK
+ * has no spaces to break at) fabricates a space the sent text never had. The joined string cannot
+ * say which kind each of its spaces is, and one string can hold both — "これは pull request です"
+ * wrapped mid-CJK has a genuine space AND a fabricated one. So the ambiguity is per-SEAM, not
+ * per-string, and no language test can resolve it.
+ *
+ * Hence: split the draft on whitespace and require its non-space runs to appear in `sent` in order,
+ * with only whitespace between them. Every visible character still has to be there, contiguously and
+ * in order — only the WIDTH of a gap the fold could have produced is treated as unknowable, which is
+ * exactly what the fold destroyed. A draft that dropped or altered a non-space character still fails.
+ *
+ * Only a gap spelled exactly like the fold's own seam (one plain space) may collapse to nothing, and
+ * only that gap is loosened at all. Any other gap — a run of spaces, a tab, an ideographic space —
+ * is whitespace the terminal actually rendered, so `sent` must carry that same whitespace verbatim.
+ * Without the distinction the guard would accept a screen holding "危険　実行" for a send of
+ * "危険実行", or "delete　file" for "delete file": different messages, both authorised.
+ *
+ * The match must also land on visible-character boundaries, because a code-unit substring can cut a
+ * character in half — "👩‍👧‍👦" sits inside "👨‍👩‍👧‍👦" without being it.
+ *
+ * The length floor stops a short unrelated remnant ("y", "n", a placeholder) from passing as a
+ * match; for a send shorter than the floor, the whole thing must be there. It counts non-space
+ * characters, since spaces are the part we just agreed not to trust.
  */
 export function draftCarriesSend(sent: string, draft: string | null): boolean {
   if (draft === null) return false;
-  const s = collapse(sent);
-  const d = collapse(draft);
-  if (d.length === 0) return false;
-  return s.includes(d) && d.length >= Math.min(s.length, MIN_MATCH_CHARS);
+  // Odd indices are the gaps, even indices the runs — the gaps decide how strict each seam is.
+  const parts = draft.trim().split(/(\s+)/);
+  const runs = parts.filter((_part, i) => i % 2 === 0);
+  const gaps = parts.filter((_part, i) => i % 2 === 1);
+  if (runs.length === 0 || runs[0]!.length === 0) return false;
+
+  const visible = runs.reduce((n, run) => n + visibleLength(run), 0);
+  if (visible < Math.min(visibleLength(sent), MIN_MATCH_CHARS)) return false;
+
+  // Runs are whitespace-free by construction, so the joined pattern can never nest quantifiers.
+  const escape = (s: string) => s.replace(REGEXP_META, "\\$&");
+  let pattern = escape(runs[0]!);
+  for (let i = 1; i < runs.length; i++) {
+    const gap = gaps[i - 1]!;
+    pattern += (gap === FOLD_SEAM ? "\\s*" : escape(gap)) + escape(runs[i]!);
+  }
+
+  // Every occurrence gets its own boundary check, not just the first: an earlier hit that happens to
+  // stop mid-character must not mask a later, properly aligned one. Rewinding to one past the hit's
+  // start (rather than to its end) keeps overlapping occurrences reachable.
+  const scan = new RegExp(pattern, "g");
+  const bounds = characterBoundaries(sent);
+  for (let hit = scan.exec(sent); hit !== null; hit = scan.exec(sent)) {
+    if (bounds.has(hit.index) && bounds.has(hit.index + hit[0].length)) return true;
+    scan.lastIndex = hit.index + 1;
+  }
+  return false;
 }
 
 export interface GuardedReplyArgs {


### PR DESCRIPTION
## The bug

`draftCarriesSend` is the #34 guard: it withholds the submit key until the typed text is verifiably in the input box, by requiring the visible draft to be a contiguous slice of what we sent.

`extractInputDraft` folds a wrapped draft's visual lines together with a space. That restores a **real** space only when the box wrapped at a word boundary. CJK has no spaces to wrap at, so a mid-run wrap fabricates a space the send never had, the slice check can never match, and the guard withholds Enter forever:

```
sent    "これちなみに電池寿命的にはどうなんだろね。"
screen  ❯ これちなみに電池寿命的にはどうなん
          だろね。
draft   "これちなみに電池寿命的にはどうなん だろね。"   ← space not in the send
        → collapse(sent).includes(collapse(draft)) is false, always
```

Every wrapped Japanese reply stalls unsubmitted. Whether a given message wraps depends on the pane width, so it presents as flaky rather than deterministic — short messages go through, longer ones silently don't.

## Why not just ignore whitespace, or branch on language

Ignoring whitespace on both sides fixes the stall but over-corrects: it also accepts a screen genuinely differing from the send by a space, which is exactly what the guard exists to catch.

Branching on "is this CJK?" is the wrong axis. The question isn't what language the text is, it's **whether a given seam was a real space** — and one draft can hold both kinds at once:

```
sent    "これは pull request のテストです"
draft   "これは pull request のテ ストです"
                ↑ real           ↑ fabricated
```

The ambiguity is per-seam, not per-string, and after the join both look identical.

## The fix

Loosen exactly the seam and nothing else. Split the draft into runs and the gaps between them; a gap spelled exactly like the fold's own seam (one plain space) may collapse to nothing, and every other gap must appear in the send verbatim, since the fold cannot produce it. Runs still match character for character, in order and contiguously.

```
draft    "これは pull request のテ ストです"
runs     ["これは", "pull", "request", "のテ", "ストです"]
pattern  /これは\s*pull\s*request\s*のテ\s*ストです/
sent     "これは pull request のテストです"     ✓
```

The same `\s*` covers a real space and a zero-width seam, so nothing has to decide which is which.

Three supporting corrections keep the check honest at the character level:

- **Non-seam gaps match verbatim.** A screen holding `危険　実行` (U+3000) no longer verifies a send of `危険実行`. The tolerance is one-directional, keyed on what the draft shows, so wrapping *at* a full-width space still folds to the seam and still passes.
- **Matches land on grapheme boundaries.** A code-unit substring can cut a cluster in half — `👩‍👧‍👦` sits inside `👨‍👩‍👧‍👦` without being it. Both ends are checked, and every occurrence is tried rather than only the first, so an earlier misaligned hit can't mask a later valid one.
- **The floor counts readable clusters,** not UTF-16 units. It segments the string as written: stripping spaces first would fuse neighbours (`🇯 🇵` into one flag) and halve the floor. Invisible formatting controls (LRM, ZWSP, soft hyphen) no longer pad it.

## Safety

The guard's protection is unchanged. A focused permission dialog leaves no input box on screen, so `extractInputDraft` returns `null` and no key is sent — verified against all of `web/src/fixtures/panes/`: every dialog capture (`permission-*`, `plan-approval*`, `trust-prompt`, `select-*`, `wizard-*`) returns `null`.

What was loosened is only the width of a gap the fold itself could have produced. What was tightened — verbatim non-seam gaps, grapheme-aligned matches, an honest floor — all runs in the false-positive direction, which is the dangerous one.

## Tests

Ten cases added, with as much weight on what must still be **rejected** as on what should now pass: wrapped CJK, mixed-script drafts at both kinds of seam, windowed tails, dropped or altered characters, non-contiguous runs, full-width vs half-width gaps, grapheme boundaries at both ends, multiple occurrences, invisible-control padding, and regex metacharacters treated as literals.

Full suite green (`bun run test` in `web/`, plus root `bun run test`); both sides typecheck.