### PR TITLE
feat(windows): add native plugin lifecycle

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,11 +21,11 @@ COLLIE_HOST=127.0.0.1
 # Tunnel: Collie publishes nothing, you point your tunnel at 127.0.0.1:$COLLIE_PORT and start it
 # however you start your other services (README → Variant E).
 # COLLIE_SKIP_SERVE=1
-# Your public URL behind the proxy — shown as the "proxy" address by `collie-ctl.sh status`.
+# Your public URL behind the proxy — shown as the "proxy" address by the status action.
 # COLLIE_PUBLIC_URL=https://collie.example.com
 
 # --- Herdr connection ---
-# Usually injected by the systemd unit; override only if your socket is elsewhere.
+# Usually injected by the native supervisor; override only if your socket is elsewhere.
 # Defaults to ~/.config/herdr/herdr.sock, or %APPDATA%\herdr\herdr.sock on Windows.
 # HERDR_SOCKET_PATH=/home/you/.config/herdr/herdr.sock
 # Which dialer opens that socket: auto (default) | net | bun. "auto" is right everywhere — node:net
@@ -33,6 +33,9 @@ COLLIE_HOST=127.0.0.1
 # "net" on Linux/macOS runs the Windows dial path against your real socket; that's how it gets
 # tested without a Windows box. See bridge/dial.ts.
 # COLLIE_HERDR_DIAL=auto
+# Windows only: use "highest" when Herdr intentionally runs as Administrator. This gives every
+# phone action Administrator power; the default is "limited".
+# COLLIE_TASK_RUN_LEVEL=highest
 # Poll cadence (ms) and scrollback lines pulled for the detail view.
 COLLIE_POLL_MS=1500
 COLLIE_READ_LINES=200

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
 
       # The MANDATORY invariant: the three version files + the newest CHANGELOG heading must agree.
       - name: Version consistency
-        run: bash scripts/check-version.sh
+        run: bun run scripts/check-version.ts
 
       - name: Install (root)
         run: bun install --frozen-lockfile
@@ -35,3 +35,12 @@ jobs:
         run: cd web && bun run typecheck
       - name: Test (web)
         run: cd web && bun run test
+
+  windows-lifecycle:
+    name: Windows lifecycle
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+      - run: bun run scripts/check-version.ts
+      - run: bun run test:ctl

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ node_modules
 
 # Build output
 dist/
