### PR TITLE
feat(nav-tray): add quick Ctrl+C button in the Esc/Up gap

### DIFF
--- a/web/src/components/nav-tray.test.tsx
+++ b/web/src/components/nav-tray.test.tsx
@@ -73,6 +73,24 @@ describe("NavTray", () => {
     expect(isBefore(right, space)).toBe(true);
   });
 
+  it("a quick Ctrl+C button sits in the Esc/Up gap and fires ctrl+c immediately", async () => {
+    const user = userEvent.setup();
+    const onSend = vi.fn();
+    render(<NavTray onSend={onSend} />);
+
+    const esc = screen.getByRole("button", { name: "Esc" });
+    const ctrlC = screen.getByRole("button", { name: "Ctrl+C" });
+    const up = screen.getByRole("button", { name: "Up" });
+    const isBefore = (a: HTMLElement, b: HTMLElement) =>
+      (a.compareDocumentPosition(b) & Node.DOCUMENT_POSITION_FOLLOWING) !== 0;
+
+    expect(isBefore(esc, ctrlC)).toBe(true);
+    expect(isBefore(ctrlC, up)).toBe(true);
+
+    await user.click(ctrlC);
+    expect(onSend).toHaveBeenCalledExactlyOnceWith(["ctrl+c"]);
+  });
+
   it("does not fire anything when disabled", async () => {
     const user = userEvent.setup();
     const onSend = vi.fn();

--- a/web/src/components/nav-tray.tsx
+++ b/web/src/components/nav-tray.tsx
@@ -224,10 +224,12 @@ export function NavTray({ onSend, onQueueChange, disabled }: NavTrayProps) {
       {tab === "keys" ? (
         <>
           {/* Same physical-keyboard geometry as the composer's inline quick keys, for muscle memory:
-              Esc top-left, Tab directly below it, arrows as an inverted-T on the right. */}
+              Esc top-left, Tab directly below it, arrows as an inverted-T on the right. The Esc/Up
+              gap holds a quick Ctrl+C — the one interrupt chord worth a single tap, without opening
+              Presets (which still lists it alongside the other Ctrl chords for discoverability). */}
           <div className="grid grid-cols-4 gap-1.5">
             {navBtn("Esc", ["Escape"])}
-            <div aria-hidden />
+            {navBtn("C-c", ["ctrl+c"], "Ctrl+C")}
             {navBtn(<ArrowUp className="size-4" />, ["Up"], "Up", true)}
             {navBtn("⏎ Enter", ["Enter"])}
             {navBtn("Tab", ["Tab"])}


### PR DESCRIPTION
Sends ctrl+c on a single tap without opening the Presets disclosure. Behaves like the existing non-danger Ctrl C preset (immediate fire, no two-tap confirm, no hold-to-repeat).