### PR TITLE
fix(push): evict persistently-failing subscriptions, log the real status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ All notable changes to Collie are recorded here. The format follows
 `version` in `herdr-plugin.toml`, `package.json`, and `web/package.json` (enforced by
 `scripts/check-version.sh`). See [`CLAUDE.md`](./CLAUDE.md) → *Versioning* for the bump policy.
 
+## [0.25.0] - 2026-08-07
+
+### Added
+
+- **A subscription that keeps failing is retired** after 5 consecutive failures, so stale duplicates (PWA reinstalls) stop accumulating and re-logging every cycle — counted only when a sibling on the same push service succeeded that round, so a service-wide rejection never costs a live device (#68, 2ea3e61) — thanks @alshedivat
+
+### Fixed
+
+- **Push failures log the status and the service's reason** instead of web-push's constant "Received unexpected response code", which named neither (2ea3e61)
+
 ## [0.24.2] - 2026-08-06
 
 ### Fixed

--- a/bridge/push.test.ts
+++ b/bridge/push.test.ts
@@ -97,6 +97,145 @@ describe("Push — broadcast delivery & pruning", () => {
   });
 });
 
+// Issue #68: a subscription can be permanently dead while the push service answers with something
+// other than 404/410 (Apple says 400 BadDeviceToken), so it was retried forever and re-logged every
+// cycle. Eviction closes that, but only where the evidence is unambiguous — hence the origin guard.
+describe("Push — eviction of persistently-failing subscriptions", () => {
+  const APPLE = "https://web.push.apple.com";
+  const FCM = "https://fcm.googleapis.com";
+  /** A rejection shaped exactly like the WebPushError `web-push` throws (message is the useless
+   *  constant; the real signal is statusCode + the service's reason in `body`). */
+  const rejects = (statusCode: number, body: string) =>
+    Object.assign(new Error("Received unexpected response code"), { statusCode, body });
+
+  /** Collects console output so eviction/prune lines can be asserted (they're the operator's only
+   *  view of this behaviour) without spraying the test run. */
+  async function capturingConsole<T>(fn: () => Promise<T>): Promise<{ result: T; lines: string[] }> {
+    const lines: string[] = [];
+    const collect = ((...args: unknown[]) => void lines.push(args.map(String).join(" "))) as typeof console.warn;
+    const [origWarn, origLog] = [console.warn, console.log];
+    console.warn = collect;
+    console.log = collect;
+    try {
+      return { result: await fn(), lines };
+    } finally {
+      console.warn = origWarn;
+      console.log = origLog;
+    }
+  }
+
+  /** A sender that fails for `failing` endpoints and delivers for everything else. */
+  function partialSender(failing: Map<string, Error>): PushSender {
+    return (s) => {
+      const err = failing.get(s.endpoint);
+      return err ? Promise.reject(err) : Promise.resolve();
+    };
+  }
+
+  const rounds = (push: Push, n: number) =>
+    capturingConsole(async () => {
+      for (let i = 0; i < n; i++) await push.notify("t", "b");
+    });
+
+  test("a dead-but-not-410 subscription is evicted once a sibling on its service succeeds", async () => {
+    const cfg = await tempCfg();
+    const [dead, live] = [`${APPLE}/dead`, `${APPLE}/live`];
+    const push = new Push(cfg, partialSender(new Map([[dead, rejects(400, '{"reason":"BadDeviceToken"}')]])));
+    const subs = enable(push, [sub(dead), sub(live)]);
+
+    // Four rounds of failure are not enough — a run of transients must not cost anyone their pushes.
+    await rounds(push, 4);
+    expect([...subs.keys()]).toEqual([dead, live]);
+
+    const { lines } = await rounds(push, 1);
+    expect([...subs.keys()]).toEqual([live]);
+    expect(await fileEndpoints(cfg.stateDir)).toEqual([live]);
+    expect(lines.some((l) => l.includes("evicting subscription after 5 consecutive failures"))).toBe(true);
+  });
+
+  test("a service-wide rejection never evicts, however long it lasts", async () => {
+    // The 403-storm case: a VAPID slip makes one service reject every device it holds. Nothing on
+    // that origin succeeds, so nothing is counted — otherwise a sender-side mistake would silently
+    // unsubscribe every iPhone in the herd. This test pins the design.
+    const cfg = await tempCfg();
+    const apples = [`${APPLE}/a`, `${APPLE}/b`, `${APPLE}/c`];
+    const storm = rejects(403, '{"reason":"InvalidProviderToken"}');
+    const push = new Push(cfg, partialSender(new Map(apples.map((e) => [e, storm]))));
+    const subs = enable(push, [...apples.map(sub), sub(`${FCM}/ok`)]);
+
+    await rounds(push, 20);
+
+    expect([...subs.keys()].length).toBe(4);
+  });
+
+  test("the only subscription is never evicted, however long it fails", async () => {
+    // No sibling ⇒ no proof the token is at fault. Losing the sole subscription would trade a loud
+    // log line for silent no-push, which is strictly worse for the one-phone operator.
+    const cfg = await tempCfg();
+    const only = `${APPLE}/only`;
+    const push = new Push(cfg, partialSender(new Map([[only, rejects(400, "BadDeviceToken")]])));
+    const subs = enable(push, [sub(only)]);
+
+    await rounds(push, 20);
+
+    expect([...subs.keys()]).toEqual([only]);
+  });
+
+  test("one delivery resets the streak", async () => {
+    const cfg = await tempCfg();
+    const [flaky, live] = [`${APPLE}/flaky`, `${APPLE}/live`];
+    const failing = new Map([[flaky, rejects(500, "")]]);
+    const push = new Push(cfg, partialSender(failing));
+    const subs = enable(push, [sub(flaky), sub(live)]);
+
+    await rounds(push, 4);
+    failing.delete(flaky);
+    await rounds(push, 1); // recovers
+    failing.set(flaky, rejects(500, ""));
+    await rounds(push, 4); // four more is short of the threshold again
+
+    expect([...subs.keys()]).toEqual([flaky, live]);
+  });
+
+  test("re-subscribing clears the streak of an identical endpoint", async () => {
+    const cfg = await tempCfg();
+    const [flaky, live] = [`${APPLE}/flaky`, `${APPLE}/live`];
+    const push = new Push(cfg, partialSender(new Map([[flaky, rejects(400, "BadDeviceToken")]])));
+    const subs = enable(push, [sub(flaky), sub(live)]);
+
+    await rounds(push, 4);
+    await push.addSubscription(sub(flaky)); // the device just asked for pushes again
+    await rounds(push, 4);
+
+    expect([...subs.keys()]).toEqual([flaky, live]);
+  });
+
+  test("a failure logs the status and the service's reason, not just the useless message", async () => {
+    // `err.message` alone is the constant "Received unexpected response code" — the whole reason
+    // this issue was undiagnosable from the logs.
+    const cfg = await tempCfg();
+    const endpoint = `${APPLE}/x`;
+    const push = new Push(cfg, partialSender(new Map([[endpoint, rejects(400, '{"reason":"BadDeviceToken"}')]])));
+    enable(push, [sub(endpoint)]);
+
+    const { lines } = await rounds(push, 1);
+
+    const failed = lines.find((l) => l.includes("send failed"));
+    expect(failed).toContain("status=400");
+    expect(failed).toContain("BadDeviceToken");
+  });
+
+  test("a 410 prune says so out loud", async () => {
+    const cfg = await tempCfg();
+    const push = new Push(cfg, (s) => (s.endpoint === "dead" ? Promise.reject(gone("dead")) : Promise.resolve()));
+    enable(push, [sub("dead")]);
+
+    const { lines } = await rounds(push, 1);
+
+    expect(lines.some((l) => l.includes("pruning gone subscription (410)"))).toBe(true);
+  });
+});
+
 describe("Push — persistence", () => {
   test("addSubscription persists with owner-only (0600) permissions", async () => {
     const cfg = await tempCfg();

--- a/bridge/push.ts
+++ b/bridge/push.ts
@@ -33,6 +33,35 @@ const SEND_OPTIONS = { TTL: 21_600, topic: "collie-herd", urgency: "high" } as c
 // update stays relevant far longer than a transient "needs you".
 const UPDATE_SEND_OPTIONS = { TTL: 259_200, topic: "collie-update" } as const;
 
+// How many consecutive same-origin-witnessed failures retire a subscription (see broadcast()).
+// Broadcasts are event-driven — several in an active hour — so five clears a stale device within a
+// day of normal use while still absorbing a run of transients that slipped past the origin guard.
+const EVICT_AFTER = 5;
+
+/** The push service an endpoint belongs to, used to tell "this device is dead" from "this service
+ *  is rejecting us". Falls back to the raw endpoint if it won't parse — an unparseable endpoint is
+ *  then its own origin, which can never witness a sibling's success, so it is never evicted. */
+function pushServiceOrigin(endpoint: string): string {
+  try {
+    return new URL(endpoint).origin;
+  } catch {
+    return endpoint;
+  }
+}
+
+/** What actually went wrong, for the log. `web-push` throws a WebPushError whose `message` is the
+ *  constant "Received unexpected response code" — useless on its own — while the status and the
+ *  service's own reason (Apple's `{"reason":"BadDeviceToken"}`, FCM's text) sit unread on the error.
+ *  Surfacing them is what makes a transient 5xx distinguishable from a permanent rejection. */
+function describeSendError(err: unknown): string {
+  const e = err as { statusCode?: number; body?: unknown };
+  const message = err instanceof Error ? err.message : String(err);
+  const status = typeof e.statusCode === "number" ? ` status=${e.statusCode}` : "";
+  const raw = typeof e.body === "string" ? e.body.replace(/\s+/g, " ").trim() : "";
+  const body = raw ? ` body=${raw.length > 200 ? `${raw.slice(0, 200)}…` : raw}` : "";
+  return `${message}${status}${body}`;
+}
+
 /** web-push delivery options (collapse topic + TTL + urgency), derived per message from its `type`. */
 export type SendOptions = { TTL: number; topic: string; urgency?: "very-low" | "low" | "normal" | "high" };
 
@@ -75,6 +104,11 @@ export class Push {
   private readonly file: string;
   private readonly sender: PushSender;
   private _enabled = false;
+  // Consecutive delivery failures per endpoint, for the eviction pass in broadcast(). Deliberately
+  // in-memory and NOT part of the persisted subscription shape: a restart forgives, which is the
+  // right bias for a counter whose whole job is spotting a *sustained* pattern — broadcasts vastly
+  // outnumber restarts, so a genuinely dead device re-earns its eviction within EVICT_AFTER rounds.
+  private failures = new Map<string, number>();
   // Saves are funnelled through this chain so concurrent writes never interleave (last enqueued
   // wins deterministically); a failed write is swallowed here so it can't poison later saves.
   private saveChain: Promise<void> = Promise.resolve();
@@ -116,6 +150,9 @@ export class Push {
   async addSubscription(sub: PushSubscription): Promise<void> {
     if (!this.enabled) return;
     this.subs.set(sub.endpoint, sub);
+    // A re-subscribe is fresh evidence even when the endpoint string is unchanged — the device just
+    // told us it wants pushes, so it doesn't inherit the failure history of its predecessor.
+    this.failures.delete(sub.endpoint);
     await this.save();
   }
 
@@ -139,26 +176,66 @@ export class Push {
   private async broadcast(payload: string, options: SendOptions): Promise<void> {
     if (!this.enabled) return;
     const dead: string[] = [];
-    await Promise.all(
+    // One entry per subscription attempted this round, so the eviction pass below can ask which
+    // push services proved themselves healthy before it holds a failure against any one device.
+    const results = await Promise.all(
       [...this.subs.values()].map(async (sub) => {
         try {
           await this.sender(sub, payload, options);
+          return { sub, err: null };
         } catch (err) {
-          // 404/410 mean the subscription is gone — prune it. Anything else (network, 5xx) is a
-          // real failure worth a log line rather than vanishing silently.
-          const code = (err as { statusCode?: number }).statusCode;
-          if (code === 404 || code === 410) {
-            dead.push(sub.endpoint);
-          } else {
-            console.warn(
-              `[push] send failed for ${sub.endpoint}: ${err instanceof Error ? err.message : String(err)}`,
-            );
-          }
+          return { sub, err };
         }
       }),
     );
+
+    // A push service that delivered to SOMEBODY this round has a working VAPID/JWT/network path,
+    // so a sibling's failure on that same origin is about that subscription and nothing else.
+    const healthy = new Set(
+      results.filter((r) => r.err === null).map((r) => pushServiceOrigin(r.sub.endpoint)),
+    );
+
+    for (const { sub, err } of results) {
+      if (err === null) {
+        // Consecutive means consecutive: one delivery wipes the slate.
+        this.failures.delete(sub.endpoint);
+        continue;
+      }
+      // 404/410 are the only statuses RFC 8030 blesses as "this subscription is gone". Everything
+      // else — 400, 401, 403, 429, 5xx — is either transient or about the SENDER (a VAPID key slip
+      // makes a whole push service reject perfectly live devices), so it must never prune on sight.
+      const code = (err as { statusCode?: number }).statusCode;
+      if (code === 404 || code === 410) {
+        console.log(`[push] pruning gone subscription (${code}): ${sub.endpoint}`);
+        dead.push(sub.endpoint);
+        continue;
+      }
+      console.warn(`[push] send failed for ${sub.endpoint}: ${describeSendError(err)}`);
+
+      // Some failures are permanent without ever being 404/410 (Apple answers a dead token with
+      // 400 BadDeviceToken), and retried forever they accumulate into the log spam of issue #68.
+      // Counting only same-origin-witnessed failures is what keeps this from becoming a 403-storm
+      // foot-gun: during a global rejection nothing on that origin succeeds, so nothing is counted.
+      // The single-subscription operator therefore never evicts — deliberately. Eviction exists to
+      // garbage-collect stale duplicates, which needs a healthy sibling to prove the token is at
+      // fault; dropping someone's only subscription would trade a loud log for silent no-push.
+      if (!healthy.has(pushServiceOrigin(sub.endpoint))) continue;
+      // Overlapping broadcasts aren't serialised, so two in-flight rounds can each land a count on
+      // the same endpoint. EVICT_AFTER is slack enough to absorb that; a mutex isn't worth it.
+      const n = (this.failures.get(sub.endpoint) ?? 0) + 1;
+      this.failures.set(sub.endpoint, n);
+      if (n < EVICT_AFTER) continue;
+      console.warn(
+        `[push] evicting subscription after ${n} consecutive failures (last: ${describeSendError(err)}): ${sub.endpoint}`,
+      );
+      dead.push(sub.endpoint);
+    }
+
     if (dead.length) {
-      for (const e of dead) this.subs.delete(e);
+      for (const e of dead) {
+        this.subs.delete(e);
+        this.failures.delete(e);
+      }
       await this.save();
     }
   }

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,6 +1,6 @@
 id = "herdr.collie"
 name = "Collie"
-version = "0.24.2"
+version = "0.25.0"
 min_herdr_version = "0.7.0"
 description = "Mobile web UI to monitor and reply to your agent herd, served over Tailscale"
 platforms = ["linux", "macos"]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "collie",
-  "version": "0.24.2",
+  "version": "0.25.0",
   "private": true,
   "license": "MIT",
   "description": "Collie — a mobile web UI to monitor and reply to your Herdr agent herd over Tailscale",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "collie-web",
-  "version": "0.24.2",
+  "version": "0.25.0",
   "private": true,
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Fixes #68

A subscription that fails with anything other than 404/410 was kept and retried forever, so stale
duplicates (PWA reinstalls) accumulated and re-logged every send cycle. The log line was
`web-push`'s constant `"Received unexpected response code"`, which named neither the status nor the
reason, so the failure was undiagnosable from the outside.

**Two changes:**

1. **Log the status and the service's reason.** `WebPushError` already carries `statusCode` and
   `body` (`{"reason":"BadDeviceToken"}` on Apple); both were being discarded at the catch site.
   The 404/410 prune, silent until now, also says so out loud.
2. **Retire an endpoint after 5 consecutive failures** — but only counting failures where a sibling
   on the *same push service* succeeded that round.

**Why the origin guard.** A service-wide rejection (Apple's `403 InvalidProviderToken` on a VAPID
slip) fails every device that service holds, live ones included. A naive five-strikes rule would
answer one sender-side mistake by unsubscribing every iPhone in the herd. Under the guard, nothing
on that origin succeeds, so nothing is counted. This is also why 403 stays out of the prune list —
RFC 8030 blesses exactly 404/410 as "subscription gone", and Apple's/FCM's 403 are both sender-side.

**A sole subscription therefore never evicts**, deliberately. With no healthy sibling there is no
proof the token is at fault, and trading a loud log line for silent no-push is the wrong way to be
wrong. The new logging is that operator's remedy.

The counter is in-memory only — the on-disk `PushSubscription[]` shape is unchanged. A restart
forgives, which is the right bias for a counter whose job is spotting a *sustained* pattern;
broadcasts vastly outnumber restarts, so a genuinely dead device re-earns eviction within 5 rounds.

**Verified** against a throwaway harness that stands up two fake push services over real TLS (Apple
and FCM on separate ports) and drives the real `Push` class through the real `web-push` library at
them, so the errors are constructed from real HTTP responses rather than hand-faked:

- dead-but-not-410 token alongside a healthy sibling → evicted on round 5, log names `status=400
  body={"reason":"BadDeviceToken"}`
- 3 live Apple devices under a service-wide 403 storm with FCM healthy → all 3 survive 10 rounds

Seven tests pin it, including the 403 storm and the sole-subscription case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)