+dist-backup/
 build/
 out/
 target/

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -49,21 +49,22 @@ The browser never touches the socket directly; the bridge is the only thing that
    Herdr server (owns panes, agents, state)
 ```
 
-## 3. Deployment model — **systemd user service, not a plugin pane**
+## 3. Deployment model — **native user supervisor, not a plugin pane**
 
 This is the clearest call in the design. A plugin **pane** runs inside a terminal pane: if the pane
 closes, the user detaches, or Herdr restarts, the bridge dies — exactly when you're on mobile and not
 watching the TUI. A long-lived network daemon must be supervised independently.
 
-- **The bridge runs as a `systemd --user` service** (launchd agent on macOS) — starts at login,
-  restarts on failure, survives Herdr restarts.
+- **The bridge runs under the native user supervisor** — `systemd --user` on Linux, a launchd agent
+  on macOS, or Task Scheduler on Windows. It starts at login, restarts on failure, and survives
+  Herdr restarts.
 - **The Herdr plugin stays — as a thin registration/launcher,** so the bridge shows up in
   `herdr plugin list` and Herdr conventions still apply. Its `[[actions]]` do things like
-  `systemctl --user start collie` and **print the tailnet URL**; they do *not* host the server. A
-  `[[build]]` step builds the web UI on `herdr plugin install` (GitHub); local `link` installs skip
-  it and build lazily on first `start`. Concretely that's `[[actions]]` + `[[build]]` and nothing
-  else: `[[panes]]` is what this section argues against, and `[[events]]` would duplicate the
-  bridge's own `events.subscribe` stream (§5).
+  start the supervisor and **print the tailnet URL**; they do *not* host the server. A `[[build]]`
+  step builds the web UI and a platform-native action launcher on `herdr plugin install`; local
+  `link` installs skip builds and must run one explicitly. Concretely that's `[[actions]]` +
+  `[[build]]` and nothing else: `[[panes]]` is what this section argues against, and `[[events]]`
+  would duplicate the bridge's own `events.subscribe` stream (§5).
 - **The checkout on disk *is* the plugin — in one of two shapes.** `herdr plugin install` does not
   clone: it `git init`s, `git fetch --depth 1 origin HEAD`s and `git checkout --detach FETCH_HEAD`s
   into `~/.config/herdr/plugins/github/<hashed-id>`, so a turnkey install is **detached and shallow**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to Collie are recorded here. The format follows
 `version` in `herdr-plugin.toml`, `package.json`, and `web/package.json` (enforced by
 `scripts/check-version.sh`). See [`CLAUDE.md`](./CLAUDE.md) → *Versioning* for the bump policy.
 
+## [0.26.0] - 2026-08-07
+
+### Added
+
+- Native Windows lifecycle through Task Scheduler, PowerShell, and an immutable launcher; Windows ingress remains operator-managed (9ad5773)
+
 ## [0.25.0] - 2026-08-07
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,13 +44,13 @@ manifest) you MUST:
    Fixed). Use the real date. **Style: super crisp and short** — one line per change, no prose
    paragraphs, and cite the feature's short commit hash at the end of the line (`… (abc1234)`).
    Land features as their own commits first, then cut the release commit so the entry can cite them.
-3. **Run `scripts/check-version.sh`** — it must print `✓`.
+3. **Run `bun run scripts/check-version.ts` on Windows or `scripts/check-version.sh` on POSIX** — it must print `✓`.
 
 Doc-only changes (`*.md`) don't need a bump. This is enforced two ways, but **you are the first
 line — do it as part of the change, not after**:
 
-- `scripts/check-version.sh` runs inside `scripts/collie-ctl.sh build` (a release can't build while
-  versions disagree).
+- The shared TypeScript version gate runs inside both native control scripts' `build` command (a
+  release can't build while versions disagree).
 - A **git pre-commit hook** (`scripts/git-hooks/pre-commit`, activate once with
   `scripts/install-hooks.sh`) blocks commits where functional code changed but the version didn't.
   Escape hatch for a single commit: `SKIP_VERSION_CHECK=1 git commit …`.
@@ -80,20 +80,26 @@ the unit name; the Herdr action runs from anywhere.
 - **Frontend changes** (`web/`): rebuild with `bun run build` (root) or `cd web && bun run build`.
   The bridge serves `web/dist` **from disk at request time**, so on the deployment host
   a rebuild is **immediately live — no restart**.
-- **Backend changes** (`bridge/*.ts`): Bun does **not** hot-reload the service — you must
-  `systemctl --user restart collie`. Forgetting this is the #1 "my change didn't take" trap.
-- `bun run build` (root) and `collie-ctl.sh build` **typecheck both sides first** (root tsc + web
-  tsc), then build web to `dist-staging` and swap it in atomically — a failed build never empties a
-  live `web/dist`. Bare `cd web && bun run build` still skips typechecking; don't ship from it.
+- **Backend changes** (`bridge/*.ts`): Bun does **not** hot-reload the service — run
+  `herdr plugin action invoke restart --plugin herdr.collie`. Forgetting this is the #1 "my change
+  didn't take" trap.
+- `bun run build` (root) and both native control scripts' `build` command **typecheck both sides
+  first** (root tsc + web tsc), then build web to `dist-staging` and swap it in atomically — a
+  failed build never empties a live `web/dist`. Bare `cd web && bun run build` still skips
+  typechecking; don't ship from it.
 - **Tests:** frontend `cd web && bun run test` (Vitest + jsdom + Testing Library + MSW; no headless
   browser); backend `bun run test` at the root — Bun's own runner over every pure-logic module in
   `bridge/` (access checks, state engine, config, journal adapters, notifications, uploads, …) plus
-  `scripts/collie-ctl.test.sh`, which exercises the ctl lifecycle in a sandboxed HOME.
-  A **pre-push hook** (`scripts/git-hooks/pre-push`) runs **both** before
-  every push — override once with `SKIP_TESTS=1 git push`. The bits that genuinely need `Bun.serve` /
+  the platform lifecycle suite selected by `scripts/test-ctl.ts` (`collie-ctl.test.sh` on POSIX,
+  `collie-ctl.test.ps1` on Windows), each in a sandboxed config directory.
+  A **pre-push hook** (`scripts/git-hooks/pre-push`) runs the platform lifecycle and web suites;
+  POSIX also runs the backend suite, whose path and file-mode assertions are not native-Windows
+  contracts. CI runs it on Linux for every PR. Override once with `SKIP_TESTS=1 git push`.
+  The bits that genuinely need `Bun.serve` /
   `Bun.connect` (HTTP handlers, the socket client) stay unit-untested — Vitest-on-Node can't run them,
   so keep new backend logic pure/injectable enough for `bun test`, or exercise it through `web/`.
-- Service: `systemd --user` unit `collie` on the deployment host; logs `journalctl --user -u collie -f`.
+- Supervisor: `systemd --user` unit `collie`, launchd agent `herdr.collie`, or Windows scheduled
+  task `herdr.collie`, depending on the host.
 - **Dependencies must be 7 days old to install** (`bunfig.toml` + `web/bunfig.toml`, mirrored in
   `.npmrc` for npm users) — a compromised release is usually pulled within hours. A brand-new
   version resolving to an older one is the rule working, not a bug; CI's `--frozen-lockfile` is
@@ -174,8 +180,6 @@ conforming reverse proxy per README Variant C (`COLLIE_SKIP_SERVE=1`) · same-or
 identity/device gates · strict CSP. A socket call can type into a real terminal — treat the bridge as
 remote shell access.
 
-**Collie manages exactly one front door: `tailscale serve`** — `collie-ctl.sh` publishes it, records
-the mapping in `tailscale-managed-handler`, and only ever tears down a mapping matching that record.
-Every other tunnel (NetBird, ZeroTier, Cloudflare Tunnel) is `COLLIE_SKIP_SERVE=1` + README Variant
-E: the operator owns the ingress, Collie publishes nothing. **Don't add a second managed front
-door** — [ADR 0001](./.adr/0001-one-managed-front-door.md).
+**Collie uses exactly one front door.** The POSIX controller manages `tailscale serve`; Windows and
+every other tunnel use operator-owned ingress. **Don't add a second managed front door** —
+[ADR 0001](./.adr/0001-one-managed-front-door.md).

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ Each agent gets a colored terminal mirror, a slash-command palette, a special-ke
 conversation history you can scroll and search. The reply box is an ordinary text field, so your
 phone's own voice dictation works in it; Collie ships none of its own.
 
-A Herdr plugin (thin launcher) plus a Bun/TypeScript bridge running as a `systemd --user` service,
-serving a Vite + React + shadcn PWA.
+A Herdr plugin (thin launcher) plus a supervised Bun/TypeScript bridge serving a Vite + React +
+shadcn PWA.
 
 ## Contents
 
@@ -141,14 +141,14 @@ On the **host** (the tailnet node your agents run on):
 
 Soft dependencies: **Node.js** (the control script uses it to extract your MagicDNS name from
 `tailscale status --json`; without it the banner falls back to the loopback URL) and a **service
-supervisor** — `systemd --user` on Linux, **launchd** on macOS (both ship with the OS); a host with
-neither falls back to an unsupervised `nohup` process. You never install JS
+supervisor** — `systemd --user` on Linux, **launchd** on macOS, or Task Scheduler on Windows; a
+POSIX host with neither falls back to an unsupervised `nohup` process. You never install JS
 deps by hand — the build runs `bun install` for you; the backend imports only Bun + `node:*`.
 [`web-push`](https://www.npmjs.com/package/web-push) is optional and lazy (see [Web
 Push](#web-push-optional)).
 
-**Linux and macOS are the supported hosts.** The bridge itself also runs on **Windows**
-(experimental) against Herdr's Windows beta — see [Windows](#windows-experimental).
+**Linux, macOS, and Windows are supported hosts.** Windows remains experimental while Herdr's
+Windows support is in preview; see [Windows](#windows-experimental).
 
 ## Install
 
@@ -165,30 +165,31 @@ herdr plugin action invoke start --plugin herdr.collie
 
 ```bash
 git clone https://github.com/AltanS/collie.git && cd collie
+bash scripts/collie-ctl.sh build
 herdr plugin link "$(pwd)"
 herdr plugin action invoke start --plugin herdr.collie
 ```
 
 They differ in *when* the UI builds — a GitHub install builds at install time (the manifest's
-`[[build]]` step), a linked clone on first `start` — and in **what lands on disk**, which matters when
+`[[build]]` step), while a linked clone builds explicitly before linking — and in **what lands on
+disk**, which matters when
 you go to [update](#update-to-a-new-release): `herdr plugin install` doesn't clone, it fetches one
 commit and detaches onto it, so the checkout has no branch. Both shapes update fine from 0.23.1 on;
 **installed earlier than that, see the note in [Update](#update-to-a-new-release)**. Either way,
 `start` does four things:
 
 1. **builds** `web/dist` if it's missing (typechecked, staged, swapped in atomically),
-2. **starts the bridge** as the `systemd --user` service `collie` (`nohup` fallback without systemd),
-3. **publishes it on the tailnet** — literally `tailscale serve --bg 8787`: HTTPS on the host's
-   MagicDNS name, `:443 → 127.0.0.1:8787`, tailnet-only,
+2. **starts the bridge** under the native user supervisor (`nohup` fallback on POSIX without one),
+3. **uses the tailnet front door** — Collie-managed on POSIX, operator-managed on Windows,
 4. **prints the banner** with the URL to open — walked through line by line in
    [First run](#first-run--what-youll-see).
 
-> No Herdr? Run `scripts/collie-ctl.sh start` directly — same effect (config then lives in
-> `~/.config/collie/.env`).
+> No Herdr? On POSIX, run `scripts/collie-ctl.sh start` directly — same effect (config then lives
+> in `~/.config/collie/.env`). Windows has the equivalent `scripts/collie-ctl.ps1` commands.
 
 ## First run — what you'll see
 
-The transcripts below are the control script's inline output. **Through `invoke start` you get
+The POSIX transcript below is the control script's inline output. **Through `invoke start` you get
 Herdr's JSON envelope instead** — the same text is the action's *captured stdout*, read with
 `herdr plugin log list --plugin herdr.collie`.
 
@@ -219,18 +220,21 @@ The `✓` is a real probe — the script connected to the bridge's port and got 
    `~/.config/systemd/user/collie.service`, enabled and started, auto-restarting on failure. Inspect
    it with `systemctl --user status collie`. On macOS a launchd agent labelled `herdr.collie`, written
    to `~/Library/LaunchAgents/herdr.collie.plist` and bootstrapped into `gui/$(id -u)`; inspect it
-   with `launchctl print gui/$(id -u)/herdr.collie`. (Neither supervisor? A `nohup` process with a
-   pidfile in the config dir instead.)
-3. **A tailnet-only `tailscale serve` mapping** — the script ran `tailscale serve --bg 8787`:
+   with `launchctl print gui/$(id -u)/herdr.collie`. On Windows, Task Scheduler runs `herdr.collie`
+   at logon and restarts it after failures. (No POSIX supervisor? A `nohup` process with a pidfile.)
+3. **A tailnet-only `tailscale serve` mapping** — on POSIX the script ran `tailscale serve --bg 8787`;
+   on Windows the operator creates it once:
    HTTPS on the host's MagicDNS name, `:443 → 127.0.0.1:8787`. Tailscale terminates TLS (managed
    cert, nothing to obtain or renew) and injects the identity header the bridge checks. Inspect
    with `tailscale serve status`; remove just this mapping with `scripts/collie-ctl.sh unserve`.
 
-`stop` merely pauses the service; `uninstall` reverses 2 + 3 and keeps your `.env` and the checkout.
+`stop` merely pauses the service. `uninstall` removes the supervisor and keeps your `.env` and
+checkout; POSIX also removes its managed Serve mapping, while Windows leaves operator-owned ingress.
 
 ### Open it on your phone
 
-The URL is the banner's `tailnet` line (print it again anytime with `scripts/collie-ctl.sh url`).
+The URL is the banner's `tailnet` line (print it again with
+`herdr plugin action invoke url --plugin herdr.collie`).
 It resolves for any device on your tailnet — so the phone needs the Tailscale app installed and
 connected to the same tailnet as the host.
 
@@ -394,7 +398,7 @@ Collie registers these actions in `herdr-plugin.toml`; invoke any with
 
 | `<id>` | Title | What it does |
 | --- | --- | --- |
-| `start` | Start web bridge | Build if needed, start the service, `tailscale serve`, print URL + banner |
+| `start` | Start web bridge | Build if needed, start the service, print URL + banner |
 | `stop` | Stop web bridge | Pause the bridge; removes nothing |
 | `restart` | Restart web bridge | `stop` + `start` |
 | `status` | Bridge status | The *Collie is running* banner — readiness ✓/⚠, version, URLs |
@@ -413,10 +417,9 @@ Pause the bridge without removing anything (a later `start` brings it right back
 scripts/collie-ctl.sh stop      # or: herdr plugin action invoke stop --plugin herdr.collie
 ```
 
-To tear the service down completely — stop + disable it, remove the service definition (the
-`systemd --user` unit, or the launchd agent plist on macOS), and remove
-Collie's own `tailscale serve` mapping (port-scoped, so other tailnet mappings on the host survive) —
-use `uninstall`. It leaves your `.env` and the checkout untouched:
+To tear the service down completely, use `uninstall`. It removes the native supervisor and leaves
+your `.env` and checkout untouched. POSIX also removes Collie's managed `tailscale serve` mapping;
+Windows leaves its operator-managed mapping unchanged:
 
 ```bash
 scripts/collie-ctl.sh uninstall # or: herdr plugin action invoke uninstall --plugin herdr.collie
@@ -450,8 +453,8 @@ herdr plugin action invoke restart --plugin herdr.collie   # reinstall doesn't r
 herdr plugin action invoke version --plugin herdr.collie   # expect 0.23.1 or newer
 ```
 
-Your `.env` and `tailscale serve` state live in the plugin config dir, outside the checkout, so they
-survive. Pinned to a version with `--ref`? Keep refreshing with `herdr plugin install --ref …` —
+Your `.env` lives outside the checkout, and persistent `tailscale serve` mappings survive updates.
+Pinned to a version with `--ref`? Keep refreshing with `herdr plugin install --ref …` —
 `update` always goes to the latest.
 
 #### What `update` actually does to the checkout
@@ -843,28 +846,41 @@ Three things to get right, none of them Collie-specific:
 
 ## Windows (experimental)
 
-The **bridge** runs on Windows against Herdr's Windows beta; the **launcher** does not. Herdr there
-exposes its control socket as a *named pipe* named after the full socket path, not an AF_UNIX
-socket, so Collie dials it through `node:net` instead of `Bun.connect` — one shim,
-[`bridge/dial.ts`](./bridge/dial.ts), which explains the mapping at the top of the file.
+Windows supports the normal Herdr plugin lifecycle. Install and start it from PowerShell:
 
-What that means in practice:
+```powershell
+herdr plugin install AltanS/collie --yes
+herdr plugin action invoke start --plugin herdr.collie
+```
 
-- **Run the bridge directly** — `bun run bridge/index.ts`. There's no systemd unit, and the Herdr
-  action buttons shell out to `bash`, so they only work if Git Bash is on `PATH`. The manifest
-  therefore still declares `linux`/`macos` only, rather than advertising buttons that may not fire.
-- **`tailscale serve` isn't wired up here.** Use the [Variant C](#variant-c--reverse-proxy-as-the-only-front-door-no-tailscale)
-  posture: loopback bind, your own ingress in front, `COLLIE_PUBLIC_HOSTS` pinned. The security
-  rules in [§Security](#%EF%B8%8F-security--read-before-you-run-it) are not relaxed on Windows.
-- **Set `COLLIE_MULTI_SESSION=off`** — session discovery derives POSIX paths.
-- The socket path defaults to `%APPDATA%\herdr\herdr.sock`; override with `HERDR_SOCKET_PATH`
-  (an explicit `\\.\pipe\…` value is passed through untouched).
+`start` registers a Task Scheduler job for the current user. The bridge starts at logon, restarts
+after failures, and survives Herdr restarts. The same `start`, `stop`, `restart`, `uninstall`,
+`update`, `url`, `status`, and `version` actions work on Linux, macOS, and Windows.
 
-**Is it actually working?** The bridge logs `[events] stream up` on start — the event stream works
-over the pipe, so Windows gets the same live updates as Linux, not degraded polling.
+The task is limited by default. If Herdr intentionally runs as Administrator, set
+`COLLIE_TASK_RUN_LEVEL=highest` in Collie's `.env`; this gives every phone action Administrator
+power. Prefer running Herdr normally.
 
-`COLLIE_HERDR_DIAL=net` forces that same dialer on Linux/macOS. It exists so the Windows code path
-can be exercised — and regression-tested — without a Windows box; `bridge/dial.test.ts` uses it.
+Windows does not change Tailscale Serve state. In Administrator PowerShell, create the mapping once:
+
+```powershell
+tailscale serve --yes --bg 8787
+```
+
+Enable HTTPS through Tailscale's consent link if prompted. The mapping persists across Collie
+restarts and uninstall; rerun the command if `COLLIE_PORT` changes.
+
+A locally linked checkout must build its platform launcher before linking because `plugin link`
+does not run manifest builds:
+
+```powershell
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File scripts/collie-ctl.ps1 build
+herdr plugin link .
+```
+
+Herdr's Windows socket is a named pipe. The socket path defaults to
+`%APPDATA%\herdr\herdr.sock`; an explicit `\\.\pipe\…` value passes through unchanged. The
+event stream and multi-session discovery use the same contracts as Linux and macOS.
 
 ## Web Push (optional)
 
@@ -909,7 +925,7 @@ pull into, and no install of that vintage could refresh itself. The fix ships in
 repairs, so it takes one reinstall to land:
 [Update to a new release](#update-to-a-new-release) has the three commands.
 
-**`start` prints `note: tailscale serve failed`.** The bridge itself is fine (still up on
+**On POSIX, `start` prints `note: tailscale serve failed`.** The bridge itself is fine (still up on
 `127.0.0.1`) — only the tailnet ingress didn't come up, and the script prints tailscale's own error
 right below the note. Usual causes: your user isn't the Tailscale operator
 (`sudo tailscale set --operator=$USER`), the node is logged out (`tailscale up`), or — on
@@ -941,7 +957,8 @@ headless host enable lingering once (`loginctl enable-linger $USER`) and the `co
 `enable`d) starts at boot with your user manager. The `tailscale serve` mapping persists on its own
 (`--bg`), so lingering is usually the whole fix. On macOS the launchd agent starts at **login**, so
 check you're actually logged in (not sitting at the login window) and that the agent is loaded:
-`launchctl print gui/$(id -u)/herdr.collie`.
+`launchctl print gui/$(id -u)/herdr.collie`. On Windows, confirm the `herdr.collie` scheduled task
+is enabled and that the user who registered it has logged in.
 
 **Phone shows a stale UI after a rebuild.** A PWA's service-worker cache is per-origin, so reaching
 Collie at two origins (a custom domain *and* the raw `host:8787`) gives you two installs, each

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -3,70 +3,72 @@ name = "Collie"
 version = "0.25.0"
 min_herdr_version = "0.7.0"
 description = "Mobile web UI to monitor and reply to your agent herd, served over Tailscale"
-platforms = ["linux", "macos"]
+platforms = ["linux", "macos", "windows"]
 
-# This plugin is a thin launcher. The actual bridge runs as a systemd --user service so it
-# outlives Herdr restarts (see ARCHITECTURE.md §3). The actions below shell out to
-# scripts/collie-ctl.sh, which gets HERDR_SOCKET_PATH / HERDR_PLUGIN_CONFIG_DIR injected.
+# This plugin is a thin launcher. The bridge runs under the native user supervisor so it outlives
+# Herdr restarts (see ARCHITECTURE.md §3). Each build creates build/collie-action-v1.exe as the one
+# platform-native command used by every action below.
 
 # Build the web UI at install time. Herdr runs [[build]] steps ONLY on `herdr plugin install`
-# (GitHub) — NOT on `herdr plugin link` (local dev), which instead builds lazily on first `start`
-# (collie-ctl.sh's ensure_build). Delegating to `collie-ctl.sh build` keeps a single build
-# definition (version gate → cd web && bun install && bun run build) shared with the `update` action.
+# (GitHub) — NOT on `herdr plugin link` (local dev), which must run a build once. Delegating to the
+# platform control script keeps one build definition (version gate → install → typecheck → web build)
+# shared with the `update` action.
 # Still needs Bun on PATH — building the frontend is the one unavoidable Bun step.
 [[build]]
 command = ["bash", "scripts/collie-ctl.sh", "build"]
 platforms = ["linux", "macos"]
 
+[[build]]
+command = ["powershell.exe", "-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-File", "scripts/collie-ctl.ps1", "build"]
+platforms = ["windows"]
+
 [[actions]]
 id = "start"
 title = "Start web bridge"
 contexts = ["workspace"]
-command = ["bash", "scripts/collie-ctl.sh", "start"]
+command = ["build/collie-action-v1.exe", "start"]
 
 [[actions]]
 id = "stop"
 title = "Stop web bridge"
 contexts = ["workspace"]
-command = ["bash", "scripts/collie-ctl.sh", "stop"]
+command = ["build/collie-action-v1.exe", "stop"]
 
 [[actions]]
 id = "restart"
 title = "Restart web bridge"
 contexts = ["workspace"]
-command = ["bash", "scripts/collie-ctl.sh", "restart"]
+command = ["build/collie-action-v1.exe", "restart"]
 
-# Full teardown: stops + disables the service, removes the systemd --user unit, and resets
-# tailscale serve. Leaves the .env and the checkout (so `start` can bring it right back). See
-# scripts/collie-ctl.sh → cmd_uninstall.
+# Full teardown removes the native supervisor and Collie's Tailscale Serve mapping. It leaves the
+# .env and checkout so `start` can bring the bridge back.
 [[actions]]
 id = "uninstall"
-title = "Uninstall web bridge (remove service)"
+title = "Uninstall web bridge"
 contexts = ["workspace"]
-command = ["bash", "scripts/collie-ctl.sh", "uninstall"]
+command = ["build/collie-action-v1.exe", "uninstall"]
 
-# Link-mode plugins ARE their on-disk git checkout (Herdr has no native `plugin update`), so this
-# action pulls + rebuilds + restarts in one step. See scripts/collie-ctl.sh → cmd_update.
+# The checkout on disk is the plugin, so this action advances it, rebuilds, and restarts in one step.
 [[actions]]
 id = "update"
 title = "Update plugin"
 contexts = ["workspace"]
-command = ["bash", "scripts/collie-ctl.sh", "update"]
+command = ["build/collie-action-v1.exe", "update"]
 
 [[actions]]
 id = "url"
 title = "Show bridge URL"
 contexts = ["workspace"]
-command = ["bash", "scripts/collie-ctl.sh", "url"]
+command = ["build/collie-action-v1.exe", "url"]
 
 [[actions]]
 id = "status"
 title = "Bridge status"
 contexts = ["workspace"]
-command = ["bash", "scripts/collie-ctl.sh", "status"]
+command = ["build/collie-action-v1.exe", "status"]
 
 [[actions]]
 id = "version"
 title = "Show version"
 contexts = ["workspace"]
-command = ["bash", "scripts/collie-ctl.sh", "version"]
+command = ["build/collie-action-v1.exe", "version"]

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,6 +1,6 @@
 id = "herdr.collie"
 name = "Collie"
-version = "0.25.0"
+version = "0.26.0"
 min_herdr_version = "0.7.0"
 description = "Mobile web UI to monitor and reply to your agent herd, served over Tailscale"
 platforms = ["linux", "macos", "windows"]

--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
     "build": "bun run typecheck && cd web && bun install && bun run typecheck && bun run build",
     "build:web": "cd web && bun run build",
     "web:dev": "cd web && bun run dev",
-    "test": "bun test ./bridge && bash scripts/collie-ctl.test.sh",
-    "test:ctl": "bash scripts/collie-ctl.test.sh",
-    "typecheck": "bunx tsc --noEmit"
+    "test": "bun test ./bridge && bun run scripts/test-ctl.ts",
+    "test:ctl": "bun run scripts/test-ctl.ts",
+    "typecheck": "bun x tsc --noEmit"
   },
   "devDependencies": {
     "@types/bun": "latest",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "collie",
-  "version": "0.25.0",
+  "version": "0.26.0",
   "private": true,
   "license": "MIT",
   "description": "Collie — a mobile web UI to monitor and reply to your Herdr agent herd over Tailscale",

--- a/scripts/check-version.sh
+++ b/scripts/check-version.sh
@@ -1,40 +1,4 @@
 #!/usr/bin/env bash
-# Version consistency gate for Collie.
-#
-# The plugin's version lives in three files that MUST agree, plus a matching CHANGELOG entry:
-#   - herdr-plugin.toml   (canonical — this is what Herdr reads)
-#   - package.json        (bridge / Bun server)
-#   - web/package.json    (PWA frontend)
-#   - CHANGELOG.md        (newest "## [x.y.z]" heading)
-#
-# Exits non-zero with a clear message on any mismatch. Run by `collie-ctl.sh build` and the
-# pre-commit hook. See CLAUDE.md → "Versioning" for the policy.
 set -euo pipefail
-
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-
-toml_v="$(sed -n 's/^[[:space:]]*version[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' "$ROOT/herdr-plugin.toml" | head -1)"
-pkg_v="$(sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$ROOT/package.json" | head -1)"
-web_v="$(sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$ROOT/web/package.json" | head -1)"
-log_v="$(sed -n 's/^##[[:space:]]*\[\([0-9][^]]*\)\].*/\1/p' "$ROOT/CHANGELOG.md" 2>/dev/null | head -1)"
-
-fail=0
-note() { printf '  %-18s %s\n' "$1" "$2"; }
-
-if [ -z "$toml_v" ]; then echo "✗ could not read version from herdr-plugin.toml" >&2; exit 1; fi
-
-if [ "$pkg_v" != "$toml_v" ] || [ "$web_v" != "$toml_v" ] || [ "$log_v" != "$toml_v" ]; then
-  fail=1
-fi
-
-if [ "$fail" -ne 0 ]; then
-  echo "✗ version mismatch — all four must equal the canonical herdr-plugin.toml version:" >&2
-  note "herdr-plugin.toml" "$toml_v  (canonical)"
-  note "package.json" "${pkg_v:-<missing>}"
-  note "web/package.json" "${web_v:-<missing>}"
-  note "CHANGELOG.md" "${log_v:-<missing>}"
-  echo "  → bump all three files to the same version and add a matching CHANGELOG entry." >&2
-  exit 1
-fi
-
-echo "✓ version $toml_v consistent across manifest, package.json, web/package.json, CHANGELOG"
+exec bun run "$ROOT/scripts/check-version.ts"

