### PR TITLE
feat(composer): add Immediate terminal input mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to Collie are recorded here. The format follows
 `version` in `herdr-plugin.toml`, `package.json`, and `web/package.json` (enforced by
 `scripts/check-version.sh`). See [`CLAUDE.md`](./CLAUDE.md) → *Versioning* for the bump policy.
 
+## [0.26.0] - 2026-08-08
+
+### Added
+
+- **Hold Send to type straight into the terminal** — Immediate mode routes the phone keyboard through ordered key batches with no appended Enter, stays armed through keyboard dismissal, resets on a pane switch, and stops on a transport failure (#74, 4f5a253)
+
 ## [0.25.0] - 2026-08-07
 
 ### Added

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,6 +1,6 @@
 id = "herdr.collie"
 name = "Collie"
-version = "0.25.0"
+version = "0.26.0"
 min_herdr_version = "0.7.0"
 description = "Mobile web UI to monitor and reply to your agent herd, served over Tailscale"
 platforms = ["linux", "macos"]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "collie",
-  "version": "0.25.0",
+  "version": "0.26.0",
   "private": true,
   "license": "MIT",
   "description": "Collie — a mobile web UI to monitor and reply to your Herdr agent herd over Tailscale",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "collie-web",
-  "version": "0.25.0",
+  "version": "0.26.0",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/web/src/components/composer.test.tsx
+++ b/web/src/components/composer.test.tsx
@@ -317,6 +317,39 @@ describe("Composer — Immediate key mode", () => {
     expect(screen.getByTestId("status")).toHaveTextContent(/immediate mode on/i);
   });
 
+  it("sends a swiped/IME-composed word once when composition commits", async () => {
+    const keyCalls: string[][] = [];
+    server.use(
+      http.post(/\/api\/pane\/[^/]+\/keys$/, async ({ request }) => {
+        keyCalls.push(((await request.json()) as { keys: string[] }).keys);
+        return HttpResponse.json({ ok: true });
+      }),
+    );
+    renderComposer();
+    const box = activateImmediateMode();
+
+    fireEvent.compositionStart(box);
+    fireEvent.input(box, {
+      target: { value: "swipe" },
+      data: "swipe",
+      inputType: "insertCompositionText",
+      isComposing: true,
+    });
+    expect(keyCalls).toEqual([]);
+    fireEvent.compositionEnd(box, { data: "swipe" });
+
+    await waitFor(() => expect(keyCalls).toEqual([["s", "w", "i", "p", "e"]]));
+    // Gboard may emit the committed value once more as an ordinary input after compositionend.
+    fireEvent.input(box, {
+      target: { value: "swipe" },
+      data: "swipe",
+      inputType: "insertText",
+      isComposing: false,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(keyCalls).toEqual([["s", "w", "i", "p", "e"]]);
+  });
+
   it("sends terminal keys that do not change the textarea value", async () => {
     const keyCalls: string[][] = [];
     server.use(
@@ -344,6 +377,20 @@ describe("Composer — Immediate key mode", () => {
     );
     await waitFor(() =>
       expect(keyCalls).toEqual([["Backspace"], ["Enter"], ["Backspace"]]),
+    );
+
+    // Gboard can mark its virtual Enter as composing while it commits the current candidate.
+    fireEvent(
+      box,
+      new InputEvent("beforeinput", {
+        bubbles: true,
+        cancelable: true,
+        inputType: "insertParagraph",
+        isComposing: true,
+      }),
+    );
+    await waitFor(() =>
+      expect(keyCalls).toEqual([["Backspace"], ["Enter"], ["Backspace"], ["Enter"]]),
     );
   });
 

--- a/web/src/components/composer.test.tsx
+++ b/web/src/components/composer.test.tsx
@@ -265,6 +265,12 @@ describe("Composer — Immediate key mode", () => {
     return screen.getByPlaceholderText(/immediate — keys send as you type/i);
   }
 
+  it("focuses the textarea synchronously so the activation gesture opens the phone keyboard", () => {
+    renderComposer();
+
+    expect(activateImmediateMode()).toHaveFocus();
+  });
+
   it("sends committed keyboard text as literal ordered keys with no implicit Enter", async () => {
     const keyCalls: string[][] = [];
     let replyCalls = 0;

--- a/web/src/components/composer.test.tsx
+++ b/web/src/components/composer.test.tsx
@@ -262,7 +262,7 @@ describe("Composer — send", () => {
 describe("Composer — Immediate key mode", () => {
   function activateImmediateMode() {
     fireEvent.contextMenu(screen.getByRole("button", { name: /hold send for immediate/i }));
-    return screen.getByPlaceholderText(/immediate — keys send as you type/i);
+    return screen.getByPlaceholderText(/type keys/i);
   }
 
   it("focuses the textarea synchronously so the activation gesture opens the phone keyboard", () => {
@@ -278,7 +278,7 @@ describe("Composer — Immediate key mode", () => {
       const button = screen.getByRole("button", { name: /hold send for immediate/i });
       fireEvent.pointerDown(button, { button: 0, clientX: 10, clientY: 10 });
       act(() => vi.advanceTimersByTime(450));
-      const box = screen.getByPlaceholderText(/immediate — keys send as you type/i);
+      const box = screen.getByPlaceholderText(/type keys/i);
 
       act(() => box.blur());
       expect(box).not.toHaveFocus();
@@ -353,7 +353,7 @@ describe("Composer — Immediate key mode", () => {
     const box = activateImmediateMode();
 
     fireEvent.blur(box); // dismissing the Android keyboard does not silently disarm the mode
-    expect(screen.getByPlaceholderText(/immediate/i)).toBeInTheDocument();
+    expect(screen.getByPlaceholderText(/type keys/i)).toBeInTheDocument();
     await user.click(screen.getByRole("button", { name: /exit immediate key mode/i }));
 
     expect(screen.getByPlaceholderText(/type a reply/i)).toBeInTheDocument();
@@ -388,7 +388,7 @@ describe("Composer — Immediate key mode", () => {
     fireEvent.contextMenu(screen.getByRole("button", { name: "Send" }));
 
     expect(screen.getByPlaceholderText(/type a reply/i)).toHaveValue("keep this draft");
-    expect(screen.queryByPlaceholderText(/immediate/i)).not.toBeInTheDocument();
+    expect(screen.queryByPlaceholderText(/type keys/i)).not.toBeInTheDocument();
     expect(screen.getByTestId("status")).toHaveTextContent(/send or clear the draft/i);
   });
 
@@ -426,7 +426,7 @@ describe("Composer — Immediate key mode", () => {
     fireEvent.click(screen.getByRole("button", { name: "Switch pane" }));
 
     expect(screen.getByPlaceholderText(/type a reply/i)).toBeInTheDocument();
-    expect(screen.queryByPlaceholderText(/immediate/i)).not.toBeInTheDocument();
+    expect(screen.queryByPlaceholderText(/type keys/i)).not.toBeInTheDocument();
   });
 });
 

--- a/web/src/components/composer.test.tsx
+++ b/web/src/components/composer.test.tsx
@@ -259,6 +259,151 @@ describe("Composer — send", () => {
   });
 });
 
+describe("Composer — Immediate key mode", () => {
+  function activateImmediateMode() {
+    fireEvent.contextMenu(screen.getByRole("button", { name: /hold send for immediate/i }));
+    return screen.getByPlaceholderText(/immediate — keys send as you type/i);
+  }
+
+  it("sends committed keyboard text as literal ordered keys with no implicit Enter", async () => {
+    const keyCalls: string[][] = [];
+    let replyCalls = 0;
+    server.use(
+      http.post(/\/api\/pane\/[^/]+\/keys$/, async ({ request }) => {
+        keyCalls.push(((await request.json()) as { keys: string[] }).keys);
+        return HttpResponse.json({ ok: true });
+      }),
+      replyHandler(() => replyCalls++),
+    );
+    renderComposerWithStatus({ dialogPresent: true });
+
+    const box = activateImmediateMode();
+    expect(screen.getByRole("button", { name: /exit immediate key mode/i })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    fireEvent.change(box, { target: { value: "b a" } });
+
+    await waitFor(() => expect(keyCalls).toEqual([["b", "Space", "a"]]));
+    expect(keyCalls.flat()).not.toContain("Enter");
+    expect(replyCalls).toBe(0);
+    expect(box).toHaveValue("");
+    expect(screen.getByTestId("status")).toHaveTextContent(/immediate mode on/i);
+  });
+
+  it("sends terminal keys that do not change the textarea value", async () => {
+    const keyCalls: string[][] = [];
+    server.use(
+      http.post(/\/api\/pane\/[^/]+\/keys$/, async ({ request }) => {
+        keyCalls.push(((await request.json()) as { keys: string[] }).keys);
+        return HttpResponse.json({ ok: true });
+      }),
+    );
+    renderComposer();
+    const box = activateImmediateMode();
+
+    fireEvent.keyDown(box, { key: "Backspace" });
+    await waitFor(() => expect(keyCalls).toEqual([["Backspace"]]));
+    fireEvent.keyDown(box, { key: "Enter" });
+    await waitFor(() => expect(keyCalls).toEqual([["Backspace"], ["Enter"]]));
+
+    // Android can omit keydown for its virtual Backspace and expose only beforeinput.
+    fireEvent(
+      box,
+      new InputEvent("beforeinput", {
+        bubbles: true,
+        cancelable: true,
+        inputType: "deleteContentBackward",
+      }),
+    );
+    await waitFor(() =>
+      expect(keyCalls).toEqual([["Backspace"], ["Enter"], ["Backspace"]]),
+    );
+  });
+
+  it("exits on a tap of the highlighted keyboard button", async () => {
+    const user = userEvent.setup();
+    renderComposer();
+    const box = activateImmediateMode();
+
+    fireEvent.blur(box); // dismissing the Android keyboard does not silently disarm the mode
+    expect(screen.getByPlaceholderText(/immediate/i)).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: /exit immediate key mode/i }));
+
+    expect(screen.getByPlaceholderText(/type a reply/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /hold send for immediate/i })).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+  });
+
+  it("stops Immediate mode when a key batch is refused", async () => {
+    server.use(
+      http.post(/\/api\/pane\/[^/]+\/keys$/, () =>
+        HttpResponse.json({ ok: false, error: "pane unavailable" }, { status: 500 }),
+      ),
+    );
+    renderComposerWithStatus();
+    const box = activateImmediateMode();
+
+    fireEvent.change(box, { target: { value: "b" } });
+
+    const replyBox = await screen.findByPlaceholderText(/type a reply/i);
+    await waitFor(() => expect(replyBox).not.toHaveFocus());
+    expect(screen.getByTestId("status")).toHaveTextContent(/pane unavailable/i);
+  });
+
+  it("refuses activation while a buffered reply exists", async () => {
+    const user = userEvent.setup();
+    renderComposerWithStatus();
+    const box = screen.getByPlaceholderText(/type a reply/i);
+    await user.type(box, "keep this draft");
+
+    fireEvent.contextMenu(screen.getByRole("button", { name: "Send" }));
+
+    expect(screen.getByPlaceholderText(/type a reply/i)).toHaveValue("keep this draft");
+    expect(screen.queryByPlaceholderText(/immediate/i)).not.toBeInTheDocument();
+    expect(screen.getByTestId("status")).toHaveTextContent(/send or clear the draft/i);
+  });
+
+  it("resets when the composer changes panes", () => {
+    function Harness() {
+      const [paneId, setPaneId] = useState("w1:p1");
+      return (
+        <>
+          <button type="button" onClick={() => setPaneId("w1:p2")}>
+            Switch pane
+          </button>
+          <Composer
+            paneId={paneId}
+            agent="claude"
+            isShell={false}
+            gone={false}
+            readOnly={false}
+            dialogPresent={false}
+            text="pane output"
+            terminalDraft={null}
+            rawTerminalDraft={null}
+            prefs={{ wrap: true, fontSize: 11, rawTerminal: false }}
+            setWrap={vi.fn()}
+            stepFontSize={vi.fn()}
+            setRawTerminal={vi.fn()}
+            onSent={vi.fn()}
+          />
+        </>
+      );
+    }
+    const router = createMemoryRouter([{ path: "/", element: <Harness /> }]);
+    render(<RouterProvider router={router} />);
+    activateImmediateMode();
+
+    fireEvent.click(screen.getByRole("button", { name: "Switch pane" }));
+
+    expect(screen.getByPlaceholderText(/type a reply/i)).toBeInTheDocument();
+    expect(screen.queryByPlaceholderText(/immediate/i)).not.toBeInTheDocument();
+  });
+});
+
 // .adr/0009: a modal that owns the keyboard has no input box, so the reply path's PRE-FLIGHT refuses
 // before typing anything. The composer's job is to keep the draft, say why, and offer one deliberate
 // override — which still runs the type-then-verify guard behind it.

--- a/web/src/components/composer.test.tsx
+++ b/web/src/components/composer.test.tsx
@@ -271,6 +271,26 @@ describe("Composer — Immediate key mode", () => {
     expect(activateImmediateMode()).toHaveFocus();
   });
 
+  it("re-focuses from pointerup after the hold timer so mobile browsers open the keyboard", () => {
+    vi.useFakeTimers();
+    try {
+      renderComposer();
+      const button = screen.getByRole("button", { name: /hold send for immediate/i });
+      fireEvent.pointerDown(button, { button: 0, clientX: 10, clientY: 10 });
+      act(() => vi.advanceTimersByTime(450));
+      const box = screen.getByPlaceholderText(/immediate — keys send as you type/i);
+
+      act(() => box.blur());
+      expect(box).not.toHaveFocus();
+      fireEvent.pointerUp(button, { button: 0, clientX: 10, clientY: 10 });
+
+      expect(box).toHaveFocus();
+    } finally {
+      vi.runOnlyPendingTimers();
+      vi.useRealTimers();
+    }
+  });
+
   it("sends committed keyboard text as literal ordered keys with no implicit Enter", async () => {
     const keyCalls: string[][] = [];
     let replyCalls = 0;

--- a/web/src/components/composer.tsx
+++ b/web/src/components/composer.tsx
@@ -756,7 +756,7 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
                 : readOnly
                   ? "Read-only — device not authorised"
                   : immediate.active
-                    ? "Immediate — keys send as you type"
+                    ? "Type keys…"
                     : isShell
                       ? "Type a shell command…"
                       : "Type a reply…"

--- a/web/src/components/composer.tsx
+++ b/web/src/components/composer.tsx
@@ -739,6 +739,8 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
             ref={inputRef}
             value={immediate.active ? immediate.value : input}
             onChange={immediate.active ? immediate.onChange : (e) => updateInput(e.target.value)}
+            onCompositionStart={immediate.active ? immediate.onCompositionStart : undefined}
+            onCompositionEnd={immediate.active ? immediate.onCompositionEnd : undefined}
             onKeyDown={
               immediate.active
                 ? immediate.onKeyDown
@@ -756,7 +758,7 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
                 : readOnly
                   ? "Read-only — device not authorised"
                   : immediate.active
-                    ? "Type keys…"
+                    ? "Type keys to send immediately"
                     : isShell
                       ? "Type a shell command…"
                       : "Type a reply…"

--- a/web/src/components/composer.tsx
+++ b/web/src/components/composer.tsx
@@ -5,6 +5,7 @@ import { Check, ImagePlus, Keyboard, Loader2, Send, Settings2, Slash, X, Zap } f
 
 import type { DisplayPrefs } from "@/hooks/use-display-prefs";
 import { usePendingConfirm } from "@/hooks/use-pending-confirm";
+import { useImmediateInput } from "@/hooks/use-immediate-input";
 import { setStatus } from "@/lib/status";
 import { Button } from "@/components/ui/button";
 import { ChatInput } from "@/components/ui/chat/chat-input";
@@ -228,6 +229,18 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const fileRef = useRef<HTMLInputElement>(null);
+  const immediate = useImmediateInput({
+    paneKey: `${session ?? ""}\0${paneId}`,
+    inputRef,
+    replyDraft: input,
+    canActivate: () => !(locked || sending || uploading),
+    sendKeys: pressKeys,
+    onActivate: () => {
+      sendConfirm.reset();
+      forceConfirm.reset();
+    },
+    focusInput: focusInputEnd,
+  });
   const sentTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const lastSentTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   // What we last sent, and when — so we can recognise our OWN reply momentarily echoing on the "❯"
@@ -291,7 +304,10 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
   // is SAFE on its own — it lives on the "❯" line and its preview re-derives after a reload — so it
   // never holds. When held, the self-updater shows the "tap to update" banner instead and updates once
   // the hold clears (see lib/self-update.ts). Keyed by pane so panes don't clobber each other's hold.
-  useHoldReload(`composer:${paneId}`, input.trim() !== "" || uploading);
+  useHoldReload(
+    `composer:${paneId}`,
+    input.trim() !== "" || immediate.active || immediate.value !== "" || immediate.busy || uploading,
+  );
 
   // Preview appearance latch. A STABLE, non-echo, not-already-handled draft flips the preview on —
   // this is the ONLY gate that waits for the 1.5s stability, so a blip or an in-flight send never
@@ -337,6 +353,7 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
   function takeOverDraft() {
     if (effectiveRaw === null) return;
     const draft = effectiveRaw;
+    immediate.deactivateSilently();
     updateInput((prev) => (prev.trim() ? `${prev.trimEnd()}\n${draft}` : draft));
     setHandledKey(normalizeDraft(draft));
     setPreviewLatched(false);
@@ -524,6 +541,7 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
   // Insert "/cmd " into the composer (arg-taking commands) and focus it. Appends to any draft already
   // typed (with a separating space) rather than clobbering it; an empty draft just gets set.
   function insertCommand(value: string) {
+    immediate.deactivateSilently();
     updateInput((prev) => (prev.trim() ? `${prev.trimEnd()} ${value}` : value));
     focusInputEnd();
   }
@@ -537,6 +555,7 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
       const res = await api.uploadImage(paneId, file, session);
       if (res.ok) {
         const path = res.path;
+        immediate.deactivateSilently();
         updateInput((prev) => (prev.trim() ? `${prev.trimEnd()} ${path}` : path));
         focusInputEnd();
         setStatus("Image added — path in message", "success");
@@ -561,7 +580,7 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
   // Only intercepts when the clipboard actually carries an image file — a plain text paste (the
   // common case) falls through untouched.
   function onPasteImage(e: ClipboardEvent<HTMLTextAreaElement>) {
-    if (locked) return;
+    if (locked || immediate.active) return;
     const items = e.clipboardData.items;
     for (let i = 0; i < items.length; i++) {
       const item = items[i];
@@ -709,7 +728,7 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
             variant="ghost"
             size="icon"
             className="rounded-full text-muted-foreground"
-            disabled={uploading || locked}
+            disabled={uploading || locked || immediate.active}
             onPointerDown={(e) => e.preventDefault()}
             onClick={() => fileRef.current?.click()}
             aria-label="Attach image"
@@ -718,28 +737,41 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
           </Button>
           <ChatInput
             ref={inputRef}
-            value={input}
-            onChange={(e) => updateInput(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
-                e.preventDefault();
-                onSendClick();
-              }
-            }}
+            value={immediate.active ? immediate.value : input}
+            onChange={immediate.active ? immediate.onChange : (e) => updateInput(e.target.value)}
+            onKeyDown={
+              immediate.active
+                ? immediate.onKeyDown
+                : (e) => {
+                    if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+                      e.preventDefault();
+                      onSendClick();
+                    }
+                  }
+            }
             onPaste={onPasteImage}
             placeholder={
               gone
                 ? "Pane is gone"
                 : readOnly
                   ? "Read-only — device not authorised"
-                  : isShell
-                    ? "Type a shell command…"
-                    : "Type a reply…"
+                  : immediate.active
+                    ? "Immediate — keys send as you type"
+                    : isShell
+                      ? "Type a shell command…"
+                      : "Type a reply…"
+            }
+            autoCorrect={immediate.active ? "off" : undefined}
+            spellCheck={immediate.active ? false : undefined}
+            className={
+              immediate.active
+                ? "border-primary focus-visible:border-primary focus-visible:ring-primary/30"
+                : undefined
             }
             disabled={locked}
             rows={1}
           />
-          {forcingSend ? (
+          {!immediate.active && forcingSend ? (
             // The pre-flight refused and the user is being offered the override. Labelled for what it
             // actually does — TYPE the text into whatever is on screen — not "send", because the
             // submit key is still conditional on the verify step behind it.
@@ -752,7 +784,7 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
             >
               Type anyway?
             </Button>
-          ) : confirmingSend ? (
+          ) : !immediate.active && confirmingSend ? (
             <Button
               variant="destructive"
               className="h-11 shrink-0 rounded-full px-4 text-sm font-semibold"
@@ -764,13 +796,28 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
             </Button>
           ) : (
             <Button
+              {...immediate.longPress}
               size="icon"
-              className="size-11 shrink-0 rounded-full"
-              onClick={onSendClick}
-              disabled={locked || !input.trim() || sending}
-              aria-label="Send"
+              className="size-11 shrink-0 select-none rounded-full [-webkit-touch-callout:none]"
+              onClick={immediate.active ? () => immediate.deactivate() : onSendClick}
+              // Keep the empty button pointer-active: holding that exact Send icon is how Immediate
+              // mode is entered. A plain empty tap remains a no-op through send().
+              disabled={locked || sending}
+              aria-label={
+                immediate.active
+                  ? "Exit immediate key mode"
+                  : locked || input.trim()
+                    ? "Send"
+                    : "Hold Send for immediate key mode"
+              }
+              aria-pressed={immediate.active}
+              title={
+                immediate.active ? "Immediate key mode — tap to exit" : "Hold for Immediate mode"
+              }
             >
-              {sending ? (
+              {immediate.active ? (
+                <Keyboard className="size-4" />
+              ) : sending ? (
                 <Loader2 className="size-4 animate-spin" />
               ) : justSent ? (
                 <Check className="size-4" />

--- a/web/src/hooks/use-immediate-input.ts
+++ b/web/src/hooks/use-immediate-input.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import type {
   ChangeEvent,
   KeyboardEvent as ReactKeyboardEvent,
@@ -104,7 +104,12 @@ export function useImmediateInput({
   // A normal tap keeps the Send button's existing meaning. Holding toggles Immediate mode;
   // useLongPress suppresses the synthesized click after the hold, including Android's contextmenu.
   const longPressAction = active ? deactivate : activate;
-  const longPress = useLongPress(canActivate() ? longPressAction : undefined);
+  const focusAfterLongPress = useCallback(() => {
+    inputRef.current?.focus();
+  }, [inputRef]);
+  const longPress = useLongPress(canActivate() ? longPressAction : undefined, {
+    onReleaseAfterLongPress: focusAfterLongPress,
+  });
 
   // Direct input never crosses a pane boundary. Reset also invalidates keys accumulated behind an
   // in-flight call; the call already on the wire captured the old pane and cannot be recalled.

--- a/web/src/hooks/use-immediate-input.ts
+++ b/web/src/hooks/use-immediate-input.ts
@@ -1,6 +1,7 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import type {
   ChangeEvent,
+  CompositionEvent as ReactCompositionEvent,
   KeyboardEvent as ReactKeyboardEvent,
   RefObject,
 } from "react";
@@ -57,9 +58,13 @@ export function useImmediateInput({
 }: ImmediateInputOptions) {
   const [active, setActive] = useState(false);
   const [value, setValue] = useState("");
+  const composing = useRef(false);
+  const committedComposition = useRef<string | null>(null);
   const sender = useOrderedKeySender(sendKeys, () => {
     setActive(false);
     setValue("");
+    composing.current = false;
+    committedComposition.current = null;
     // Stop the phone keyboard too: otherwise continued typing after a transport failure silently
     // becomes a buffered Reply, which is a different action with an eventual Enter attached. Defer
     // past the activation focus timer so even an immediate failure cannot be re-focused behind us.
@@ -76,6 +81,8 @@ export function useImmediateInput({
     }
     onActivate();
     setValue("");
+    composing.current = false;
+    committedComposition.current = null;
     setActive(true);
     setStatus("Immediate mode on — keys send as you type.", "success");
     // Focus synchronously while the long-press/contextmenu gesture still carries browser user
@@ -89,6 +96,8 @@ export function useImmediateInput({
   function clearMode() {
     setActive(false);
     setValue("");
+    composing.current = false;
+    committedComposition.current = null;
     focusInput();
   }
 
@@ -116,6 +125,8 @@ export function useImmediateInput({
   useEffect(() => {
     setActive(false);
     setValue("");
+    composing.current = false;
+    committedComposition.current = null;
     sender.reset();
   }, [paneKey, sender.reset]);
 
@@ -125,9 +136,11 @@ export function useImmediateInput({
     const inputEl = inputRef.current;
     if (!active || inputEl === null) return;
     const onBeforeInput = (event: InputEvent) => {
-      if (event.isComposing) return;
       const key = keyForInputType(event.inputType);
       if (key === null) return;
+      // Backspace inside an active IME edits the candidate; Enter commits/submits and must still reach
+      // the terminal. Gboard commonly marks that insertParagraph event as composing.
+      if (event.isComposing && key === "Backspace") return;
       event.preventDefault();
       sender.enqueue([key]);
     };
@@ -138,11 +151,37 @@ export function useImmediateInput({
   function onChange(event: ChangeEvent<HTMLTextAreaElement>) {
     const next = event.target.value;
     setValue(next);
-    // Keep an Android IME's in-progress composition local. Its final change event arrives with
-    // isComposing=false and sends the committed string in one ordered batch.
     const inputEvent = event.nativeEvent as InputEvent;
-    if (inputEvent.isComposing || next.length === 0) return;
+    if (inputEvent.isComposing || composing.current) return;
+
+    // Gboard can follow compositionend with one ordinary input carrying the same committed word.
+    // Drop that prefix rather than sending a swipe twice, while preserving any suffix typed in the
+    // same event (commonly the auto-inserted space before the next swiped word).
+    const committed = committedComposition.current;
+    if (committed !== null) {
+      committedComposition.current = null;
+      const remainder = next.startsWith(committed) ? next.slice(committed.length) : next;
+      if (remainder.length > 0) sender.enqueue(textToKeySequence(remainder));
+      setValue("");
+      return;
+    }
+
+    if (next.length === 0) return;
     sender.enqueue(textToKeySequence(next));
+    setValue("");
+  }
+
+  function onCompositionStart() {
+    composing.current = true;
+    committedComposition.current = null;
+  }
+
+  function onCompositionEnd(event: ReactCompositionEvent<HTMLTextAreaElement>) {
+    composing.current = false;
+    const committed = event.currentTarget.value || event.data;
+    if (committed.length === 0) return;
+    committedComposition.current = committed;
+    sender.enqueue(textToKeySequence(committed));
     setValue("");
   }
 
@@ -161,6 +200,8 @@ export function useImmediateInput({
     deactivate,
     deactivateSilently,
     onChange,
+    onCompositionStart,
+    onCompositionEnd,
     onKeyDown,
   };
 }

--- a/web/src/hooks/use-immediate-input.ts
+++ b/web/src/hooks/use-immediate-input.ts
@@ -78,6 +78,11 @@ export function useImmediateInput({
     setValue("");
     setActive(true);
     setStatus("Immediate mode on — keys send as you type.", "success");
+    // Focus synchronously while the long-press/contextmenu gesture still carries browser user
+    // activation; a deferred focus selects the field but mobile browsers may refuse to open their
+    // software keyboard once that activation has expired. The existing callback still runs after
+    // React swaps the controlled value so selection lands at the end.
+    inputRef.current?.focus();
     focusInput();
   }
 

--- a/web/src/hooks/use-immediate-input.ts
+++ b/web/src/hooks/use-immediate-input.ts
@@ -1,0 +1,156 @@
+import { useEffect, useState } from "react";
+import type {
+  ChangeEvent,
+  KeyboardEvent as ReactKeyboardEvent,
+  RefObject,
+} from "react";
+
+import { useLongPress } from "@/hooks/use-long-press";
+import { useOrderedKeySender } from "@/hooks/use-ordered-key-sender";
+import { textToKeySequence } from "@/lib/key-queue";
+import { setStatus } from "@/lib/status";
+
+// Physical-keyboard events that do not change a textarea value still need wire names. Printable
+// text, spaces and line breaks normally arrive through the input/change path instead.
+const SPECIAL_KEYS: Readonly<Record<string, string>> = {
+  Escape: "Escape",
+  Tab: "Tab",
+  ArrowUp: "Up",
+  ArrowDown: "Down",
+  ArrowLeft: "Left",
+  ArrowRight: "Right",
+};
+
+function keyForInputType(inputType: string): string | null {
+  if (inputType === "deleteContentBackward") return "Backspace";
+  if (inputType === "insertLineBreak" || inputType === "insertParagraph") return "Enter";
+  return null;
+}
+
+function keyForKeyDown(key: string): string | undefined {
+  if (key === "Backspace") return "Backspace";
+  if (key === "Enter") return "Enter";
+  return SPECIAL_KEYS[key];
+}
+
+interface ImmediateInputOptions {
+  paneKey: string;
+  inputRef: RefObject<HTMLTextAreaElement | null>;
+  replyDraft: string;
+  canActivate: () => boolean;
+  sendKeys: (keys: string[]) => Promise<boolean>;
+  onActivate: () => void;
+  focusInput: () => void;
+}
+
+// The normal composer textarea's direct-terminal mode. It owns the activation gesture, transient
+// Android IME composition value, pane-boundary reset and special-key capture; transport ordering
+// stays in useOrderedKeySender so this hook never permits concurrent one-shot Herdr writes.
+export function useImmediateInput({
+  paneKey,
+  inputRef,
+  replyDraft,
+  canActivate,
+  sendKeys,
+  onActivate,
+  focusInput,
+}: ImmediateInputOptions) {
+  const [active, setActive] = useState(false);
+  const [value, setValue] = useState("");
+  const sender = useOrderedKeySender(sendKeys, () => {
+    setActive(false);
+    setValue("");
+    // Stop the phone keyboard too: otherwise continued typing after a transport failure silently
+    // becomes a buffered Reply, which is a different action with an eventual Enter attached. Defer
+    // past the activation focus timer so even an immediate failure cannot be re-focused behind us.
+    setTimeout(() => inputRef.current?.blur(), 0);
+  });
+
+  function activate() {
+    if (!canActivate()) return;
+    // A buffered reply and live keystrokes cannot safely share one field. Keep the durable draft
+    // exactly where it is and make the user send or clear it before arming direct terminal input.
+    if (replyDraft.length > 0) {
+      setStatus("Send or clear the draft before starting Immediate mode.", "info");
+      return;
+    }
+    onActivate();
+    setValue("");
+    setActive(true);
+    setStatus("Immediate mode on — keys send as you type.", "success");
+    focusInput();
+  }
+
+  function clearMode() {
+    setActive(false);
+    setValue("");
+    focusInput();
+  }
+
+  function deactivate() {
+    clearMode();
+    setStatus("Immediate mode off", "info");
+  }
+
+  function deactivateSilently() {
+    clearMode();
+  }
+
+  // A normal tap keeps the Send button's existing meaning. Holding toggles Immediate mode;
+  // useLongPress suppresses the synthesized click after the hold, including Android's contextmenu.
+  const longPressAction = active ? deactivate : activate;
+  const longPress = useLongPress(canActivate() ? longPressAction : undefined);
+
+  // Direct input never crosses a pane boundary. Reset also invalidates keys accumulated behind an
+  // in-flight call; the call already on the wire captured the old pane and cannot be recalled.
+  useEffect(() => {
+    setActive(false);
+    setValue("");
+    sender.reset();
+  }, [paneKey, sender.reset]);
+
+  // Android virtual Backspace/Enter can arrive as beforeinput without a useful keydown. A native
+  // listener is intentional: React's synthetic beforeinput omits these events on some engines.
+  useEffect(() => {
+    const inputEl = inputRef.current;
+    if (!active || inputEl === null) return;
+    const onBeforeInput = (event: InputEvent) => {
+      if (event.isComposing) return;
+      const key = keyForInputType(event.inputType);
+      if (key === null) return;
+      event.preventDefault();
+      sender.enqueue([key]);
+    };
+    inputEl.addEventListener("beforeinput", onBeforeInput);
+    return () => inputEl.removeEventListener("beforeinput", onBeforeInput);
+  }, [active, inputRef, sender.enqueue]);
+
+  function onChange(event: ChangeEvent<HTMLTextAreaElement>) {
+    const next = event.target.value;
+    setValue(next);
+    // Keep an Android IME's in-progress composition local. Its final change event arrives with
+    // isComposing=false and sends the committed string in one ordered batch.
+    const inputEvent = event.nativeEvent as InputEvent;
+    if (inputEvent.isComposing || next.length === 0) return;
+    sender.enqueue(textToKeySequence(next));
+    setValue("");
+  }
+
+  function onKeyDown(event: ReactKeyboardEvent<HTMLTextAreaElement>) {
+    const key = keyForKeyDown(event.key);
+    if (key === undefined) return;
+    event.preventDefault();
+    sender.enqueue([key]);
+  }
+
+  return {
+    active,
+    value,
+    busy: sender.busy,
+    longPress,
+    deactivate,
+    deactivateSilently,
+    onChange,
+    onKeyDown,
+  };
+}

--- a/web/src/hooks/use-long-press.test.ts
+++ b/web/src/hooks/use-long-press.test.ts
@@ -10,6 +10,9 @@ const DELAY = 450;
 function down(x = 0, y = 0, button = 0): ReactPointerEvent {
   return { button, clientX: x, clientY: y } as unknown as ReactPointerEvent;
 }
+function pointerEndEvent(): ReactPointerEvent {
+  return { preventDefault: vi.fn() } as unknown as ReactPointerEvent;
+}
 function clickEvent(): ReactMouseEvent {
   return { preventDefault: vi.fn(), stopPropagation: vi.fn() } as unknown as ReactMouseEvent;
 }
@@ -38,6 +41,25 @@ describe("useLongPress", () => {
     act(() => result.current.onPointerDown(down()));
     act(() => vi.advanceTimersByTime(DELAY - 1));
     expect(onLongPress).not.toHaveBeenCalled();
+  });
+
+  it("runs the completion callback from pointerup's trusted gesture after a fired hold", () => {
+    const onLongPress = vi.fn();
+    const onReleaseAfterLongPress = vi.fn();
+    const { result } = renderHook(() =>
+      useLongPress(onLongPress, { onReleaseAfterLongPress }),
+    );
+    act(() => result.current.onPointerDown(down()));
+    act(() => vi.advanceTimersByTime(DELAY));
+    expect(onReleaseAfterLongPress).not.toHaveBeenCalled();
+
+    const up = pointerEndEvent();
+    act(() => result.current.onPointerUp(up));
+    expect(up.preventDefault).toHaveBeenCalled();
+    expect(onReleaseAfterLongPress).toHaveBeenCalledTimes(1);
+
+    act(() => result.current.onClickCapture(clickEvent()));
+    expect(onReleaseAfterLongPress).toHaveBeenCalledTimes(1);
   });
 
   it("cancels on pointerup before the delay (a normal tap)", () => {
@@ -125,13 +147,17 @@ describe("useLongPress", () => {
 
   // Android long-press / desktop right-click reach us as a `contextmenu` event, not (or not only) the
   // hold timer. These cover that trigger and its idempotency against the timer.
-  it("opens via contextmenu and prevents the native menu (Android long-press / right-click)", () => {
+  it("opens and completes via contextmenu (Android long-press / right-click)", () => {
     const onLongPress = vi.fn();
-    const { result } = renderHook(() => useLongPress(onLongPress));
+    const onReleaseAfterLongPress = vi.fn();
+    const { result } = renderHook(() =>
+      useLongPress(onLongPress, { onReleaseAfterLongPress }),
+    );
     const e = contextMenuEvent();
     act(() => result.current.onContextMenu(e));
     expect(e.preventDefault).toHaveBeenCalled();
     expect(onLongPress).toHaveBeenCalledTimes(1);
+    expect(onReleaseAfterLongPress).toHaveBeenCalledTimes(1);
   });
 
   it("opens via contextmenu even when a pointercancel already killed the hold timer", () => {

--- a/web/src/hooks/use-long-press.ts
+++ b/web/src/hooks/use-long-press.ts
@@ -13,6 +13,9 @@ const MOVE_CANCEL_PX = 16;
 interface LongPressOptions {
   delayMs?: number;
   moveTolerance?: number;
+  // Runs from the trusted pointer/contextmenu event that ends a completed hold. Use this for browser
+  // APIs (notably opening a phone keyboard) that reject calls made from the hold timer itself.
+  onReleaseAfterLongPress?: () => void;
 }
 
 /**
@@ -36,12 +39,17 @@ interface LongPressOptions {
  */
 export function useLongPress(
   onLongPress: (() => void) | undefined,
-  { delayMs = LONG_PRESS_MS, moveTolerance = MOVE_CANCEL_PX }: LongPressOptions = {},
+  {
+    delayMs = LONG_PRESS_MS,
+    moveTolerance = MOVE_CANCEL_PX,
+    onReleaseAfterLongPress,
+  }: LongPressOptions = {},
 ) {
   const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const startPos = useRef<{ x: number; y: number } | null>(null);
   // A long-press fired on the in-progress gesture → suppress the ensuing click so it doesn't navigate.
   const fired = useRef(false);
+  const releaseHandled = useRef(false);
 
   const clear = useCallback(() => {
     if (timer.current !== null) {
@@ -64,6 +72,12 @@ export function useLongPress(
     onLongPress();
   }, [onLongPress, clear]);
 
+  const finish = useCallback(() => {
+    if (!fired.current || releaseHandled.current) return;
+    releaseHandled.current = true;
+    onReleaseAfterLongPress?.();
+  }, [onReleaseAfterLongPress]);
+
   const onPointerDown = useCallback(
     (e: ReactPointerEvent) => {
       if (!onLongPress) return;
@@ -71,6 +85,7 @@ export function useLongPress(
       // so a repeat that reaches us via `contextmenu` (desktop right-click's pointerdown is button 2)
       // can open again rather than being blocked by the previous gesture's still-set flag.
       fired.current = false;
+      releaseHandled.current = false;
       // Primary pointer only (0 for touch/pen too) — ignore right-click / secondary contacts for the
       // hold timer (right-click still opens via onContextMenu below).
       if (e.button !== 0) return;
@@ -92,6 +107,18 @@ export function useLongPress(
     [clear, moveTolerance],
   );
 
+  const finishPointerGesture = useCallback(
+    (e?: ReactPointerEvent) => {
+      clear();
+      if (!fired.current) return;
+      // Do not let the button's pointer-up default action reclaim focus after the completion callback
+      // moves it elsewhere (the exact ordering that otherwise closes a newly-opened phone keyboard).
+      e?.preventDefault();
+      finish();
+    },
+    [clear, finish],
+  );
+
   // Android Chrome raises `contextmenu` at the end of a long-press (desktop does on right-click). When
   // actions are enabled we (1) preventDefault so the native menu never hijacks the gesture, and (2)
   // trigger the sheet — this is the fallback path when a native `pointercancel` already killed the
@@ -102,24 +129,30 @@ export function useLongPress(
       if (!onLongPress) return;
       e.preventDefault();
       fire();
+      finish();
     },
-    [onLongPress, fire],
+    [onLongPress, fire, finish],
   );
 
-  const onClickCapture = useCallback((e: ReactMouseEvent) => {
-    if (!fired.current) return;
-    fired.current = false;
-    // Capture phase runs before the element's own bubble-phase onClick; stopping here cancels it.
-    e.preventDefault();
-    e.stopPropagation();
-  }, []);
+  const onClickCapture = useCallback(
+    (e: ReactMouseEvent) => {
+      if (!fired.current) return;
+      finish();
+      fired.current = false;
+      releaseHandled.current = false;
+      // Capture phase runs before the element's own bubble-phase onClick; stopping here cancels it.
+      e.preventDefault();
+      e.stopPropagation();
+    },
+    [finish],
+  );
 
   return {
     onPointerDown,
     onPointerMove,
-    onPointerUp: clear,
-    onPointerLeave: clear,
-    onPointerCancel: clear,
+    onPointerUp: finishPointerGesture,
+    onPointerLeave: finishPointerGesture,
+    onPointerCancel: finishPointerGesture,
     onContextMenu,
     onClickCapture,
   };

--- a/web/src/hooks/use-ordered-key-sender.test.ts
+++ b/web/src/hooks/use-ordered-key-sender.test.ts
@@ -1,0 +1,86 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { useOrderedKeySender } from "./use-ordered-key-sender";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+describe("useOrderedKeySender", () => {
+  it("keeps one call in flight and batches everything typed behind it", async () => {
+    const first = deferred<boolean>();
+    const send = vi
+      .fn<(keys: string[]) => Promise<boolean>>()
+      .mockImplementationOnce(() => first.promise)
+      .mockResolvedValue(true);
+    const { result } = renderHook(() => useOrderedKeySender(send, vi.fn()));
+
+    act(() => result.current.enqueue(["a"]));
+    await waitFor(() => expect(send).toHaveBeenCalledWith(["a"]));
+
+    act(() => {
+      result.current.enqueue(["b"]);
+      result.current.enqueue(["c", "d"]);
+    });
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(result.current.busy).toBe(true);
+
+    first.resolve(true);
+    await waitFor(() => expect(send).toHaveBeenNthCalledWith(2, ["b", "c", "d"]));
+    await waitFor(() => expect(result.current.busy).toBe(false));
+  });
+
+  it("splits a large committed string into bounded ordered requests", async () => {
+    const send = vi.fn<(keys: string[]) => Promise<boolean>>().mockResolvedValue(true);
+    const { result } = renderHook(() => useOrderedKeySender(send, vi.fn()));
+    const keys = Array.from({ length: 70 }, (_, i) => String(i % 10));
+
+    act(() => result.current.enqueue(keys));
+
+    await waitFor(() => expect(send).toHaveBeenCalledTimes(2));
+    expect(send.mock.calls[0][0]).toEqual(keys.slice(0, 64));
+    expect(send.mock.calls[1][0]).toEqual(keys.slice(64));
+    await waitFor(() => expect(result.current.busy).toBe(false));
+  });
+
+  it("stops and discards queued keys after a failed batch", async () => {
+    const first = deferred<boolean>();
+    const send = vi.fn<(keys: string[]) => Promise<boolean>>().mockReturnValue(first.promise);
+    const onFailure = vi.fn();
+    const { result } = renderHook(() => useOrderedKeySender(send, onFailure));
+
+    act(() => result.current.enqueue(["a"]));
+    await waitFor(() => expect(send).toHaveBeenCalledTimes(1));
+    act(() => result.current.enqueue(["b"]));
+
+    first.resolve(false);
+    await waitFor(() => expect(onFailure).toHaveBeenCalledTimes(1));
+    expect(send).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(result.current.busy).toBe(false));
+  });
+
+  it("reset drops queued keys without cancelling the batch already on the wire", async () => {
+    const first = deferred<boolean>();
+    const send = vi
+      .fn<(keys: string[]) => Promise<boolean>>()
+      .mockImplementationOnce(() => first.promise)
+      .mockResolvedValue(true);
+    const { result } = renderHook(() => useOrderedKeySender(send, vi.fn()));
+
+    act(() => result.current.enqueue(["old"]));
+    await waitFor(() => expect(send).toHaveBeenCalledTimes(1));
+    act(() => {
+      result.current.enqueue(["discard"]);
+      result.current.reset();
+    });
+
+    first.resolve(true);
+    await waitFor(() => expect(result.current.busy).toBe(false));
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/src/hooks/use-ordered-key-sender.ts
+++ b/web/src/hooks/use-ordered-key-sender.ts
@@ -1,0 +1,87 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+// Bound one request when an IME or paste commits a large string at once. The remainder stays queued
+// behind it, preserving order without handing the bridge an unbounded JSON array.
+const MAX_BATCH = 64;
+
+// Serialize bursts of keys through Herdr's one-shot RPC. Ordering is guaranteed inside one
+// `send_keys` array, but not across concurrent connections, so one batch stays in flight while any
+// later input accumulates into the next batch. This is transport backpressure, not a typing delay:
+// the first key leaves immediately and a slow round trip merely makes the following batch larger.
+export function useOrderedKeySender(
+  send: (keys: string[]) => Promise<boolean>,
+  onFailure: () => void,
+) {
+  const pending = useRef<string[]>([]);
+  const inFlight = useRef(false);
+  const generation = useRef(0);
+  const mounted = useRef(true);
+  const sendRef = useRef(send);
+  const failureRef = useRef(onFailure);
+  const pumpRef = useRef<() => void>(() => {});
+  const [busy, setBusy] = useState(false);
+
+  sendRef.current = send;
+  failureRef.current = onFailure;
+
+  const pump = useCallback(() => {
+    if (inFlight.current || pending.current.length === 0) return;
+
+    const batch = pending.current.splice(0, MAX_BATCH);
+    const batchGeneration = generation.current;
+    inFlight.current = true;
+
+    const flush = async () => {
+      try {
+        let ok = false;
+        try {
+          ok = await sendRef.current(batch);
+        } catch {
+          // A thrown transport failure has the same stop-now semantics as a false verdict.
+        }
+        if (!ok && batchGeneration === generation.current) {
+          // A failure makes the target's input state unknown. Stop immediately and discard anything
+          // that had not reached the wire rather than resuming blind after a transient error.
+          pending.current = [];
+          generation.current += 1;
+          failureRef.current();
+        }
+      } finally {
+        inFlight.current = false;
+        if (pending.current.length > 0) {
+          pumpRef.current();
+        } else if (mounted.current) {
+          setBusy(false);
+        }
+      }
+    };
+    void flush();
+  }, []);
+  pumpRef.current = pump;
+
+  const enqueue = useCallback((keys: string[]) => {
+    if (keys.length === 0) return;
+    pending.current.push(...keys);
+    if (mounted.current) setBusy(true);
+    pumpRef.current();
+  }, []);
+
+  // Invalidate queued work when the pane changes. An RPC already in flight cannot be recalled, but
+  // it captured the old target before the reset; no unsent key is allowed to leak into the new pane.
+  const reset = useCallback(() => {
+    generation.current += 1;
+    pending.current = [];
+    if (!inFlight.current && mounted.current) setBusy(false);
+  }, []);
+
+  useEffect(
+    () => () => {
+      mounted.current = false;
+      generation.current += 1;
+      pending.current = [];
+    },
+    [],
+  );
+
+  return { enqueue, reset, busy };
+}

--- a/web/src/lib/key-queue.test.ts
+++ b/web/src/lib/key-queue.test.ts
@@ -7,6 +7,7 @@ import {
   modifierLabel,
   nextModMode,
   normalizeBaseChar,
+  textToKeySequence,
 } from "./key-queue";
 
 describe("composeKey", () => {
@@ -124,5 +125,28 @@ describe("normalizeBaseChar", () => {
     expect(normalizeBaseChar("")).toBeNull();
     expect(normalizeBaseChar(" ")).toBeNull();
     expect(normalizeBaseChar("\t")).toBeNull();
+  });
+});
+
+describe("textToKeySequence", () => {
+  it("preserves literal character order and case without adding Enter", () => {
+    expect(textToKeySequence("b")).toEqual(["b"]);
+    expect(textToKeySequence("Ab!")).toEqual(["A", "b", "!"]);
+  });
+
+  it("uses verified names for whitespace keys", () => {
+    expect(textToKeySequence("a b\tc\nd")).toEqual([
+      "a",
+      "Space",
+      "b",
+      "Tab",
+      "c",
+      "Enter",
+      "d",
+    ]);
+  });
+
+  it("normalises CRLF and CR to one explicit Enter each", () => {
+    expect(textToKeySequence("a\r\nb\rc")).toEqual(["a", "Enter", "b", "Enter", "c"]);
   });
 });

--- a/web/src/lib/key-queue.ts
+++ b/web/src/lib/key-queue.ts
@@ -1,7 +1,7 @@
-// Pure model for the nav-tray key queue: compose a set of modifiers onto a base key, label a key
-// for a chip, flag danger keys, cycle a modifier's three-state mode, and normalise the one-char key
-// input. No React, no I/O — every string this produces is what goes on the wire to Herdr's
-// `pane.send_keys` (see HERDR_API.md).
+// Pure model for the nav-tray key queue and the composer's immediate-input mode: compose a set of
+// modifiers onto a base key, turn typed text into ordered Herdr keys, label keys for chips, flag
+// danger keys, cycle modifier state, and normalise the one-char chord input. No React, no I/O —
+// every string this produces is what goes on the wire to Herdr's `pane.send_keys`.
 
 // The modifiers Collie surfaces in the tray. Multi-modifier chords in ANY order — `ctrl+shift+p`,
 // the triple `ctrl+alt+shift+p`, `alt+Up` — are now LIVE-VERIFIED against Herdr (0.7.3 sandbox +
@@ -108,4 +108,17 @@ export function normalizeBaseChar(raw: string): string | null {
   const code = ch.charCodeAt(0);
   if (code < 0x21 || code > 0x7e) return null;
   return ch.toLowerCase();
+}
+
+// Turn text committed by a phone keyboard into one ordered `pane.send_keys` array. Ordinary
+// characters stay literal and case-preserving; whitespace whose literal wire behaviour is not
+// verified uses Herdr's named keys. A newline the user explicitly typed becomes Enter, but no
+// trailing Enter is ever added. Normalise pasted CRLF/CR first so one visual line break is one key.
+export function textToKeySequence(text: string): string[] {
+  return Array.from(text.replace(/\r\n?/g, "\n"), (char) => {
+    if (char === " ") return "Space";
+    if (char === "\t") return "Tab";
+    if (char === "\n") return "Enter";
+    return char;
+  });
 }


### PR DESCRIPTION
Fixes #74.

## The gap

The composer always followed text with the harness submit key. The Keys dock could send digits,
special keys and chords, but the phone keyboard could not drive a TUI that expects bare printable
keys such as `b`.

## Immediate mode

Hold the normal Send button to arm **Immediate mode**. The textarea and button change visibly, and
committed phone-keyboard input goes straight to `pane.send_keys` instead of becoming a reply:

- ordinary text is case-preserving and ordered;
- Space, Tab and explicit line breaks use Herdr's verified key names;
- Android/physical Backspace and Enter are captured even when they do not change the textarea;
- no trailing Enter is added;
- a tap on the highlighted keyboard button exits.

The mode survives ordinary blur/keyboard dismissal, but never a pane switch. It refuses to arm over
a buffered reply, and reply-only actions (Take over, slash-command insertion, image upload) disarm
it rather than reinterpret their text as terminal keys.

## Ordering and failure

Herdr uses one connection per RPC, so concurrent `send_keys` calls have no ordering guarantee. A
one-in-flight pump sends the first key immediately, accumulates later input behind it, and flushes
bounded 64-key batches in order. A slow tailnet therefore grows the next batch rather than reordering
characters.

If a batch fails, queued keys are discarded, Immediate mode stops, and the textarea blurs so
continued typing cannot silently become a normal Reply with an eventual Enter attached.

## Verification

- `bun x tsc --noEmit` — root typecheck clean
- `bun run test` — 534 bridge tests plus the collie-ctl lifecycle suite
- `cd web && bun run typecheck` — client and service-worker typechecks clean
- `cd web && bun run test` — 1,616 tests passed
- `cd web && bun run build` — production PWA build passed
- `scripts/check-version.sh` — 0.26.0 consistent

The tests exercise the Android `contextmenu` long-press fallback, native `beforeinput` Backspace,
IME-style committed strings, ordering/backpressure, blur persistence, pane reset, and failure stop.
A real Android/Gboard smoke test is still needed; jsdom cannot reproduce an OEM keyboard's exact IME
event stream.
