### PR TITLE
feat(harness): add Pi read-only adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to Collie are recorded here. The format follows
 `version` in `herdr-plugin.toml`, `package.json`, and `web/package.json` (enforced by
 `scripts/check-version.sh`). See [`CLAUDE.md`](./CLAUDE.md) → *Versioning* for the bump policy.
 
+## [0.26.0] - 2026-08-08
+
+### Added
+
+- **Pi gets a read-only adapter** — its verified stock inline editor yields a draft while unrecognised terminal state stays raw, and reply submission requires a changed observed draft (2efea2f)
+
 ## [0.25.0] - 2026-08-07
 
 ### Added

--- a/HARNESS_CONTRIBUTING.md
+++ b/HARNESS_CONTRIBUTING.md
@@ -2,8 +2,8 @@
 
 Collie up-levels an agent's terminal dialogs (permission prompts, AskUserQuestion menus, plan
 approvals, …) into native phone buttons. The per-agent knowledge that makes this safe lives in a
-**harness adapter**. Claude Code is the one verified adapter today; this is how you add another
-(codex, pi, opencode, …).
+**harness adapter**. Claude Code and Pi are verified adapters today; this is how you add another
+(codex, opencode, …).
 
 Read first: [`ARCHITECTURE.md`](./ARCHITECTURE.md) (the interaction loop + security model),
 [`HERDR_API.md`](./HERDR_API.md) (the verified socket + `pane.send_keys` key grammar), and
@@ -30,7 +30,7 @@ Detectors are developed and gated entirely against **byte-faithful pane captures
 from screenshots. The loop:
 
 1. In a **sandbox pane** (a scratch agent, never a real work session), drive the agent into the dialog