--- a/scripts/check-version.ts
+++ b/scripts/check-version.ts
@@ -1,0 +1,26 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const root = join(import.meta.dir, "..");
+const read = (path: string) => readFileSync(join(root, path), "utf8");
+const manifestVersion = /^\s*version\s*=\s*"([^"]+)"/m.exec(read("herdr-plugin.toml"))?.[1] ?? "";
+
+if (!manifestVersion) {
+  console.error("✗ could not read version from herdr-plugin.toml");
+  process.exit(1);
+}
+
+const versions = {
+  "herdr-plugin.toml": manifestVersion,
+  "package.json": (JSON.parse(read("package.json")) as { version?: string }).version ?? "",
+  "web/package.json": (JSON.parse(read("web/package.json")) as { version?: string }).version ?? "",
+  "CHANGELOG.md": /^##\s*\[([^\]]+)\]/m.exec(read("CHANGELOG.md"))?.[1] ?? "",
+};
+
+if (Object.values(versions).some((version) => version !== manifestVersion)) {
+  console.error(`✗ version mismatch - all four must equal herdr-plugin.toml (${manifestVersion}):`);
+  for (const [file, version] of Object.entries(versions)) console.error(`  ${file}: ${version || "<missing>"}`);
+  process.exit(1);
+}
+
+console.log(`✓ version ${manifestVersion} consistent across manifest, package.json, web/package.json, CHANGELOG`);