-   state you want to lift.
+   or chrome state you want to project.
 2. Capture it byte-for-byte:
    ```sh
    scripts/capture-fixture.sh <paneId> <name>   # paneIds: GET /api/snapshot
@@ -51,13 +51,13 @@ An adapter earns capability incrementally. Ship a lower tier first; each is inde
 - **Tier 0 — raw mirror.** Every agent gets this for free: the colored terminal mirror + slash palette
   + special-keys pad. No adapter needed. It already works.
 - **Tier 1 — read-only lift.** Chrome/status/draft extraction (`extractStatusLines`,
-  `extractInputDraft`) plus **detection of a NEW, not-yet-wired block kind** — recognised and drawn,
-  but with no keystroke recipe behind it, so taps send **no keystrokes**. Mergeable **from fixtures
-  alone**: a mis-parse only costs cosmetics because there is no send path to fire into a terminal.
-  **Caveat:** this holds only for a brand-new kind. If your adapter emits an EXISTING interactive kind
-  (`prompt-select` / `wizard` / `multi-select`), its keystroke recipe is already live, so those taps
-  go hot the moment your detector matches — that is automatically **Tier 2** and must clear the full
-  Tier-2 bar below (corpus, notes, conformance, live-verification), not the read-only one.
+  `extractInputDraft`) plus either **detection of a NEW, not-yet-wired block kind** or a conservative
+  raw-only projection that omits verified harness chrome. Neither sends keystrokes. Mergeable **from
+  fixtures alone**: a mis-parse only costs cosmetics because there is no send path to fire into a
+  terminal. **Caveat:** if your adapter emits an EXISTING interactive kind (`prompt-select` /
+  `wizard` / `multi-select`), its keystroke recipe is already live, so those taps go hot the moment
+  your detector matches — that is automatically **Tier 2** and must clear the full Tier-2 bar below
+  (corpus, notes, conformance, live-verification), not the read-only one.
 - **Tier 2 — interactive.** Wiring taps to keystrokes (the buttons go hot). This is the bar that types
   into a real shell, so it requires **all** of:
   - a **dated fixture corpus** covering the dialog's states,
@@ -66,12 +66,21 @@ An adapter earns capability incrementally. Ship a lower tier first; each is inde
   - a green **`describeAdapterConformance`** run (the CI gate, below), and
   - **maintainer live-verification against a real pane** before the send path is enabled.
 
-### The fail-closed contract (non-negotiable)
+### The conservative detection contract (non-negotiable)
 
 **A detector MUST return `null` on anything it does not confidently recognise.** A partial lift is a
 bug, not a nicety — it types a keystroke into a live terminal. When in doubt, fall back to the raw
 mirror; the user can always drive Tier 0 by hand. Never up-level a dialog you can't fully model (e.g.
 a menu numbered past 9, whose option would need the unsendable key `"10"` — bail to raw instead).
+
+### Rendered-pane limit
+
+A pane buffer cannot reveal which Pi child component owns focus or whether a shape-preserving custom
+editor preserves stock key semantics. Do not claim that a row-shape detector rejects every overlay or
+custom editor, and do not implement `composerReady` without independent focus/semantics evidence.
+Baseline reply verification prevents an unchanged visible draft from authorising Enter, but cannot
+prevent text or pre-clear keys reaching the focused component, prove custom Enter semantics, or
+attribute a changed draft to Collie rather than concurrent activity.
 
 ## Menus (generic modals)
 

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,6 +1,6 @@
 id = "herdr.collie"
 name = "Collie"
-version = "0.25.0"
+version = "0.26.0"
 min_herdr_version = "0.7.0"
 description = "Mobile web UI to monitor and reply to your agent herd, served over Tailscale"
 platforms = ["linux", "macos"]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "collie",
-  "version": "0.25.0",
+  "version": "0.26.0",
   "private": true,
   "license": "MIT",
   "description": "Collie — a mobile web UI to monitor and reply to your Herdr agent herd over Tailscale",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "collie-web",
-  "version": "0.25.0",
+  "version": "0.26.0",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/web/src/components/agent-chat.test.tsx
+++ b/web/src/components/agent-chat.test.tsx
@@ -330,10 +330,9 @@ describe("AgentChat — prompt-select race guard wiring (frozen {text, revision}
   });
 });
 
-// The block grammars are provably scoped to Claude Code (spec T8): a non-Claude pane gets the plain
-// raw mirror — no prompt-select buttons, no chrome stripping, no re-surfaced status strip — because
-// running Claude-tuned matchers on an unverified TUI could mis-lift or mis-strip its output.
-describe("AgentChat — block-grammar scoping (Claude-only)", () => {
+// Harness adapters stay scoped to their verified TUI shape: unverified panes get the raw mirror,
+// while Pi gets only its conservative standard-editor projection (no Claude dialogs or status strip).
+describe("AgentChat — block-grammar scoping", () => {
   // A codex agent sharing the Claude fixture's ids, so only the agent kind differs from the default.
   const codexAgent = { ...fixtureAgents[0]!, agent: "codex" };
 
@@ -367,6 +366,24 @@ describe("AgentChat — block-grammar scoping (Claude-only)", () => {
     expect(status.closest("pre")).not.toBeNull();
     // …and the input box itself is preserved verbatim (no chrome stripping for a non-Claude agent).
     expect(screen.getByText(/❯/)).toBeInTheDocument();
+  });
+
+  it("omits Pi's confident editor without extracting a status strip or hiding its footer", () => {
+    const piAgent = { ...fixtureAgents[0]!, agent: "pi" };
+    const piMeter = "0.0%/0 (auto)";
+    const piModel = "no-model";
+    const piText = [
+      `\x1b[38;2;80;80;80m${RULE}\x1b[0m`,
+      "draft\x1b[7m \x1b[0m",
+      `\x1b[38;2;80;80;80m${RULE}\x1b[0m`,
+      "\x1b[38;2;102;102;102m/sandbox/cwd\x1b[0m",
+      `\x1b[38;2;102;102;102m${piMeter}${" ".repeat(RULE.length - piMeter.length - piModel.length)}${piModel}\x1b[0m`,
+    ].join("\n");
+    renderChat({ text: piText, agent: piAgent });
+
+    expect(screen.queryByText("draft")).not.toBeInTheDocument();
+    const footer = screen.getByText(/0\.0%\/0 \(auto\)/);
+    expect(footer.closest("pre")).not.toBeNull();
   });
 });
 

--- a/web/src/components/ansi-output.tsx
+++ b/web/src/components/ansi-output.tsx
@@ -54,8 +54,8 @@ export interface AnsiOutputProps {
   currentMatch?: number;
   /** Reports the current match count back to the parent (drives the find bar's "3/17"). */
   onMatchCount?: (count: number) => void;
-  /** The pane's agent — gates the Claude-only block grammars (prompt-select, chrome). Absent/other
-   *  agents render pure raw output. */
+  /** The pane's agent — selects its registered adapter's projection. Unknown/absent agents render
+   *  pure raw output. */
   agent?: string;
   /** Injected handler for a prompt-select tap (the race guard lives in AgentChat). Absent (or with a
    *  disabled block) means the buttons render but don't act — AnsiOutput never touches the network. */

--- a/web/src/components/composer.test.tsx
+++ b/web/src/components/composer.test.tsx
@@ -636,6 +636,25 @@ describe("Composer — terminal-draft preview", () => {
 // Enter lands), it must NOT be treated as a stranded draft — no chip, and no destructive clear-prefix
 // on the next Send. A harness lets the test flip `terminalDraft` after a send, the way the parent
 // would once the mirror echoes the in-flight text back.
+describe("Composer — opaque Pi terminal draft", () => {
+  it("shows Pi's own lowercase paste marker without offering to take it over", () => {
+    renderComposer({
+      agent: "pi",
+      terminalDraft: "[paste #2 +11 lines]",
+      rawTerminalDraft: "[paste #2 +11 lines]",
+    });
+
+    expect(screen.getByText(/draft in terminal/i)).toBeInTheDocument();
+    expect(screen.getByText("[paste #2 +11 lines]")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /take over/i })).not.toBeInTheDocument();
+  });
+});
+
+// Mitigation A for the in-flight self-race: the composer knows what it just sent, so when the SAME
+// text shows up on the terminal's "❯" line moments later (our own reply before the bridge's pending
+// Enter lands), it must NOT be treated as a stranded draft — no chip, and no destructive clear-prefix
+// on the next Send. A harness lets the test flip `terminalDraft` after a send, the way the parent
+// would once the mirror echoes the in-flight text back.
 describe("Composer — in-flight echo suppression (match-last-sent)", () => {
   function EchoHarness({ echoValue }: { echoValue: string }) {
     // The echo lands on BOTH the raw and the stabilised line at once (a persistent echo is stable).

--- a/web/src/fixtures/panes/README.md
+++ b/web/src/fixtures/panes/README.md
@@ -112,6 +112,32 @@ All sandbox-generated (a scratch pane driven through the bridge) except `claude-
 which is a real pane working on this repo. Every `blocked` fixture's menu sits at the **buffer
 tail** — the invariant T2's detector leans on.
 
+## Pi editor corpus (captured 2026-08-08, Pi 0.82.1, SANITIZED)
+
+| Fixture | State / what's in it |
+|---|---|
+| `pi--editor.txt` | Offline, resource-disabled Pi standard editor with an inverse blank cursor, its two `─` borders, and the untouched cwd/context footer. |
+| `pi--editor-draft.txt` | The same physical viewport with an unsent synthetic `review emoji: é 👩‍👧‍👦` draft before autocomplete; pins draft recovery including the rendered graphemes. |
+
+Captured from a newly-created, non-focused disposable Herdr workspace/pane (41 viewport rows) through
+`GET /api/pane/:id?lines=41`, after a temporary PATH wrapper named `pi` emitted `CSI 2J`, `CSI H`,
+and `CSI 3J` immediately before execing Pi. Pi ran with `--offline --no-session --no-tools`, all
+resource discovery disabled, isolated HOME/XDG/Pi directories, no model prompt, and no submit key.
+The created workspace and all temporary files were removed after capture. No existing pane output was
+read. The fixture contains literal SGR and CRLF bytes from that endpoint. Every identifying filesystem
+span (`/Users/...` and the disposable `/private/...` root) was deterministically replaced with an
+ASCII same-byte-width `/xxx…` span; ANSI placement, CRLFs, physical row width, row count, styles, and
+all editor-detector-relevant content are otherwise unchanged. The Pi startup warning and footer remain
+on purpose: the adapter must retain output/footer raw and omit only the confidently recognised editor.
+
+Pi projection supports only this single-row stock rendering. Trailing draft whitespace is normalised
+because the grid cannot distinguish it from padding/cursor space; internal whitespace is preserved.
+Visible wraps/scrolling, custom footer/status tails, autocomplete, and disrupted layouts remain raw.
+Away overlays and shape-preserving custom editors cannot be detected from pane bytes, so Pi does not
+claim composer readiness. Baseline reply verification prevents an unchanged draft from authorising
+Enter, but cannot stop text/pre-clear keys reaching the focused component or prove custom Enter
+semantics.
+
 ## Lessons already encoded here (don't re-learn them)
 
 - **Match on parsed text, not raw bytes**: SGR codes sit *between* glyphs (`❯` and `1.` are in

--- a/web/src/fixtures/panes/pi--editor-draft.txt
+++ b/web/src/fixtures/panes/pi--editor-draft.txt
@@ -1,0 +1,22 @@
+[0m[38;5;3mfd not found. Offline mode enabled, skipping download.[0m
+
+ [0m[1m[38;2;138;190;183mpi[0m[38;2;102;102;102m v0.82.1[0m                                                                                                                                                  
+ [0m[38;2;102;102;102mescape[0m[38;2;128;128;128m interrupt · [0m[38;2;102;102;102mctrl+c/ctrl+d[0m[38;2;128;128;128m clear/exit · [0m[38;2;102;102;102m/[0m[38;2;128;128;128m commands · [0m[38;2;102;102;102m![0m[38;2;128;128;128m bash · [0m[38;2;102;102;102mctrl+o[0m[38;2;128;128;128m more[0m                                                                             
+ [0m[38;2;102;102;102mPress ctrl+o to show full startup help and loaded resources.[0m                                                                                                
+                                                                                                                                                             
+ [0m[38;2;102;102;102mPi can explain its own features and look up its docs. Ask it how to use or extend Pi.[0m                                                                       
+
+
+ [0m[38;2;255;255;0mWarning: No models available. Use /login to log into a provider via OAuth or API key. See:                                                                  [0m
+ [0m[38;2;255;255;0m                                                                                                                                                            [0m
+ [0m[38;2;255;255;0m/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx [0m
+ [0m[38;2;255;255;0ms/@earendil-works/pi-coding-agent/docs/providers.md                                                                                                         [0m
+ [0m[38;2;255;255;0m                                                                                                                                                            [0m
+ [0m[38;2;255;255;0m/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx [0m
+ [0m[38;2;255;255;0ms/@earendil-works/pi-coding-agent/docs/models.md[0m                                                                                                            
+
+[0m[38;2;80;80;80m─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────[0m
+review emoji: é 👩‍👧‍👦[0m[7m [0m                                                                                                                                          
+[0m[38;2;80;80;80m─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────[0m
+[0m[38;2;102;102;102m/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/cwd[0m
+[0m[38;2;102;102;102m0.0%/0 (auto)                                                                                                                                         unknown[0m

--- a/web/src/fixtures/panes/pi--editor.txt
+++ b/web/src/fixtures/panes/pi--editor.txt
@@ -1,0 +1,22 @@
+[0m[38;5;3mfd not found. Offline mode enabled, skipping download.[0m
+
+ [0m[1m[38;2;138;190;183mpi[0m[38;2;102;102;102m v0.82.1[0m                                                                                                                                                  
+ [0m[38;2;102;102;102mescape[0m[38;2;128;128;128m interrupt · [0m[38;2;102;102;102mctrl+c/ctrl+d[0m[38;2;128;128;128m clear/exit · [0m[38;2;102;102;102m/[0m[38;2;128;128;128m commands · [0m[38;2;102;102;102m![0m[38;2;128;128;128m bash · [0m[38;2;102;102;102mctrl+o[0m[38;2;128;128;128m more[0m                                                                             
+ [0m[38;2;102;102;102mPress ctrl+o to show full startup help and loaded resources.[0m                                                                                                
+                                                                                                                                                             
+ [0m[38;2;102;102;102mPi can explain its own features and look up its docs. Ask it how to use or extend Pi.[0m                                                                       
+
+
+ [0m[38;2;255;255;0mWarning: No models available. Use /login to log into a provider via OAuth or API key. See:                                                                  [0m
+ [0m[38;2;255;255;0m                                                                                                                                                            [0m
+ [0m[38;2;255;255;0m/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx [0m
+ [0m[38;2;255;255;0ms/@earendil-works/pi-coding-agent/docs/providers.md                                                                                                         [0m
+ [0m[38;2;255;255;0m                                                                                                                                                            [0m
+ [0m[38;2;255;255;0m/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx [0m
+ [0m[38;2;255;255;0ms/@earendil-works/pi-coding-agent/docs/models.md[0m                                                                                                            
+
+[0m[38;2;80;80;80m─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────[0m
+[0m[7m [0m                                                                                                                                                            
+[0m[38;2;80;80;80m─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────[0m
+[0m[38;2;102;102;102m/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/cwd[0m
+[0m[38;2;102;102;102m0.0%/0 (auto)                                                                                                                                         unknown[0m

--- a/web/src/lib/ansi.test.ts
+++ b/web/src/lib/ansi.test.ts
@@ -106,12 +106,14 @@ describe("parseAnsi — SGR colour & weight", () => {
     expect(parseAnsi(`${ESC}[38;2;10;20;30mx`)[0]!.fg).toBe("rgb(10,20,30)");
   });
 
-  it("swaps fg/bg for inverse video (7m), with sensible fallbacks", () => {
-    const segs = parseAnsi(`${ESC}[7mx`);
+  it("swaps fg/bg for inverse video (7m), while retaining the raw inverse bit", () => {
+    const segs = parseAnsi(`${ESC}[7mx${ESC}[27my`);
     // Literal dark-space values, not tokens — one spelling throughout the mirror (.adr/0002 rule 2).
     // Same pixels either way; these are --background/--foreground's dark halves.
     expect(segs[0]!.fg).toBe("#0a0a0a");
     expect(segs[0]!.bg).toBe("#fafafa");
+    expect(segs[0]!.inverse).toBe(true);
+    expect(segs[1]!.inverse).toBe(false);
   });
 
   it("skips OSC sequences (window title) without leaking them into the text", () => {

--- a/web/src/lib/ansi.ts
+++ b/web/src/lib/ansi.ts
@@ -16,6 +16,8 @@ export interface AnsiSegment {
   italic?: boolean;
   underline?: boolean;
   strike?: boolean;
+  /** Raw SGR 7 state, retained for harnesses that need to distinguish reverse video from a background. */
+  inverse?: boolean;
   // Pre-computed presentation — consumed by AnsiOutput to avoid per-render allocation.
   style: CSSProperties;
   /** True when the segment contains only box-drawing/rule glyphs; the renderer mutes it. */
@@ -169,6 +171,7 @@ export function parseAnsi(input: string): AnsiSegment[] {
       italic: state.italic,
       underline: state.underline,
       strike: state.strike,
+      inverse: state.inverse,
       style: buildStyle(state, fg, bg),
       muted: checkMuted(buf),
     });

--- a/web/src/lib/blocks.test.ts
+++ b/web/src/lib/blocks.test.ts
@@ -175,9 +175,9 @@ describe("buildBlocks — Claude grammars (ctx.agent === 'claude')", () => {
     expect(blocks[0]!.lines).toBe(lines); // untouched — same reference
   });
 
-  // The hasBlockGrammar gate is provably Claude-only: the SAME menu-shaped buffer that Claude lifts
-  // into a prompt-select stays a single raw block for a codex agent (above) AND for an unknown/absent
-  // agent (below) — the universal fallback. No Claude-tuned matcher ever runs on them.
+  // Claude's prompt-select grammar is adapter-scoped: the SAME menu-shaped buffer it lifts stays a
+  // single raw block for codex (above) and an unknown/absent agent (below). Other registered adapters
+  // select their own projections.
   it("leaves a menu-shaped buffer raw for an unknown/absent agent (universal fallback)", () => {
     const lines = fixtureLines("claude--select-menu.txt");
     const blocks = buildBlocks(lines, { agent: undefined });

--- a/web/src/lib/harness/conformance.test.ts
+++ b/web/src/lib/harness/conformance.test.ts
@@ -7,12 +7,12 @@ import { splitLines } from "../blocks";
 import { claudeAdapter } from "./claude";
 import { describeAdapterConformance, isValidHerdrKey } from "./conformance";
 
-// The Claude adapter is the reference implementation the conformance suite gates. The fixture
+// The Claude adapter is one registered implementation gated by the conformance suite. Its fixture
 // cohorts are derived from the byte-faithful corpus (web/src/fixtures/panes/claude--*.txt) by
 // GLOBBING it, so a newly-captured dialog is covered the moment it lands — including the multiSelect
 // captures whose block may still be wiring up (a not-yet-detecting own fixture is tolerated by the
-// suite, see conformance.ts). Foreign = [] until a second adapter exists; the harness handles the
-// empty cohort cleanly.
+// suite, see conformance.ts). This invocation has no foreign dialog-fixture cohort; the harness
+// handles an empty cohort cleanly.
 
 const PANES_DIR = join(import.meta.dirname, "..", "..", "fixtures", "panes");
 
@@ -50,7 +50,7 @@ const neutralFixtures = allClaudeFixtures.filter((f) => NEUTRAL.includes(f));
 
 describeAdapterConformance(claudeAdapter, {
   ownFixtures,
-  foreignFixtures: [], // no second adapter yet — the suite tolerates an empty foreign cohort
+  foreignFixtures: [], // no foreign dialog-fixture cohort for this invocation
   neutralFixtures,
 });
 

--- a/web/src/lib/harness/pi/editor.test.ts
+++ b/web/src/lib/harness/pi/editor.test.ts
@@ -1,0 +1,133 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { parseAnsi } from "../../ansi";
+import { lineText, splitLines } from "../../blocks";
+import { analysePiEditor, extractInputDraft, piAdapter, piBuildBlocks } from ".";
+
+const PANES_DIR = join(import.meta.dirname, "..", "..", "..", "fixtures", "panes");
+const fixtureLines = (name: string) => splitLines(parseAnsi(readFileSync(join(PANES_DIR, name), "utf8")));
+const rawText = (lines: ReturnType<typeof fixtureLines>) => lines.map(lineText).join("\n");
+
+const RULE = "─".repeat(100);
+const FOOTER = "\x1b[38;2;102;102;102m";
+const BORDER = "\x1b[38;2;80;80;80m";
+const HIGH_CONTEXT = "\x1b[38;2;255;180;0m";
+
+function meter(prefix = "", context = "0.0%/0 (auto)", highlighted = false): string {
+  const right = "no-model";
+  const left = `${prefix}${context}`;
+  const padding = " ".repeat(RULE.length - left.length - right.length);
+  const contextText = highlighted ? `${HIGH_CONTEXT}${context}\x1b[0m${FOOTER}` : context;
+  return `${FOOTER}${prefix}${contextText}${padding}${right}\x1b[0m`;
+}
+
+function standard(
+  input: string,
+  { prefix, context, highlighted, extra = [] }: { prefix?: string; context?: string; highlighted?: boolean; extra?: string[] } = {},
+) {
+  return splitLines(
+    parseAnsi(
+      [
+        ...extra,
+        `${BORDER}${RULE}\x1b[0m`,
+        input,
+        `${BORDER}${RULE}\x1b[0m`,
+        `${FOOTER}/sandbox/cwd\x1b[0m`,
+        meter(prefix, context, highlighted),
+      ].join("\n"),
+    ),
+  );
+}
+
+const replacementLine = (text: string) => splitLines(parseAnsi(text))[0]!;
+
+describe("Pi standard editor", () => {
+  it("does not claim composer readiness from rendered pane bytes", () => {
+    expect(piAdapter.composerReady).toBeUndefined();
+  });
+
+  it("omits only the captured standard editor, retaining startup output and footer raw", () => {
+    const lines = fixtureLines("pi--editor.txt");
+    const editor = analysePiEditor(lines);
+    expect(editor).toMatchObject({ draft: null });
+
+    const kept = rawText(piBuildBlocks(lines)[0]!.lines);
+    expect(kept).toContain("fd not found. Offline mode enabled");
+    expect(kept).toContain("0.0%/0 (auto)");
+    expect(kept).not.toContain("─".repeat(40));
+  });
+
+  it("recovers the real unsent draft, including its combining mark and grapheme", () => {
+    expect(extractInputDraft(fixtureLines("pi--editor-draft.txt"))).toBe("review emoji: é 👩‍👧‍👦");
+  });
+
+  it("keeps a source-real inverse grapheme and an internal cursor-on-space", () => {
+    expect(extractInputDraft(standard(`before \x1b[7m👩‍👧‍👦\x1b[0m after`))).toBe("before 👩‍👧‍👦 after");
+    expect(extractInputDraft(standard(`a\x1b[7m \x1b[0mb`))).toBe("a b");
+  });
+
+  it("accepts stock active, high-context, and unknown-context footer states", () => {
+    const active = standard("reply\x1b[7m \x1b[0m", {
+      prefix: "↑1.2k ↓300 R2.0k W1.0k CH75.0% $0.123 ",
+      context: "80.1%/128k (auto)",
+      highlighted: true,
+    });
+    const unknown = standard("reply\x1b[7m \x1b[0m", {
+      prefix: "↑1.2k ↓300 ",
+      context: "?/128k (auto)",
+    });
+
+    expect(extractInputDraft(active)).toBe("reply");
+    expect(extractInputDraft(unknown)).toBe("reply");
+  });
+
+  it("rejects ordinary backgrounds, weak or unequal rules, faux footers, and a disrupted tail", () => {
+    const ordinaryBackground = standard(`a\x1b[38;2;1;2;3;48;2;4;5;6mX\x1b[0m`);
+    const oneGlyph = standard("\x1b[7m \x1b[0m");
+    oneGlyph[0] = replacementLine(`${BORDER}─\x1b[0m`);
+    const unequal = standard("\x1b[7m \x1b[0m");
+    unequal[2] = replacementLine(`${BORDER}${"─".repeat(39)}\x1b[0m`);
+    const fauxFooter = standard("\x1b[7m \x1b[0m");
+    const fauxMeter = "0.0%/0 not-pi";
+    fauxFooter[4] = replacementLine(`${FOOTER}${fauxMeter}${" ".repeat(RULE.length - fauxMeter.length)}\x1b[0m`);
+    const tailDisruption = standard("\x1b[7m \x1b[0m").concat(replacementLine("overlay elsewhere"));
+
+    for (const lines of [ordinaryBackground, oneGlyph, unequal, fauxFooter, tailDisruption]) {
+      expect(analysePiEditor(lines)).toBeNull();
+      expect(piBuildBlocks(lines)[0]!.lines).toBe(lines);
+      expect(extractInputDraft(lines)).toBeNull();
+    }
+  });
+
+  it("keeps wraps, a second editor frame, autocomplete, and custom footer tails raw", () => {
+    const wrapped = splitLines(
+      parseAnsi(
+        [
+          `${BORDER}${RULE}\x1b[0m`,
+          "first row",
+          "\x1b[7m \x1b[0m",
+          `${BORDER}${RULE}\x1b[0m`,
+          `${FOOTER}/sandbox/cwd\x1b[0m`,
+          meter(),
+        ].join("\n"),
+      ),
+    );
+    const secondFrame = standard("\x1b[7m \x1b[0m");
+    secondFrame.unshift(...standard("\x1b[7m \x1b[0m").slice(0, 3));
+    const autocomplete = standard("\x1b[7m \x1b[0m").concat(replacementLine("autocomplete option"));
+    const customFooter = standard("\x1b[7m \x1b[0m");
+    customFooter[4] = replacementLine(`${FOOTER}custom status tail\x1b[0m`);
+
+    for (const lines of [wrapped, secondFrame, autocomplete, customFooter]) {
+      expect(analysePiEditor(lines)).toBeNull();
+      expect(piBuildBlocks(lines)[0]!.lines).toBe(lines);
+    }
+  });
+
+  it("does not filter a standalone U+2500 output row unless a full editor was analysed", () => {
+    const lines = splitLines(parseAnsi(`meaningful output\n${RULE}\nmore output`));
+    expect(rawText(piBuildBlocks(lines)[0]!.lines)).toContain(RULE);
+  });
+});

--- a/web/src/lib/harness/pi/editor.ts
+++ b/web/src/lib/harness/pi/editor.ts
@@ -1,0 +1,130 @@
+// Conservative, Pi-local analysis of the stock inline editor rendered by Pi 0.82.1.
+//
+// This recognises only a complete, single-row editor immediately above Pi's built-in two-row footer.
+// The narrow physical-tail shape deliberately leaves wrapped/scrolled editors, extension status rows,
+// autocomplete, replacement editors, and torn layouts in the raw mirror.
+
+import { lineText, type StyledLine } from "../../blocks";
+
+export interface PiEditor {
+  /** Inclusive indexes of the two editor border rows. */
+  top: number;
+  bottom: number;
+  /** The only safely reconstructable (single-row) draft, or null for an empty editor. */
+  draft: string | null;
+}
+
+const MIN_BORDER_WIDTH = 20;
+const TOKEN = String.raw`\d+(?:\.\d+)?[kM]?`;
+// The stock footer constructs these fields in this order. The model name is right-aligned after at
+// least two spaces, so it remains intentionally unconstrained (it is provider/user configuration).
+const METER = new RegExp(
+  String.raw`^(?:↑${TOKEN} )?(?:↓${TOKEN} )?(?:R${TOKEN} )?(?:W${TOKEN} )?(?:CH\d+\.\d+% )?(?:\$\d+\.\d{3}(?: \(sub\))? )?(?<context>(?:\d+\.\d+%|\?)\/${TOKEN}(?: \(auto\))?)(?: {2,}\S.*)?$`,
+  "u",
+);
+
+/** A full-width stock border is exactly repeated U+2500, never a labelled/trimmed rule. */
+function borderWidth(line: StyledLine): number | null {
+  const text = lineText(line);
+  return /^─+$/u.test(text) && text.length >= MIN_BORDER_WIDTH ? text.length : null;
+}
+
+/** Pi's footer/borders are foreground-only; backgrounds, reverse video, and emphasis are foreign. */
+function foregroundOnly(segment: StyledLine["segments"][number]): boolean {
+  return (
+    segment.fg !== undefined &&
+    segment.bg === undefined &&
+    !segment.inverse &&
+    !segment.bold &&
+    !segment.dim &&
+    !segment.italic &&
+    !segment.underline &&
+    !segment.strike
+  );
+}
+
+/** The one foreground colour used by a stock border/cwd row, or null for a mixed/foreign style. */
+function singleForeground(line: StyledLine): string | null {
+  let foreground: string | undefined;
+  for (const segment of line.segments) {
+    if (!foregroundOnly(segment)) return null;
+    if (foreground === undefined) foreground = segment.fg;
+    else if (segment.fg !== foreground) return null;
+  }
+  return foreground ?? null;
+}
+
+function graphemeCount(text: string): number | null {
+  if (typeof Intl.Segmenter !== "function") return null;
+  let count = 0;
+  for (const _ of new Intl.Segmenter(undefined, { granularity: "grapheme" }).segment(text)) count++;
+  return count;
+}
+
+/** Pi paints exactly one SGR-7 grapheme for its cursor; an ordinary explicit background is not one. */
+function cursorSegment(line: StyledLine) {
+  const inverse = line.segments.filter((segment) => segment.inverse);
+  return inverse.length === 1 && graphemeCount(inverse[0]!.text) === 1 ? inverse[0]! : null;
+}
+
+function isEditorFrame(lines: StyledLine[], top: number): boolean {
+  const topWidth = borderWidth(lines[top]!);
+  const bottomWidth = borderWidth(lines[top + 2]!);
+  if (topWidth === null || topWidth !== bottomWidth) return false;
+  const topForeground = singleForeground(lines[top]!);
+  return topForeground !== null && topForeground === singleForeground(lines[top + 2]!) && cursorSegment(lines[top + 1]!) !== null;
+}
+
+/** Require the footer's source order and permit only its one warning/error context colour change. */
+function isStockFooter(cwd: StyledLine, meter: StyledLine, width: number): boolean {
+  const cwdForeground = singleForeground(cwd);
+  if (cwdForeground === null || !/^(?:\/|~(?:\/|$))/.test(lineText(cwd))) return false;
+
+  const text = lineText(meter);
+  if (text.length !== width) return false;
+  const match = METER.exec(text);
+  if (match === null || match.groups?.context === undefined) return false;
+  const contextStart = match.index + match[0].indexOf(match.groups.context);
+  const contextEnd = contextStart + match.groups.context.length;
+
+  let differentForeground: string | undefined;
+  let offset = 0;
+  for (const segment of meter.segments) {
+    if (!foregroundOnly(segment)) return false;
+    if (segment.fg !== cwdForeground) {
+      if (differentForeground === undefined) differentForeground = segment.fg;
+      if (segment.fg !== differentForeground || offset < contextStart || offset + segment.text.length > contextEnd) {
+        return false;
+      }
+    }
+    offset += segment.text.length;
+  }
+  return true;
+}
+
+/**
+ * Analyse one fully visible standard editor. The footer must be the physical tail: there is no safe
+ * way to distinguish a custom status/overlay tail from stock Pi bytes. A rendered grid also cannot
+ * preserve trailing draft whitespace, so draft recovery intentionally uses trimEnd(); internal spaces
+ * (including the grapheme beneath the cursor) remain intact.
+ */
+export function analysePiEditor(lines: StyledLine[]): PiEditor | null {
+  if (lines.length < 5) return null;
+
+  const footerFirst = lines.length - 2;
+  const bottom = footerFirst - 1;
+  const input = bottom - 1;
+  const top = input - 1;
+  if (top < 0 || !isEditorFrame(lines, top)) return null;
+
+  const width = borderWidth(lines[top]!);
+  if (width === null || !isStockFooter(lines[footerFirst]!, lines[footerFirst + 1]!, width)) return null;
+
+  // A second complete-looking editor frame makes the layout ambiguous, even if only one is at tail.
+  let frames = 0;
+  for (let i = 0; i + 2 < lines.length; i++) if (isEditorFrame(lines, i)) frames++;
+  if (frames !== 1) return null;
+
+  const draft = lineText(lines[input]!).trimEnd();
+  return { top, bottom, draft: draft.length === 0 ? null : draft };
+}

--- a/web/src/lib/harness/pi/index.ts
+++ b/web/src/lib/harness/pi/index.ts
@@ -1,0 +1,43 @@
+// Pi's inline editor is deliberately recognised more narrowly than Claude's box: this adapter has
+// no interaction grammars, and its only safe projection is removing a fully verified standard editor
+// while leaving every other terminal row raw. The analyser is pure and fixture-grounded.
+
+import type { Block, StyledLine } from "../../blocks";
+import type { HarnessAdapter } from "../types";
+import { analysePiEditor } from "./editor";
+import { isPiPastePlaceholder } from "./paste";
+
+/** Pi's read-only pipeline: omit only the exact editor range the analyser verified. */
+export function piBuildBlocks(lines: StyledLine[]): Block[] {
+  const editor = analysePiEditor(lines);
+  if (editor === null) return [{ kind: "raw", lines }];
+
+  // The editor's two borders are the only standalone repeated U+2500 rows removed. Everything
+  // outside this analysed range — startup output, widgets, autocomplete, footer and terminal text —
+  // remains verbatim in the universal raw block.
+  return [{
+    kind: "raw",
+    lines: lines.filter((_, index) => index < editor.top || index > editor.bottom),
+  }];
+}
+
+/** A draft is safe only for the analyser's single, unwrapped editor row. */
+export function extractInputDraft(lines: StyledLine[]): string | null {
+  return analysePiEditor(lines)?.draft ?? null;
+}
+
+export const piAdapter: HarnessAdapter = {
+  agent: "pi",
+  buildBlocks: piBuildBlocks,
+  // Pi's footer stays in the raw terminal; it is not a Collie status-line projection.
+  extractStatusLines: () => [],
+  extractInputDraft,
+  // Pane bytes cannot establish Pi child focus or custom-editor Enter semantics, so this adapter
+  // intentionally omits composerReady. The generic baseline check still withholds Enter when its
+  // observed draft did not change after typing.
+  // Pi's lowercase paste marker is its own opaque display token, not user text. It is intentionally
+  // NOT send evidence: this adapter does not implement draftCarriesSend without live verification.
+  draftIsOpaque: isPiPastePlaceholder,
+};
+
+export { analysePiEditor, isPiPastePlaceholder };

--- a/web/src/lib/harness/pi/paste.test.ts
+++ b/web/src/lib/harness/pi/paste.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+
+import { isPiPastePlaceholder } from "./paste";
+
+describe("Pi paste placeholders", () => {
+  it("recognises Pi's lowercase opaque line and character markers", () => {
+    expect(isPiPastePlaceholder("[paste #2 +11 lines]")).toBe(true);
+    expect(isPiPastePlaceholder("[paste #12 1042 chars]")).toBe(true);
+  });
+
+  it("does not treat uppercase, mixed content, or ordinary drafts as opaque", () => {
+    expect(isPiPastePlaceholder("[Paste #2 +11 lines]")).toBe(false);
+    expect(isPiPastePlaceholder("[paste #2 +11 lines] tail")).toBe(false);
+    expect(isPiPastePlaceholder("review the change")).toBe(false);
+  });
+});

--- a/web/src/lib/harness/pi/paste.ts
+++ b/web/src/lib/harness/pi/paste.ts
@@ -1,0 +1,8 @@
+// Pi 0.82.1 collapses large input into lowercase markers. They are visible terminal state but not
+// user-authored text, so the draft preview must never offer to copy one into the phone composer.
+
+const PI_PASTE = /^\[paste #\d+ (?:\+\d+ lines|\d+ chars)\]$/;
+
+export function isPiPastePlaceholder(draft: string): boolean {
+  return PI_PASTE.test(draft.trim());
+}

--- a/web/src/lib/harness/registry.test.ts
+++ b/web/src/lib/harness/registry.test.ts
@@ -7,12 +7,13 @@ import { adapterFor, hasBlockGrammar } from "./registry";
 // pinning directly — this re-homes the old grammar/agents predicate test onto the registry, which
 // now derives the predicate from adapterFor().
 describe("hasBlockGrammar", () => {
-  it("is true only for Claude Code", () => {
+  it("is true for every verified adapter", () => {
     expect(hasBlockGrammar("claude")).toBe(true);
+    expect(hasBlockGrammar("pi")).toBe(true);
   });
 
-  it("is false for every non-Claude agent (unverified TUI ⇒ raw mirror)", () => {
-    for (const agent of ["codex", "opencode", "pi", "shell", "unknown"]) {
+  it("is false for unverified agents (raw mirror)", () => {
+    for (const agent of ["codex", "opencode", "shell", "unknown"]) {
       expect(hasBlockGrammar(agent)).toBe(false);
     }
   });

--- a/web/src/lib/harness/registry.ts
+++ b/web/src/lib/harness/registry.ts
@@ -7,11 +7,12 @@
 
 import type { HarnessAdapter } from "./types";
 import { claudeAdapter } from "./claude";
+import { piAdapter } from "./pi";
 
 // Built FROM the adapter list (not a hand-written literal) so a key can't silently drift from its
 // adapter's own `agent` string — the map key IS `adapter.agent`.
 const ADAPTERS: Record<string, HarnessAdapter> = Object.fromEntries(
-  [claudeAdapter].map((a) => [a.agent, a]),
+  [claudeAdapter, piAdapter].map((a) => [a.agent, a]),
 );
 
 /** The adapter for `agent`, or undefined when the agent is unknown/absent (→ raw fallback). `Object.hasOwn`

--- a/web/src/lib/harness/types.ts
+++ b/web/src/lib/harness/types.ts
@@ -29,13 +29,13 @@ export interface HarnessAdapter {
    *  known placeholder). */
   extractInputDraft(lines: StyledLine[]): string | null;
   /**
-   * Whether this agent's free-text input box is on screen right now — i.e. whether typing a reply
-   * would reach the composer at all, rather than a modal that has the keyboard.
+   * Whether this adapter has independent evidence that its stock composer owns input and retains
+   * normal Enter semantics. Rendered pane bytes alone cannot establish child focus or custom-editor
+   * identity, so an adapter that only sees terminal output MUST omit this.
    *
    * OPTIONAL, and its absence means "no idea": the reply path's pre-flight (lib/reply-action.ts)
-   * only refuses to type when an adapter answers a definite `false`. An adapter that can't tell
-   * omits it and keeps today's type-then-verify behaviour, which is still safe — the submit key is
-   * withheld either way; the pre-flight just avoids depositing the text in a menu first.
+   * only refuses to type when an adapter answers a definite `false`. It still requires a changed
+   * post-type draft before Enter, but that cannot stop text/pre-clear keys reaching another component.
    */
   composerReady?(lines: StyledLine[]): boolean;
   /**

--- a/web/src/lib/reply-action.test.ts
+++ b/web/src/lib/reply-action.test.ts
@@ -12,9 +12,21 @@ const BOX_RULE = "─".repeat(40); // clears the 20-glyph border threshold in ha
 const paneWithDraft = (draft: string) => `some output\n${BOX_RULE}\n❯ ${draft}\n${BOX_RULE}`;
 // A focused permission dialog: no input box at the tail at all, so extractInputDraft sees nothing.
 const paneWithDialog = "Do you want to proceed?\n ❯ 1. Yes\n   2. No\n\n Esc to cancel";
+const PI_RULE = "─".repeat(40);
+const paneWithPiDraft = (draft: string) => {
+  const meter = "0.0%/0 (auto)";
+  const model = "no-model";
+  return [
+    `\x1b[38;2;80;80;80m${PI_RULE}\x1b[0m`,
+    `${draft}\x1b[7m \x1b[0m`,
+    `\x1b[38;2;80;80;80m${PI_RULE}\x1b[0m`,
+    "\x1b[38;2;102;102;102m/sandbox/cwd\x1b[0m",
+    `\x1b[38;2;102;102;102m${meter}${" ".repeat(PI_RULE.length - meter.length - model.length)}${model}\x1b[0m`,
+  ].join("\n");
+};
 
 /** Record every reply POST, and let the fake pane's screen be swapped per test. */
-function harness(screen: () => string) {
+function harness(screen: () => string, onReply: (body: { text: string; submit: boolean }) => void = () => {}) {
   const calls: Array<{ text: string; submit: boolean }> = [];
   server.use(
     http.get(/\/api\/pane\/[^/]+$/, () =>
@@ -23,6 +35,7 @@ function harness(screen: () => string) {
     http.post(/\/api\/pane\/[^/]+\/reply$/, async ({ request }) => {
       const body = (await request.json()) as { text: string; submit: boolean };
       calls.push(body);
+      onReply(body);
       return HttpResponse.json({ ok: true });
     }),
   );
@@ -182,8 +195,14 @@ describe("draftCarriesSend", () => {
 });
 
 describe("sendGuardedReply", () => {
-  it("types, verifies the text on the input line, then submits", async () => {
-    const calls = harness(() => paneWithDraft("ship it please"));
+  it("types, verifies a changed input line, then submits", async () => {
+    let draft = "";
+    const calls = harness(
+      () => paneWithDraft(draft),
+      ({ text, submit }) => {
+        draft = submit ? "" : text;
+      },
+    );
 
     const out = await sendGuardedReply({
       paneId: "w1:p1",
@@ -199,6 +218,62 @@ describe("sendGuardedReply", () => {
       { text: "ship it please", submit: false },
       { text: "", submit: true },
     ]);
+  });
+
+  it("uses Pi's recognised standard editor for the same guarded reply protocol", async () => {
+    let draft = "";
+    const calls = harness(
+      () => paneWithPiDraft(draft),
+      ({ text, submit }) => {
+        draft = submit ? "" : text;
+      },
+    );
+
+    const out = await sendGuardedReply({
+      paneId: "w1:p1",
+      text: "ship it please",
+      agent: "pi",
+      ...instant,
+    });
+
+    expect(out).toEqual({ status: "sent" });
+    expect(calls).toEqual([
+      { text: "ship it please", submit: false },
+      { text: "", submit: true },
+    ]);
+  });
+
+  it("never submits an unchanged stale generic or Pi draft, even when it matches the send", async () => {
+    for (const [agent, screen] of [
+      ["claude", () => paneWithDraft("ship it please")],
+      ["pi", () => paneWithPiDraft("ship it please")],
+    ] as const) {
+      const calls = harness(screen);
+      const out = await sendGuardedReply({ paneId: "w1:p1", text: "ship it please", agent, ...instant });
+      expect(out.status).toBe("stalled");
+      expect(calls).toEqual([{ text: "ship it please", submit: false }]);
+    }
+  });
+
+  it("requires a successful baseline read even under force", async () => {
+    const calls: Array<{ text: string; submit: boolean }> = [];
+    server.use(
+      http.get(/\/api\/pane\/[^/]+$/, () => HttpResponse.error()),
+      http.post(/\/api\/pane\/[^/]+\/reply$/, async ({ request }) => {
+        calls.push((await request.json()) as { text: string; submit: boolean });
+        return HttpResponse.json({ ok: true });
+      }),
+    );
+
+    const out = await sendGuardedReply({
+      paneId: "w1:p1",
+      text: "ship it please",
+      agent: "claude",
+      force: true,
+      ...instant,
+    });
+    expect(out).toMatchObject({ status: "blocked", error: expect.stringMatching(/read.*before typing/i) });
+    expect(calls).toEqual([]);
   });
 
   // The PRE-FLIGHT (.adr/0009). The verify-after guard below already kept Enter from answering a
@@ -267,8 +342,14 @@ describe("sendGuardedReply", () => {
   // holds `[Pasted text #N +M lines]`, so the generic matcher can never see our words and the send
   // stalled forever, un-sendable, with every retry re-collapsing (.adr/0010). The adapter's
   // supplemental evidence is what closes that.
-  it("submits when the box holds a paste placeholder consistent with a long multi-line send", async () => {
-    const calls = harness(() => paneWithDraft("[Pasted text #3 +3 lines]"));
+  it("submits when a changed box holds a paste placeholder consistent with a long multi-line send", async () => {
+    let draft = "";
+    const calls = harness(
+      () => paneWithDraft(draft),
+      ({ submit }) => {
+        draft = submit ? "" : "[Pasted text #3 +3 lines]";
+      },
+    );
 
     const out = await sendGuardedReply({
       paneId: "w1:p1",
@@ -282,6 +363,18 @@ describe("sendGuardedReply", () => {
       { text: "first line\nsecond line\nthird line\nfourth line", submit: false },
       { text: "", submit: true },
     ]);
+  });
+
+  it("does not let an unchanged stale paste placeholder authorise Enter", async () => {
+    const calls = harness(() => paneWithDraft("[Pasted text #3 +3 lines]"));
+    const out = await sendGuardedReply({
+      paneId: "w1:p1",
+      text: "first line\nsecond line\nthird line\nfourth line",
+      agent: "claude",
+      ...instant,
+    });
+    expect(out.status).toBe("stalled");
+    expect(calls.some((call) => call.submit)).toBe(false);
   });
 
   it("stalls on a placeholder inconsistent with what we sent — no submit key", async () => {
@@ -337,17 +430,19 @@ describe("sendGuardedReply", () => {
   });
 
   it("reports textDelivered when the text landed but the submit key failed", async () => {
+    let draft = "";
     server.use(
       http.get(/\/api\/pane\/[^/]+$/, () =>
         HttpResponse.json({
           paneId: "w1:p1",
-          text: paneWithDraft("ship it please"),
+          text: paneWithDraft(draft),
           truncated: false,
           revision: 1,
         }),
       ),
       http.post(/\/api\/pane\/[^/]+\/reply$/, async ({ request }) => {
-        const body = (await request.json()) as { submit: boolean };
+        const body = (await request.json()) as { text: string; submit: boolean };
+        if (!body.submit) draft = body.text;
         return body.submit
           ? HttpResponse.json({ ok: false, error: "keys failed" })
           : HttpResponse.json({ ok: true });

--- a/web/src/lib/reply-action.ts
+++ b/web/src/lib/reply-action.ts
@@ -191,28 +191,27 @@ export async function sendGuardedReply(args: GuardedReplyArgs): Promise<ReplyOut
   // harnesses gain this safety exactly when they gain an adapter.
   if (!adapter) return oneShot(args);
 
-  // PRE-FLIGHT. The verify-after guard below is enough to keep Enter from answering a dialog, but it
-  // is not enough to keep the MESSAGE out of one: it types first and checks second, so a modal that
-  // owns the keyboard (Claude's `/model` picker — no input box at the tail at all) receives the
-  // user's text before anything notices. One read up front is the difference between "nothing
-  // happened" and "your reply is now sitting in a picker".
-  //
-  // Adapter-scoped and fail-OPEN in both weak directions: an adapter without `composerReady` keeps
-  // today's behaviour, and a read that throws falls through to the guard rather than blocking a send
-  // on a transient network blip. Only a definite `false` refuses.
-  if (adapter.composerReady && !args.force) {
-    try {
-      const probe = await fetchPane(args.paneId, args.requestedLines, args.session);
-      if (!adapter.composerReady(splitLines(parseAnsi(probe.text)))) {
-        return {
-          status: "blocked",
-          error:
-            "The agent's input box isn't on screen — a menu or dialog is probably up. Nothing was typed.",
-        };
-      }
-    } catch {
-      // Transient read failure: fall through. The type-then-verify guard still protects the submit key.
+  // PRE-TYPE BASELINE. A later draft that merely repeats an old visible value cannot vouch for Enter:
+  // it may belong to an underlying editor while an overlay has focus. This read is mandatory even for
+  // adapters that cannot report composer readiness. `force` may overrule only a definite readiness
+  // refusal; it never overrules the baseline because without it there is no way to prove movement.
+  let baseline: string | null;
+  try {
+    const probe = await fetchPane(args.paneId, args.requestedLines, args.session);
+    const lines = splitLines(parseAnsi(probe.text));
+    baseline = adapter.extractInputDraft(lines);
+    if (adapter.composerReady && !args.force && !adapter.composerReady(lines)) {
+      return {
+        status: "blocked",
+        error:
+          "The agent's input box isn't on screen — a menu or dialog is probably up. Nothing was typed.",
+      };
     }
+  } catch {
+    return {
+      status: "blocked",
+      error: "Couldn't read the agent input before typing. Nothing was typed.",
+    };
   }
 
   let typed;
@@ -236,6 +235,9 @@ export async function sendGuardedReply(args: GuardedReplyArgs): Promise<ReplyOut
     } catch {
       continue; // transient read failure — the bounded loop is the timeout
     }
+    // A matching stale baseline can be an editor painted beneath an overlay. It must never authorise
+    // Enter, including through an adapter's opaque-paste evidence below.
+    if (draft === baseline) continue;
     if (draftCarriesSend(args.text, draft)) return submitOnly(args);
     // The adapter gets a second look, and only a second look: a harness can SWALLOW what we typed and
     // paint a token of its own instead (Claude collapses anything past its paste threshold into


### PR DESCRIPTION
## Summary
- Add a read-only Pi harness adapter for the verified stock Pi 0.82.1 inline editor only.
- Recognition is intentionally narrow and fail-closed: overlays and custom editors stay in the raw terminal mirror rather than becoming writable composer state.
- Reply verification is baseline-aware for normal typing and paste paths, requiring an observed changed draft before submission.
- Add real, sanitized Pi pane fixtures with documented provenance.

## Release / compatibility
- No dependencies, lockfile changes, migrations, or configuration changes.

## Validation
- `bash scripts/check-version.sh`
- `bun install --frozen-lockfile && bun run typecheck && bun run test` — 534 tests passed
- `cd web && bun install --frozen-lockfile && NODE_OPTIONS=--no-experimental-webstorage bun run typecheck && NODE_OPTIONS=--no-experimental-webstorage bun run test` — 1,619 tests passed