--- a/scripts/collie-action.cs
+++ b/scripts/collie-action.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+
+internal static class CollieAction
+{
+    private static int Main(string[] args)
+    {
+        var executable = Process.GetCurrentProcess().MainModule.FileName;
+        var root = Path.GetFullPath(Path.Combine(Path.GetDirectoryName(executable), ".."));
+        if (root.StartsWith(@"\\?\", StringComparison.Ordinal)) root = root.Substring(4);
+
+        var start = new ProcessStartInfo
+        {
+            FileName = Path.Combine(Environment.SystemDirectory, @"WindowsPowerShell\v1.0\powershell.exe"),
+            Arguments = "-NoProfile -NonInteractive -ExecutionPolicy Bypass -File \"" +
+                Path.Combine(root, "scripts", "collie-ctl.ps1") + "\" " + string.Join(" ", args),
+            UseShellExecute = false,
+        };
+        using (var child = Process.Start(start))
+        {
+            child.WaitForExit();
+            return child.ExitCode;
+        }
+    }
+}

--- a/scripts/collie-ctl.ps1
+++ b/scripts/collie-ctl.ps1
@@ -1,0 +1,543 @@
+[CmdletBinding()]
+param(
+  [Parameter(Position = 0)]
+  [string]$Command,
+  [Parameter(ValueFromRemainingArguments = $true)]
+  [string[]]$CommandArgs,
+  [string]$TaskConfigDir,
+  [string]$TaskSocketPath
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$script:PluginRoot = [IO.Path]::GetFullPath((Join-Path $PSScriptRoot ".."))
+$script:PluginId = "herdr.collie"
+$script:TaskName = if ($env:COLLIE_TASK_NAME) { $env:COLLIE_TASK_NAME } else { "herdr.collie" }
+
+function Resolve-CollieConfigDir {
+  if ($env:HERDR_PLUGIN_CONFIG_DIR) {
+    return $env:HERDR_PLUGIN_CONFIG_DIR
+  }
+
+  $herdr = Get-Command herdr.exe -ErrorAction SilentlyContinue
+  if ($herdr) {
+    try {
+      $resolved = (& $herdr.Source plugin config-dir $script:PluginId 2>$null | Select-Object -First 1).Trim()
+      if ($resolved) { return $resolved }
+    } catch {
+      # Herdr may not be running during login. Fall through to its conventional Windows path.
+    }
+  }
+
+  $roaming = if ($env:APPDATA) { $env:APPDATA } else { Join-Path $env:USERPROFILE "AppData\Roaming" }
+  return Join-Path $roaming "herdr\plugins\config\$($script:PluginId)"
+}
+
+$script:ConfigDir = if ($TaskConfigDir) { $TaskConfigDir } else { Resolve-CollieConfigDir }
+$script:EnvFile = Join-Path $script:ConfigDir ".env"
+$script:LogFile = Join-Path $script:ConfigDir "collie.log"
+$script:ErrorLogFile = Join-Path $script:ConfigDir "collie-error.log"
+$script:PreviousLogFile = Join-Path $script:ConfigDir "collie-previous.log"
+$script:PreviousErrorLogFile = Join-Path $script:ConfigDir "collie-error-previous.log"
+$script:PidFile = Join-Path $script:ConfigDir "collie-processes"
+
+function Import-CollieEnv([string]$Path) {
+  if (-not (Test-Path -LiteralPath $Path)) { return }
+
+  foreach ($line in Get-Content -LiteralPath $Path) {
+    $trimmed = $line.Trim()
+    if (-not $trimmed -or $trimmed.StartsWith("#")) { continue }
+    $match = [regex]::Match($trimmed, '^([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)$')
+    if (-not $match.Success) {
+      throw "invalid .env line: $line"
+    }
+    $name = $match.Groups[1].Value
+    $value = $match.Groups[2].Value.Trim()
+    if ($value.Length -ge 2 -and (($value[0] -eq '"' -and $value[-1] -eq '"') -or ($value[0] -eq "'" -and $value[-1] -eq "'"))) {
+      $value = $value.Substring(1, $value.Length - 2)
+    }
+    [Environment]::SetEnvironmentVariable($name, $value, "Process")
+  }
+}
+
+Import-CollieEnv $script:EnvFile
+
+function Get-ColliePort {
+  $port = 8787
+  if ($env:COLLIE_PORT) {
+    $parsed = 0
+    if (-not [int]::TryParse($env:COLLIE_PORT, [ref]$parsed) -or $parsed -lt 1 -or $parsed -gt 65535) {
+      Write-Warning "COLLIE_PORT=$($env:COLLIE_PORT) is invalid - using 8787"
+    } else {
+      $port = $parsed
+    }
+  }
+  return $port
+}
+
+$script:Port = Get-ColliePort
+$script:ServeMode = if ($env:COLLIE_SERVE_MODE -eq "http") { "http" } else { "https" }
+$script:SkipServe = $env:COLLIE_SKIP_SERVE -eq "1"
+$script:RoamingDir = if ($env:APPDATA) { $env:APPDATA } else { Join-Path $env:USERPROFILE "AppData\Roaming" }
+$script:SocketPath = if ($TaskSocketPath) {
+  $TaskSocketPath
+} elseif ($env:HERDR_SOCKET_PATH) {
+  $env:HERDR_SOCKET_PATH
+} else {
+  Join-Path $script:RoamingDir "herdr\herdr.sock"
+}
+
+function Resolve-Bun {
+  $command = Get-Command bun.exe -ErrorAction SilentlyContinue
+  if ($command) { return $command.Source }
+
+  $candidates = @(
+    (Join-Path $env:USERPROFILE ".bun\bin\bun.exe"),
+    (Join-Path $env:ProgramData "chocolatey\bin\bun.exe"),
+    (Join-Path $env:LOCALAPPDATA "bun\bin\bun.exe")
+  )
+  foreach ($candidate in $candidates) {
+    if ($candidate -and (Test-Path -LiteralPath $candidate)) { return $candidate }
+  }
+  throw "bun not found - install Bun and make bun.exe available on PATH"
+}
+
+function Resolve-Tailscale {
+  $command = Get-Command tailscale.exe -ErrorAction SilentlyContinue
+  if ($command) { return $command.Source }
+  foreach ($candidate in @(
+      (Join-Path $env:ProgramFiles "Tailscale\tailscale.exe"),
+      (Join-Path ${env:ProgramFiles(x86)} "Tailscale\tailscale.exe"),
+      (Join-Path $env:LOCALAPPDATA "Tailscale\tailscale.exe")
+    )) {
+    if ($candidate -and (Test-Path -LiteralPath $candidate)) { return $candidate }
+  }
+  return $null
+}
+
+function Invoke-InDirectory([string]$Path, [scriptblock]$Body) {
+  Push-Location -LiteralPath $Path
+  try { & $Body } finally { Pop-Location }
+}
+
+function Assert-LastExit([string]$What) {
+  if ($LASTEXITCODE -ne 0) { throw "$What failed with exit code $LASTEXITCODE" }
+}
+
+function Write-CollieActionLauncher {
+  $launcherDir = Join-Path $script:PluginRoot "build"
+  $launcher = Join-Path $launcherDir "collie-action-v1.exe"
+  if (Test-Path -LiteralPath $launcher) {
+    $stream = [IO.File]::OpenRead($launcher)
+    try { $isExecutable = $stream.ReadByte() -eq 77 -and $stream.ReadByte() -eq 90 } finally { $stream.Dispose() }
+    if (-not $isExecutable) {
+      throw "action launcher was built for POSIX; delete '$launcher' and rebuild"
+    }
+    return
+  }
+  New-Item -ItemType Directory -Force -Path $launcherDir | Out-Null
+  Add-Type -Path (Join-Path $PSScriptRoot "collie-action.cs") -OutputAssembly $launcher -OutputType ConsoleApplication
+}
+
+function Install-CollieWebDist([string]$WebRoot) {
+  $staging = Join-Path $WebRoot "dist-staging"
+  $dist = Join-Path $WebRoot "dist"
+  $backup = Join-Path $WebRoot "dist-backup"
+
+  if (Test-Path -LiteralPath $backup) {
+    if (Test-Path -LiteralPath $dist) {
+      Remove-Item -LiteralPath $backup -Recurse -Force
+    } else {
+      Move-Item -LiteralPath $backup -Destination $dist
+    }
+  }
+  if (Test-Path -LiteralPath $dist) { Move-Item -LiteralPath $dist -Destination $backup }
+  try {
+    Move-Item -LiteralPath $staging -Destination $dist
+  } catch {
+    if ((Test-Path -LiteralPath $backup) -and -not (Test-Path -LiteralPath $dist)) {
+      Move-Item -LiteralPath $backup -Destination $dist
+    }
+    throw
+  }
+  Remove-Item -LiteralPath $backup -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+function Invoke-CollieApplicationBuild([string]$Bun) {
+  New-Item -ItemType Directory -Force -Path $script:ConfigDir | Out-Null
+  if ($env:SKIP_VERSION_CHECK -ne "1") {
+    & $Bun run (Join-Path $PSScriptRoot "check-version.ts")
+    Assert-LastExit "version consistency check"
+  }
+
+  Invoke-InDirectory $script:PluginRoot {
+    & $Bun install
+    Assert-LastExit "root bun install"
+    & $Bun run typecheck
+    Assert-LastExit "root typecheck"
+  }
+
+  $webRoot = Join-Path $script:PluginRoot "web"
+  $staging = Join-Path $webRoot "dist-staging"
+  if (Test-Path -LiteralPath $staging) { Remove-Item -LiteralPath $staging -Recurse -Force }
+  Invoke-InDirectory $webRoot {
+    & $Bun install
+    Assert-LastExit "web bun install"
+    & $Bun run typecheck
+    Assert-LastExit "web typecheck"
+    & $Bun run build -- --outDir dist-staging --emptyOutDir
+    Assert-LastExit "web build"
+  }
+  Install-CollieWebDist $webRoot
+}
+
+function Invoke-CollieBuild {
+  $bun = Resolve-Bun
+  Write-CollieActionLauncher
+  Invoke-CollieApplicationBuild $bun
+}
+
+function Ensure-CollieBuild {
+  if (Test-Path -LiteralPath (Join-Path $script:PluginRoot "web\dist\index.html")) { return }
+  Write-Output "building web UI (first run)..."
+  Invoke-CollieApplicationBuild (Resolve-Bun)
+}
+
+function Test-Administrator {
+  $principal = [Security.Principal.WindowsPrincipal]::new([Security.Principal.WindowsIdentity]::GetCurrent())
+  return $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+}
+
+function Get-CollieTaskRunLevel {
+  $requested = if ($env:COLLIE_TASK_RUN_LEVEL) { $env:COLLIE_TASK_RUN_LEVEL.Trim() } else { "limited" }
+  if ($requested -ieq "limited") { return "Limited" }
+  if ($requested -ine "highest") { throw "COLLIE_TASK_RUN_LEVEL must be 'limited' or 'highest'" }
+  if (-not (Test-Administrator)) { throw "COLLIE_TASK_RUN_LEVEL=highest requires Administrator PowerShell" }
+  return "Highest"
+}
+
+function Register-CollieTask {
+  [void](Resolve-Bun)
+  $powershell = (Get-Command powershell.exe -ErrorAction Stop).Source
+  $ctl = Join-Path $PSScriptRoot "collie-ctl.ps1"
+  $arguments = '-NoProfile -NonInteractive -ExecutionPolicy Bypass -File "{0}" -TaskConfigDir "{1}" -TaskSocketPath "{2}" _exec-bridge' -f $ctl, $script:ConfigDir, $script:SocketPath
+  $identity = [Security.Principal.WindowsIdentity]::GetCurrent().Name
+
+  $action = New-ScheduledTaskAction -Execute $powershell -Argument $arguments -WorkingDirectory $script:PluginRoot
+  $trigger = New-ScheduledTaskTrigger -AtLogOn -User $identity
+  $principal = New-ScheduledTaskPrincipal -UserId $identity -LogonType Interactive -RunLevel (Get-CollieTaskRunLevel)
+  $settings = New-ScheduledTaskSettingsSet `
+    -AllowStartIfOnBatteries `
+    -DontStopIfGoingOnBatteries `
+    -ExecutionTimeLimit ([TimeSpan]::Zero) `
+    -MultipleInstances IgnoreNew `
+    -RestartCount 999 `
+    -RestartInterval (New-TimeSpan -Minutes 1) `
+    -StartWhenAvailable
+
+  Register-ScheduledTask -TaskName $script:TaskName -Action $action -Trigger $trigger -Principal $principal -Settings $settings -Description "Collie mobile bridge for Herdr" -Force | Out-Null
+  Enable-ScheduledTask -TaskName $script:TaskName | Out-Null
+}
+
+function Test-BridgeReady([int]$Attempts = 25) {
+  for ($i = 0; $i -lt $Attempts; $i++) {
+    $client = [Net.Sockets.TcpClient]::new()
+    try {
+      $connect = $client.ConnectAsync("127.0.0.1", $script:Port)
+      if ($connect.Wait(200) -and $client.Connected) { return $true }
+    } catch {
+      # The bridge may still be starting.
+    } finally {
+      $client.Dispose()
+    }
+    Start-Sleep -Milliseconds 200
+  }
+  return $false
+}
+
+function Test-HerdrReady([int]$Attempts = 1) {
+  for ($i = 0; $i -lt $Attempts; $i++) {
+    try {
+      $snapshot = Invoke-RestMethod -Uri "http://127.0.0.1:$($script:Port)/api/snapshot" -TimeoutSec 1
+      if ($snapshot.bridge -eq "connected") { return $true }
+    } catch {
+      # The bridge or Herdr endpoint may still be starting.
+    }
+    if ($i + 1 -lt $Attempts) { Start-Sleep -Milliseconds 250 }
+  }
+  return $false
+}
+
+function Get-CollieVersion {
+  $buildInfo = Join-Path $script:PluginRoot "web\dist\build-info.json"
+  if (Test-Path -LiteralPath $buildInfo) {
+    $info = Get-Content -LiteralPath $buildInfo -Raw | ConvertFrom-Json
+    if ($info.sha) { return "$($info.version)+$($info.sha)" }
+    return [string]$info.version
+  }
+  $manifest = Get-Content -LiteralPath (Join-Path $script:PluginRoot "herdr-plugin.toml") -Raw
+  $version = [regex]::Match($manifest, '(?m)^\s*version\s*=\s*"([^"]+)"').Groups[1].Value
+  return "$version (manifest; web not built)"
+}
+
+function Get-TailscaleStatus {
+  $tailscale = Resolve-Tailscale
+  if (-not $tailscale) { throw "tailscale not found" }
+  $raw = & $tailscale status --json 2>$null | Out-String
+  Assert-LastExit "tailscale status"
+  return $raw | ConvertFrom-Json
+}
+
+function Get-TailscaleDnsName {
+  try {
+    $status = Get-TailscaleStatus
+    return ([string]$status.Self.DNSName).TrimEnd(".")
+  } catch {
+    return ""
+  }
+}
+
+function Get-CollieUrl {
+  if ($script:SkipServe) {
+    if ($env:COLLIE_PUBLIC_URL) { return $env:COLLIE_PUBLIC_URL }
+    return "http://127.0.0.1:$($script:Port) (COLLIE_SKIP_SERVE=1; public URL unset)"
+  }
+  $dnsName = Get-TailscaleDnsName
+  if (-not $dnsName) { return "http://127.0.0.1:$($script:Port) (Tailscale name unavailable)" }
+  if ($script:ServeMode -eq "http") { return "http://$dnsName`:$($script:Port)" }
+  return "https://$dnsName"
+}
+
+function Show-CollieServeStatus {
+  if ($script:SkipServe) {
+    Write-Output "  serve config: skipped (COLLIE_SKIP_SERVE=1)"
+    return
+  }
+
+  Write-Output "  serve config:"
+  $tailscale = Resolve-Tailscale
+  if (-not $tailscale) {
+    Write-Output "    (tailscale not found)"
+    return
+  }
+  $status = & $tailscale serve status 2>$null
+  if ($LASTEXITCODE -eq 0 -and $status) {
+    $status | ForEach-Object { Write-Output "    $_" }
+  } else {
+    Write-Output "    (unavailable)"
+  }
+}
+
+function Show-CollieStatus {
+  $task = Get-ScheduledTask -TaskName $script:TaskName -ErrorAction SilentlyContinue
+  $service = if ($task) { "Task Scheduler ($($script:TaskName)) - $($task.State)" } else { "not supervised" }
+  Write-Output ""
+  if (Test-HerdrReady) {
+    Write-Output "  OK Collie is running - v$(Get-CollieVersion)"
+  } elseif (Test-BridgeReady 1) {
+    Write-Output "  WARN Collie is running but cannot reach Herdr - check logs"
+  } else {
+    Write-Output "  WARN Collie is not answering on :$($script:Port) - check logs"
+  }
+  Write-Output "    service   $service"
+  Write-Output "    local     http://127.0.0.1:$($script:Port)"
+  Write-Output "    remote    $(Get-CollieUrl)"
+  Write-Output ""
+  Show-CollieServeStatus
+}
+
+function Start-Collie {
+  Ensure-CollieBuild
+  Register-CollieTask | Out-Null
+  Start-ScheduledTask -TaskName $script:TaskName
+  Write-Output "bridge started (Task Scheduler: $($script:TaskName))"
+  if (-not (Test-HerdrReady 30)) {
+    Write-Warning "Collie cannot reach Herdr yet. Herdr may be temporarily unavailable or running as Administrator. The bridge remains supervised and will reconnect."
+  }
+  Show-CollieStatus
+}
+
+function Stop-RecordedCollieProcesses {
+  if (-not (Test-Path -LiteralPath $script:PidFile)) { return }
+  $record = (Get-Content -LiteralPath $script:PidFile -Raw).Trim()
+  $match = [regex]::Match($record, '^(\d+)\|(\d+)$')
+  if (-not $match.Success) { throw "invalid Collie process ownership state: $record" }
+
+  $launcherId = [int]$match.Groups[1].Value
+  $bridgeId = [int]$match.Groups[2].Value
+  $launcher = Get-CimInstance Win32_Process -Filter "ProcessId = $launcherId" -ErrorAction SilentlyContinue
+  if ($launcher) {
+    $controlScript = Join-Path $PSScriptRoot "collie-ctl.ps1"
+    if ($launcher.CommandLine -and $launcher.CommandLine.Contains($controlScript) -and $launcher.CommandLine.Contains("_exec-bridge")) {
+      & (Join-Path $env:SystemRoot "System32\taskkill.exe") /PID $launcherId /T /F | Out-Null
+    }
+  }
+
+  $bridge = if ($bridgeId -gt 0) {
+    Get-CimInstance Win32_Process -Filter "ProcessId = $bridgeId" -ErrorAction SilentlyContinue
+  }
+  if ($bridge) {
+    $bridgeScript = Join-Path $script:PluginRoot "bridge\index.ts"
+    if ($bridge.CommandLine -and $bridge.CommandLine.Contains($bridgeScript)) {
+      Stop-Process -Id $bridgeId -Force
+    }
+  }
+  Remove-Item -LiteralPath $script:PidFile -ErrorAction SilentlyContinue
+}
+
+function Stop-Collie {
+  $task = Get-ScheduledTask -TaskName $script:TaskName -ErrorAction SilentlyContinue
+  if ($task) {
+    Disable-ScheduledTask -TaskName $script:TaskName | Out-Null
+  }
+  Stop-RecordedCollieProcesses
+  if ($task) { Stop-ScheduledTask -TaskName $script:TaskName -ErrorAction SilentlyContinue }
+  Write-Output "bridge stopped"
+}
+
+function Uninstall-Collie {
+  Stop-Collie
+  if (Get-ScheduledTask -TaskName $script:TaskName -ErrorAction SilentlyContinue) {
+    Unregister-ScheduledTask -TaskName $script:TaskName -Confirm:$false
+  }
+  Write-Output "OK uninstalled: task stopped and removed"
+  Write-Output "  Tailscale Serve is operator-managed and was left unchanged"
+  Write-Output "  kept: $($script:EnvFile) and the checkout"
+}
+
+function Test-CollieGitCommand([string[]]$GitArgs) {
+  $savedPreference = $ErrorActionPreference
+  try {
+    $ErrorActionPreference = "Continue"
+    & git -C $script:PluginRoot @GitArgs *> $null
+    return $LASTEXITCODE -eq 0
+  } finally {
+    $ErrorActionPreference = $savedPreference
+  }
+}
+
+function Test-CollieManagedCheckout {
+  return -not (Test-CollieGitCommand @("symbolic-ref", "-q", "HEAD"))
+}
+
+function Update-CollieCheckout {
+  if (-not (Test-CollieGitCommand @("rev-parse", "--git-dir"))) {
+    throw "not a git checkout - refresh with: herdr plugin install AltanS/collie --yes"
+  }
+
+  if (-not (Test-CollieManagedCheckout)) {
+    Write-Output "updating Collie (git pull --ff-only)..."
+    & git -C $script:PluginRoot pull --ff-only
+    Assert-LastExit "git pull"
+    return
+  }
+
+  Write-Output "updating Collie (Herdr-managed checkout: fetch + detach onto origin HEAD)..."
+  $shallow = (& git -C $script:PluginRoot rev-parse --is-shallow-repository | Out-String).Trim()
+  Assert-LastExit "git shallow check"
+  $depth = if ($shallow -eq "true") { @("--depth", "1") } else { @() }
+  & git -C $script:PluginRoot fetch @depth origin HEAD
+  Assert-LastExit "git fetch"
+  & git -C $script:PluginRoot checkout -q --detach --force FETCH_HEAD
+  Assert-LastExit "git checkout"
+  $head = (& git -C $script:PluginRoot log -1 --format="%h %s" | Out-String).Trim()
+  Assert-LastExit "git log"
+  Write-Output "now at $head"
+}
+
+function Refresh-CollieRegistry {
+  if (Test-CollieManagedCheckout) {
+    Write-Output "note: Herdr-managed install - registry left alone (re-linking would block plugin reinstall)"
+    return
+  }
+  try {
+    & herdr plugin link $script:PluginRoot | Out-Null
+    Assert-LastExit "herdr plugin link"
+    Write-Output "herdr registry refreshed (re-linked)"
+  } catch {
+    Write-Warning "could not refresh the Herdr registry; run: herdr plugin link `"$($script:PluginRoot)`""
+  }
+}
+
+function Apply-CollieUpdate {
+  Invoke-CollieBuild
+  Stop-Collie
+  Start-Collie
+  Refresh-CollieRegistry
+  Write-Output "OK update complete"
+}
+
+function Update-Collie {
+  Update-CollieCheckout
+  $powershell = (Get-Command powershell.exe -ErrorAction Stop).Source
+  & $powershell -NoProfile -NonInteractive -ExecutionPolicy Bypass -File (Join-Path $PSScriptRoot "collie-ctl.ps1") _apply-update
+  Assert-LastExit "apply update"
+}
+
+function Preserve-CollieCrashLogs {
+  if (Test-Path -LiteralPath $script:LogFile) {
+    Move-Item -LiteralPath $script:LogFile -Destination $script:PreviousLogFile -Force
+  }
+  if (Test-Path -LiteralPath $script:ErrorLogFile) {
+    Move-Item -LiteralPath $script:ErrorLogFile -Destination $script:PreviousErrorLogFile -Force
+  }
+}
+
+function Invoke-CollieBridge {
+  $bun = Resolve-Bun
+  New-Item -ItemType Directory -Force -Path $script:ConfigDir | Out-Null
+  $env:HERDR_SOCKET_PATH = $script:SocketPath
+  $env:COLLIE_PORT = [string]$script:Port
+  $env:HERDR_PLUGIN_CONFIG_DIR = $script:ConfigDir
+  if (-not $env:HERDR_PLUGIN_STATE_DIR) {
+    $localData = if ($env:LOCALAPPDATA) { $env:LOCALAPPDATA } else { Join-Path $env:USERPROFILE "AppData\Local" }
+    $env:HERDR_PLUGIN_STATE_DIR = Join-Path $localData "herdr\plugins\$($script:PluginId)"
+  }
+  $bridge = Join-Path $script:PluginRoot "bridge\index.ts"
+  Stop-RecordedCollieProcesses
+  while ($true) {
+    "$PID|0" | Set-Content -LiteralPath $script:PidFile -NoNewline
+    $process = Start-Process `
+      -FilePath $bun `
+      -ArgumentList @("run", "`"$bridge`"") `
+      -WorkingDirectory $script:PluginRoot `
+      -NoNewWindow `
+      -PassThru `
+      -RedirectStandardOutput $script:LogFile `
+      -RedirectStandardError $script:ErrorLogFile
+    "$PID|$($process.Id)" | Set-Content -LiteralPath $script:PidFile -NoNewline
+    $process.WaitForExit()
+    $exitCode = $process.ExitCode
+    "$PID|0" | Set-Content -LiteralPath $script:PidFile -NoNewline
+    if ($exitCode -eq 0) { exit 0 }
+    Preserve-CollieCrashLogs
+    Start-Sleep -Seconds 5
+  }
+}
+
+if ($MyInvocation.InvocationName -eq ".") { return }
+
+switch ($Command) {
+  "build" { Invoke-CollieBuild }
+  "start" { Start-Collie }
+  "stop" { Stop-Collie }
+  "restart" { Stop-Collie; Start-Collie }
+  "uninstall" { Uninstall-Collie }
+  "update" { Update-Collie }
+  "_apply-update" { Apply-CollieUpdate }
+  "status" { Show-CollieStatus }
+  "url" { Get-CollieUrl }
+  "version" { Get-CollieVersion }
+  "logs" {
+    $lines = if ($CommandArgs -and $CommandArgs.Count -gt 0) { [int]$CommandArgs[0] } else { 50 }
+    if (Test-Path -LiteralPath $script:PreviousLogFile) { Write-Output "previous bridge crash (stdout):"; Get-Content -LiteralPath $script:PreviousLogFile -Tail $lines -Encoding UTF8 }
+    if (Test-Path -LiteralPath $script:PreviousErrorLogFile) { Write-Output "previous bridge crash (stderr):"; Get-Content -LiteralPath $script:PreviousErrorLogFile -Tail $lines -Encoding UTF8 }
+    if (Test-Path -LiteralPath $script:LogFile) { Get-Content -LiteralPath $script:LogFile -Tail $lines -Encoding UTF8 } else { "(no log)" }
+    if (Test-Path -LiteralPath $script:ErrorLogFile) { Get-Content -LiteralPath $script:ErrorLogFile -Tail $lines -Encoding UTF8 }
+  }
+  "_exec-bridge" { Invoke-CollieBridge }
+  default {
+    Write-Error "usage: collie-ctl.ps1 {start|stop|restart|uninstall|update|version|build|status|url|logs}"
+  }
+}

--- a/scripts/collie-ctl.sh
+++ b/scripts/collie-ctl.sh
@@ -132,14 +132,27 @@ xml_escape() {
   printf '%s' "$1" | sed -e 's/&/\&amp;/g' -e 's/</\&lt;/g' -e 's/>/\&gt;/g'
 }
 
+write_action_launcher() {
+  local launcher="${PLUGIN_ROOT}/build/collie-action-v1.exe"
+  if [ ! -e "$launcher" ]; then
+    mkdir -p "${PLUGIN_ROOT}/build"
+    printf '%s\n' '#!/bin/sh' 'exec bash "$(dirname "$0")/../scripts/collie-ctl.sh" "$@"' > "$launcher"
+  elif [ "$(head -n 1 "$launcher")" != '#!/bin/sh' ]; then
+    echo "error: action launcher was built for Windows; delete '$launcher' and rebuild" >&2
+    return 1
+  fi
+  chmod +x "$launcher"
+}
+
 # Build the Vite/React PWA into web/dist. The bridge serves that directory; without it the API
 # still runs but the UI 503s. Safe to call repeatedly (no-op if already built, unless forced).
 cmd_build() {
   [ -n "$BUN" ] || { echo "error: bun not found on PATH" >&2; exit 1; }
+  write_action_launcher
   # Version gate: refuse to build a release whose version files / CHANGELOG disagree.
   # Override (e.g. mid-refactor) with SKIP_VERSION_CHECK=1.
   if [ "${SKIP_VERSION_CHECK:-}" != "1" ]; then
-    bash "${PLUGIN_ROOT}/scripts/check-version.sh"
+    "$BUN" run "${PLUGIN_ROOT}/scripts/check-version.ts"
   fi
   # Install BOTH dependency trees before typechecking. The root typecheck (tsconfig `types: ["bun"]`)
   # resolves @types/bun from the ROOT node_modules; a fresh Herdr checkout ships neither tree, so
@@ -804,7 +817,7 @@ cmd_serve() {
   if [ "$SERVE_MODE" = "http" ]; then
     ensure_tailscale_root_available "$PORT" http "$expected_proxy" || return 1
     printf '%s|%s|%s\n' "http:${PORT}" "${tailscale_host}:${PORT}" "$expected_proxy" > "$TAILSCALE_HANDLER_FILE"
-    if tailscale serve --bg --http="$PORT" --set-path=/ "$PORT" >"$out" 2>&1; then
+    if tailscale serve --yes --bg --http="$PORT" --set-path=/ "$PORT" >"$out" 2>&1; then
       echo "tailscale serve (http) → tailnet :${PORT} -> 127.0.0.1:${PORT}"
     else
       rm -f "$TAILSCALE_HANDLER_FILE"
@@ -815,7 +828,7 @@ cmd_serve() {
   else
     ensure_tailscale_root_available 443 https "$expected_proxy" || return 1
     printf '%s|%s|%s\n' "https:443" "${tailscale_host}:443" "$expected_proxy" > "$TAILSCALE_HANDLER_FILE"
-    if tailscale serve --bg --set-path=/ "$PORT" >"$out" 2>&1; then
+    if tailscale serve --yes --bg --set-path=/ "$PORT" >"$out" 2>&1; then
       echo "tailscale serve (https) → tailnet :443 -> 127.0.0.1:${PORT}"
     else
       rm -f "$TAILSCALE_HANDLER_FILE"

--- a/scripts/collie-ctl.test.ps1
+++ b/scripts/collie-ctl.test.ps1
@@ -1,0 +1,260 @@
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+function Assert-Equal($Actual, $Expected, [string]$Message) {
+  if ($Actual -ne $Expected) { throw "$Message - expected '$Expected', got '$Actual'" }
+}
+
+function Assert-Contains([string]$Actual, [string]$Expected, [string]$Message) {
+  if (-not $Actual.Contains($Expected)) { throw "$Message - '$Expected' not found in '$Actual'" }
+}
+
+$temp = Join-Path ([IO.Path]::GetTempPath()) "collie-ctl-$([guid]::NewGuid().ToString('N'))"
+$savedConfigDir = $env:HERDR_PLUGIN_CONFIG_DIR
+$savedTaskName = $env:COLLIE_TASK_NAME
+$savedPort = $env:COLLIE_PORT
+$savedSocketPath = $env:HERDR_SOCKET_PATH
+$savedTaskRunLevel = $env:COLLIE_TASK_RUN_LEVEL
+$originalPluginRoot = $null
+
+try {
+  New-Item -ItemType Directory -Path $temp | Out-Null
+  @'
+COLLIE_PORT=9123
+COLLIE_HOST="127.0.0.1"
+'@ | Set-Content -LiteralPath (Join-Path $temp ".env") -Encoding Ascii
+  $env:HERDR_PLUGIN_CONFIG_DIR = $temp
+  $env:COLLIE_TASK_NAME = "herdr.collie-test"
+  Remove-Item Env:COLLIE_PORT -ErrorAction SilentlyContinue
+  Remove-Item Env:COLLIE_TASK_RUN_LEVEL -ErrorAction SilentlyContinue
+  $env:HERDR_SOCKET_PATH = "\\.\pipe\collie-test"
+
+  . (Join-Path $PSScriptRoot "collie-ctl.ps1")
+  Assert-Equal $script:Port 9123 ".env port"
+  Assert-Equal $env:COLLIE_HOST "127.0.0.1" ".env quoted value"
+
+  $originalPluginRoot = $script:PluginRoot
+  $script:PluginRoot = Join-Path $temp "launcher plugin & space"
+  $launcherScripts = New-Item -ItemType Directory -Path (Join-Path $script:PluginRoot "scripts")
+  'param([string]$Command); if ($Command -eq "fail") { exit 23 }; "action:$Command"' |
+    Set-Content -LiteralPath (Join-Path $launcherScripts "collie-ctl.ps1") -Encoding Ascii
+  Write-CollieActionLauncher
+  $launcher = Join-Path $script:PluginRoot "build\collie-action-v1.exe"
+  Assert-Equal ((& "\\?\$launcher" version | Out-String).Trim()) "action:version" "canonical action launcher execution"
+  & $launcher fail *> $null
+  Assert-Equal $LASTEXITCODE 23 "action launcher exit code"
+  $launcherBody = Get-Content -LiteralPath $launcher -Raw
+  Write-CollieActionLauncher
+  Assert-Equal (Get-Content -LiteralPath $launcher -Raw) $launcherBody "immutable action launcher"
+
+  $script:PluginRoot = Join-Path $temp "lazy-plugin"
+  New-Item -ItemType Directory -Path (Join-Path $script:PluginRoot "web") -Force | Out-Null
+  $script:lazyApplicationBuilds = 0
+  function Resolve-Bun { "C:\fake\bun.exe" }
+  function Invoke-CollieApplicationBuild([string]$Bun) { $script:lazyApplicationBuilds++ }
+  Ensure-CollieBuild | Out-Null
+  Assert-Equal $script:lazyApplicationBuilds 1 "lazy start builds the application"
+  $script:PluginRoot = $originalPluginRoot
+
+  "crashed stdout" | Set-Content -LiteralPath $script:LogFile
+  "crashed stderr" | Set-Content -LiteralPath $script:ErrorLogFile
+  Preserve-CollieCrashLogs
+  Assert-Contains (Get-Content -LiteralPath $script:PreviousLogFile -Raw) "crashed stdout" "crash stdout preservation"
+  Assert-Contains (Get-Content -LiteralPath $script:PreviousErrorLogFile -Raw) "crashed stderr" "crash stderr preservation"
+
+  $swapRoot = Join-Path $temp "web"
+  New-Item -ItemType Directory -Path (Join-Path $swapRoot "dist"), (Join-Path $swapRoot "dist-staging") | Out-Null
+  "live" | Set-Content -LiteralPath (Join-Path $swapRoot "dist\index.html")
+  "staged" | Set-Content -LiteralPath (Join-Path $swapRoot "dist-staging\index.html")
+  function Move-Item {
+    param([string]$LiteralPath, [string]$Destination, [switch]$Force)
+    if ((Split-Path -Leaf $LiteralPath) -eq "dist-staging") { throw "simulated staged move failure" }
+    Microsoft.PowerShell.Management\Move-Item @PSBoundParameters
+  }
+  try {
+    Install-CollieWebDist $swapRoot
+    throw "failed web swap was accepted"
+  } catch {
+    Assert-Contains $_.Exception.Message "simulated staged move failure" "web swap failure"
+  }
+  Remove-Item Function:\Move-Item
+  Assert-Contains (Get-Content -LiteralPath (Join-Path $swapRoot "dist\index.html") -Raw) "live" "failed web swap preserves live dist"
+
+  "not valid" | Set-Content -LiteralPath (Join-Path $temp "invalid.env") -Encoding Ascii
+  try {
+    Import-CollieEnv (Join-Path $temp "invalid.env")
+    throw "invalid .env line was accepted"
+  } catch {
+    Assert-Contains $_.Exception.Message "invalid .env line" ".env validation"
+  }
+
+  "$PID|0" | Set-Content -LiteralPath $script:PidFile -NoNewline
+  Stop-RecordedCollieProcesses
+  Assert-Equal (Test-Path -LiteralPath $script:PidFile) $false "stale launcher PID record is cleared"
+
+  $script:registered = $null
+  $script:enabled = @()
+  $script:disabled = @()
+  $script:started = @()
+  $script:stopped = @()
+  function New-ScheduledTaskAction($Execute, $Argument, $WorkingDirectory) {
+    [pscustomobject]@{ Execute = $Execute; Argument = $Argument; WorkingDirectory = $WorkingDirectory }
+  }
+  function New-ScheduledTaskTrigger([switch]$AtLogOn, $User) {
+    [pscustomobject]@{ AtLogOn = $AtLogOn; User = $User }
+  }
+  function New-ScheduledTaskPrincipal($UserId, $LogonType, $RunLevel) {
+    [pscustomobject]@{ UserId = $UserId; LogonType = $LogonType; RunLevel = $RunLevel }
+  }
+  function New-ScheduledTaskSettingsSet {
+    param(
+      [switch]$AllowStartIfOnBatteries,
+      [switch]$DontStopIfGoingOnBatteries,
+      $ExecutionTimeLimit,
+      $MultipleInstances,
+      $RestartCount,
+      $RestartInterval,
+      [switch]$StartWhenAvailable
+    )
+    [pscustomobject]@{
+      ExecutionTimeLimit = $ExecutionTimeLimit
+      RestartCount = $RestartCount
+      RestartInterval = $RestartInterval
+    }
+  }
+  function Register-ScheduledTask {
+    param($TaskName, $Action, $Trigger, $Principal, $Settings, $Description, [switch]$Force)
+    $script:registered = [pscustomobject]@{
+      TaskName = $TaskName
+      Action = $Action
+      Trigger = $Trigger
+      Principal = $Principal
+      Settings = $Settings
+    }
+  }
+  function Enable-ScheduledTask($TaskName) { $script:enabled += $TaskName }
+  function Get-ScheduledTask($TaskName) { [pscustomobject]@{ TaskName = $TaskName; State = "Ready" } }
+  function Disable-ScheduledTask($TaskName) { $script:disabled += $TaskName }
+  function Start-ScheduledTask($TaskName) { $script:started += $TaskName }
+  function Stop-ScheduledTask($TaskName) { $script:stopped += $TaskName }
+  function Unregister-ScheduledTask($TaskName, [switch]$Confirm) { $script:unregistered += $TaskName }
+
+  Register-CollieTask | Out-Null
+  Assert-Equal $script:registered.TaskName "herdr.collie-test" "task ownership"
+  Assert-Contains $script:registered.Action.Argument "_exec-bridge" "task action"
+  Assert-Contains $script:registered.Action.Argument $temp "task preserves resolved config dir"
+  Assert-Contains $script:registered.Action.Argument "\\.\pipe\collie-test" "task preserves resolved socket path"
+  Assert-Equal $script:registered.Trigger.User ([Security.Principal.WindowsIdentity]::GetCurrent().Name) "logon trigger user"
+  Assert-Equal $script:registered.Principal.RunLevel "Limited" "task privilege"
+  Assert-Equal $script:registered.Settings.ExecutionTimeLimit ([TimeSpan]::Zero) "task execution limit"
+  Assert-Equal $script:registered.Settings.RestartCount 999 "task restart policy"
+
+  $env:COLLIE_TASK_RUN_LEVEL = "highest"
+  function Test-Administrator { $true }
+  Register-CollieTask | Out-Null
+  Assert-Equal $script:registered.Principal.RunLevel "Highest" "explicit elevated task"
+  function Test-Administrator { $false }
+  try {
+    Register-CollieTask | Out-Null
+    throw "non-Administrator registered an elevated task"
+  } catch {
+    Assert-Contains $_.Exception.Message "requires Administrator" "elevated task privilege gate"
+  }
+  Remove-Item Env:COLLIE_TASK_RUN_LEVEL
+
+  Stop-Collie | Out-Null
+  Assert-Equal ($script:disabled -join ",") "herdr.collie-test" "stop disables only Collie's task"
+  Assert-Equal ($script:stopped -join ",") "herdr.collie-test" "stop stops only Collie's task"
+
+  $script:unregistered = @()
+  $uninstallOutput = Uninstall-Collie | Out-String
+  Assert-Equal ($script:unregistered -join ",") "herdr.collie-test" "uninstall always removes Collie's task"
+  Assert-Contains $uninstallOutput "operator-managed" "uninstall leaves Tailscale Serve unchanged"
+
+  $fakeTailscale = Join-Path $temp "tailscale.cmd"
+  "@echo off`r`nif `%1`==serve if `%2`==status echo https://host.example.ts.net`r`n" |
+    Set-Content -LiteralPath $fakeTailscale -Encoding Ascii
+  function Resolve-Tailscale { $fakeTailscale }
+  function Test-HerdrReady { $true }
+  function Get-CollieUrl { "https://host.example.ts.net" }
+  $statusOutput = Show-CollieStatus | Out-String
+  Assert-Contains $statusOutput "serve config:" "status includes Tailscale configuration"
+  Assert-Contains $statusOutput "https://host.example.ts.net" "status includes Tailscale mapping"
+
+  $script:disabled = @()
+  function Ensure-CollieBuild {}
+  function Test-HerdrReady([int]$Attempts = 1) { $false }
+  function Show-CollieStatus {}
+  $startOutput = Start-Collie 3>&1 | Out-String
+  Assert-Contains $startOutput "temporarily unavailable" "temporary Herdr outage warning"
+  Assert-Equal ($script:started -join ",") "herdr.collie-test" "start launches Collie's task"
+  Assert-Equal ($script:disabled -join ",") "" "temporary Herdr outage keeps Collie's task enabled"
+
+  function Invoke-TestGit([string]$Repo, [string[]]$GitArgs) {
+    & git -c user.name=collie-test -c user.email=test@example.invalid -C $Repo @GitArgs | Out-Null
+    Assert-LastExit "test git $($GitArgs -join ' ')"
+  }
+
+  $origin = Join-Path $temp "origin"
+  New-Item -ItemType Directory -Path $origin | Out-Null
+  Invoke-TestGit $origin @("init", "-q", "-b", "main")
+  "v1" | Set-Content -LiteralPath (Join-Path $origin "VERSION") -NoNewline
+  "lock-v1" | Set-Content -LiteralPath (Join-Path $origin "bun.lock") -NoNewline
+  Invoke-TestGit $origin @("add", "-A")
+  Invoke-TestGit $origin @("commit", "-qm", "first")
+  $originUri = ([Uri]::new($origin)).AbsoluteUri
+
+  $managed = Join-Path $temp "managed"
+  New-Item -ItemType Directory -Path $managed | Out-Null
+  Invoke-TestGit $managed @("init", "-q")
+  Invoke-TestGit $managed @("remote", "add", "origin", $originUri)
+  Invoke-TestGit $managed @("fetch", "-q", "--depth", "1", "origin", "HEAD")
+  Invoke-TestGit $managed @("checkout", "-q", "--detach", "FETCH_HEAD")
+  "v2" | Set-Content -LiteralPath (Join-Path $origin "VERSION") -NoNewline
+  Invoke-TestGit $origin @("add", "-A")
+  Invoke-TestGit $origin @("commit", "-qm", "second")
+  "rewritten-by-build" | Set-Content -LiteralPath (Join-Path $managed "bun.lock") -NoNewline
+
+  $script:PluginRoot = $managed
+  Assert-Equal (Test-CollieManagedCheckout) $true "managed checkout detection"
+  $managedOutput = Update-CollieCheckout | Out-String
+  Assert-Contains $managedOutput "Herdr-managed checkout" "managed update path"
+  Assert-Equal (Get-Content -Raw -LiteralPath (Join-Path $managed "VERSION")) "v2" "managed checkout update"
+  Assert-Equal (Get-Content -Raw -LiteralPath (Join-Path $managed "bun.lock")) "lock-v1" "managed update discards build dirt"
+  Assert-Equal ((& git -C $managed rev-parse --is-shallow-repository | Out-String).Trim()) "true" "managed checkout stays shallow"
+  Assert-Equal (Test-CollieManagedCheckout) $true "managed checkout stays detached"
+  $registryOutput = Refresh-CollieRegistry | Out-String
+  Assert-Contains $registryOutput "registry left alone" "managed update does not re-link"
+
+  $linked = Join-Path $temp "linked"
+  & git clone -q $originUri $linked
+  Assert-LastExit "test git clone"
+  Invoke-TestGit $origin @("commit", "-q", "--allow-empty", "-m", "third")
+  $script:PluginRoot = $linked
+  Assert-Equal (Test-CollieManagedCheckout) $false "linked checkout detection"
+  $linkedOutput = Update-CollieCheckout | Out-String
+  Assert-Contains $linkedOutput "git pull --ff-only" "linked update path"
+  Assert-Equal ((& git -C $linked rev-parse HEAD | Out-String).Trim()) ((& git -C $origin rev-parse HEAD | Out-String).Trim()) "linked checkout update"
+  Assert-Equal ((& git -C $linked symbolic-ref --short HEAD | Out-String).Trim()) "main" "linked checkout stays on branch"
+
+  $plain = Join-Path $temp "plain"
+  New-Item -ItemType Directory -Path $plain | Out-Null
+  $script:PluginRoot = $plain
+  try {
+    Update-CollieCheckout | Out-Null
+    throw "a non-git checkout was accepted"
+  } catch {
+    Assert-Contains $_.Exception.Message "herdr plugin install AltanS/collie --yes" "non-git update recovery"
+  }
+  $script:PluginRoot = $originalPluginRoot
+
+  Write-Output "OK Windows lifecycle tests"
+} finally {
+  if ($originalPluginRoot) { $script:PluginRoot = $originalPluginRoot }
+  if (Test-Path -LiteralPath $temp) { Remove-Item -LiteralPath $temp -Recurse -Force }
+  [Environment]::SetEnvironmentVariable("HERDR_PLUGIN_CONFIG_DIR", $savedConfigDir, "Process")
+  [Environment]::SetEnvironmentVariable("COLLIE_TASK_NAME", $savedTaskName, "Process")
+  [Environment]::SetEnvironmentVariable("COLLIE_PORT", $savedPort, "Process")
+  [Environment]::SetEnvironmentVariable("HERDR_SOCKET_PATH", $savedSocketPath, "Process")
+  [Environment]::SetEnvironmentVariable("COLLIE_TASK_RUN_LEVEL", $savedTaskRunLevel, "Process")
+}

--- a/scripts/collie-ctl.test.sh
+++ b/scripts/collie-ctl.test.sh
@@ -74,7 +74,7 @@ if [ "\${1:-}" = serve ] && [ "\${2:-}" = status ] && [ "\${3:-}" = --json ]; th
   cat "$TS_STATUS"
   exit 0
 fi
-if [ "\${1:-}" = serve ] && [[ " \$* " == *" --bg "* ]]; then
+if [ "\${1:-}" = serve ] && [[ " \$* " == *" --yes "* ]] && [[ " \$* " == *" --bg "* ]]; then
   target="\${!#}"
   listener=443
   protocol=HTTPS
@@ -648,6 +648,30 @@ EOF
   assert_contains "$(cat "${CASE_DIR}/build.out")" 'bun not found'
 }
 
+test_action_launcher_generation() {
+  setup_case action-launcher
+  local plugin_root="${CASE_DIR}/plugin & space" harness="${CASE_DIR}/launcher.sh"
+  mkdir -p "$plugin_root"
+  cat > "$harness" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+export HOME="$HOME_DIR"
+export HERDR_PLUGIN_CONFIG_DIR="$CONFIG_DIR"
+export PATH="$BIN_DIR:$BASE_PATH"
+source "$CTL"
+PLUGIN_ROOT="$plugin_root"
+write_action_launcher
+EOF
+  bash "$harness"
+  local launcher="${plugin_root}/build/collie-action-v1.exe"
+  [ -x "$launcher" ] || fail "Unix action launcher is not executable"
+  bash -n "$launcher"
+  assert_contains "$(cat "$launcher")" 'collie-ctl.sh'
+  local before; before="$(cat "$launcher")"
+  bash "$harness"
+  assert_eq "$(cat "$launcher")" "$before"
+}
+
 # ── update: the checkout can be in either of the two shapes Collie is installed in ───────────────
 #
 # `herdr plugin install` does NOT clone: it runs `git init` + `git fetch --depth 1 origin HEAD` +
@@ -803,5 +827,6 @@ test_update_advances_a_herdr_managed_checkout
 test_update_fast_forwards_a_linked_clone
 test_update_reports_a_non_git_checkout
 test_registry_refresh_skips_a_managed_checkout
+test_action_launcher_generation
 
 echo "collie-ctl lifecycle tests: passed"

--- a/scripts/git-hooks/pre-push
+++ b/scripts/git-hooks/pre-push
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# Pre-push guard: typecheck both sides, then run the test suites (backend Bun + web Vitest) before
-# anything leaves the machine. Install with: scripts/install-hooks.sh (sets core.hooksPath).
+# Pre-push guard: typecheck both sides, then run the platform lifecycle and web suites. The backend
+# suite also runs on POSIX; its path and file-mode assertions are not portable to native Windows.
 # Override once: SKIP_TYPECHECK=1 git push (skip typecheck) · SKIP_TESTS=1 git push (skip tests).
 set -euo pipefail
 
@@ -34,22 +34,27 @@ if [ "${SKIP_TESTS:-}" = "1" ]; then
   exit 0
 fi
 
-echo "pre-push: running backend test suite (bun test ./bridge)…" >&2
-if ! (cd "$ROOT" && bun test ./bridge); then
-  cat >&2 <<'EOF'
+if [ "${OS:-}" = "Windows_NT" ]; then
+  echo "pre-push: running Windows lifecycle suite…" >&2
+  (cd "$ROOT" && bun run test:ctl)
+else
+  echo "pre-push: running backend test suite (bun test ./bridge)…" >&2
+  if ! (cd "$ROOT" && bun test ./bridge); then
+    cat >&2 <<'EOF'
 ✗ pre-push: backend tests failed — push aborted.
   Fix the failing tests, or override once with: SKIP_TESTS=1 git push
 EOF
-  exit 1
-fi
+    exit 1
+  fi
 
-echo "pre-push: running control-script lifecycle suite (collie-ctl.test.sh)…" >&2
-if ! (cd "$ROOT" && bash scripts/collie-ctl.test.sh); then
-  cat >&2 <<'EOF'
+  echo "pre-push: running platform control-script lifecycle suite…" >&2
+  if ! (cd "$ROOT" && bun run test:ctl); then
+    cat >&2 <<'EOF'
 ✗ pre-push: collie-ctl lifecycle tests failed — push aborted.
   Fix the failing tests, or override once with: SKIP_TESTS=1 git push
 EOF
-  exit 1
+    exit 1
+  fi
 fi
 
 echo "pre-push: running web test suite (vitest)…" >&2

--- a/scripts/test-ctl.ts
+++ b/scripts/test-ctl.ts
@@ -1,0 +1,9 @@
+import { join } from "node:path";
+
+const script =
+  process.platform === "win32"
+    ? [join(process.env.SystemRoot ?? "C:\\Windows", "System32", "WindowsPowerShell", "v1.0", "powershell.exe"), "-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-File", join(import.meta.dir, "collie-ctl.test.ps1")]
+    : ["bash", join(import.meta.dir, "collie-ctl.test.sh")];
+
+const child = Bun.spawn(script, { stdin: "inherit", stdout: "inherit", stderr: "inherit" });
+process.exit(await child.exited);

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "collie-web",
-  "version": "0.25.0",
+  "version": "0.26.0",
   "private": true,
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Completes the native launcher gap left after #27 added Windows named-pipe transport. Windows can now install and run Collie through the same Herdr actions as Linux and macOS.

## What changes

- Adds a PowerShell lifecycle controller backed by Task Scheduler.
- Generates one immutable platform-native action launcher used by every host.
- Updates both Herdr-managed detached installs and linked clones without changing their install type.
- Keeps Tailscale Serve operator-managed on Windows; Collie only reports the existing ingress.
- Keeps full application CI on Linux and adds Windows lifecycle coverage on standard GitHub-hosted runners.

## Defaults

- The Windows task runs with limited privileges by default.
- If Herdr intentionally runs as Administrator, COLLIE_TASK_RUN_LEVEL=highest is an explicit opt-in; phone actions then inherit Administrator power.
- The bridge remains bound to loopback behind Tailscale Serve or another operator-owned ingress.
- Linux and macOS keep their existing supervisor and managed-Serve behavior.

## Verification

- Linux bridge suite: 534 passed; POSIX lifecycle passed before the final launcher correction, with its changed launcher generation rechecked under WSL.
- Windows lifecycle suite: passed, including canonical \\?\ paths and both task run levels.
- Web suite: 1,603 passed.
- Root and web typechecks: passed.
- Herdr invoked version and restart successfully from the linked canonical path.
- Windows production build and live HTTPS bridge: 0.26.0+8192f01, connected with 20 agents.
- Review Suite fast: green (rvw_6f575a57).

## Notes

This really isn't a sort of "merge as is" more of a reference how I got this to work quite nicely on Windows.

I'm still minimizing it but figured maybe it helps serve as reference.

Edit: Did a fair bit of minimizing, can now be considered reasonable to merge.