### PR TITLE
fix(web): make the reply guard's input-box detection width-independent

### DIFF
--- a/web/src/lib/harness/claude/chrome.test.ts
+++ b/web/src/lib/harness/claude/chrome.test.ts
@@ -4,7 +4,8 @@ import { describe, expect, it } from "vitest";
 
 import { parseAnsi } from "../../ansi";
 import { splitLines, type StyledLine } from "../../blocks";
-import { extractInputDraft, extractStatusLines, stripChrome } from "./chrome";
+import { draftCarriesSend } from "../../reply-action";
+import { extractInputDraft, extractStatusLines, hasInputBox, stripChrome } from "./chrome";
 import { lineText } from "./markers";
 
 /** The statusline run as plain text. extractStatusLines returns STYLED lines — a statusline tells
@@ -17,8 +18,9 @@ const statusText = (lines: StyledLine[]): string[] =>
 const PANES_DIR = join(import.meta.dirname, "..", "..", "..", "fixtures", "panes");
 
 // Synthesise the input-box shape: a top rule, the "❯ …" prompt line, a bottom rule, and an optional
-// statusline below it (matched by position, like the real captures). 40 box glyphs clear the
-// 20-glyph border threshold in isBoxBorder.
+// statusline below it (matched by position, like the real captures). 40 glyphs is comfortably above
+// isBoxBorder's BARE_BORDER_MIN floor (8) — see the narrow (19- and 8-glyph) and labelled-border
+// cases below for the width-dependent bug this shape used to have.
 function boxBuffer(promptLine: string, status?: string): StyledLine[] {
   const rule = "─".repeat(40);
   const rows = [rule, promptLine, rule];
@@ -31,6 +33,15 @@ function boxBuffer(promptLine: string, status?: string): StyledLine[] {
 function wrappedBoxBuffer(promptLine: string, continuationLines: string[], above?: string[]): StyledLine[] {
   const rule = "─".repeat(40);
   const rows = [...(above ?? []), rule, promptLine, ...continuationLines, rule];
+  return splitLines(parseAnsi(rows.join("\n")));
+}
+
+// Same shape as boxBuffer, but with a caller-chosen border WIDTH — for pinning bug #76's
+// width-dependent border test at a narrow (sub-20-glyph) pane.
+function narrowBoxBuffer(promptLine: string, ruleWidth: number, status?: string): StyledLine[] {
+  const rule = "─".repeat(ruleWidth);
+  const rows = [rule, promptLine, rule];
+  if (status !== undefined) rows.push(status);
   return splitLines(parseAnsi(rows.join("\n")));
 }
 
@@ -338,11 +349,237 @@ describe("extractInputDraft — recovers a stranded prompt-line draft", () => {
     expect(draft).toBe("the quick brown fox jumps over the lazy dog again and again");
   });
 
-  // Conservatism: the multi-line scan is bounded (MAX_DRAFT_LINES) and aborts on a border en route,
-  // so it can't run away up a borderless buffer and strip real output as a giant "draft".
-  it("does not match a box whose draft exceeds the wrap bound (falls back to raw)", () => {
-    const tooMany = Array.from({ length: 20 }, (_, i) => `  continuation ${i}`);
-    expect(extractInputDraft(wrappedBoxBuffer("❯ opening line", tooMany))).toBeNull();
+  // Bug #76 fix: the wrapped-draft scan used to be bounded by MAX_DRAFT_LINES (12), so a draft long
+  // enough to wrap past that many continuation rows made locateInputBox return null — the send guard
+  // then saw no draft at all and stalled forever even though the text had landed. The bound is now
+  // 100 (defense-in-depth, not a correctness bound — see the comment on MAX_DRAFT_LINES in chrome.ts),
+  // comfortably above real wraps, so a draft this long is still found.
+  it("matches a box whose draft wraps past the old 12-line bound", () => {
+    const many = Array.from({ length: 20 }, (_, i) => `  continuation ${i}`);
+    const draft = extractInputDraft(wrappedBoxBuffer("❯ opening line", many));
+    expect(draft).toBe(["opening line", ...many.map((l) => l.trim())].join(" "));
+  });
+
+  // A very long draft (610 chars / 25 logical lines, per the issue) can wrap to ~40 rows at a narrow
+  // pane's column count. Pin that the walk reaches all the way up to the prompt (well past the old
+  // 12-line cap, comfortably under the new 100-line one), and that the resulting join is exactly what
+  // reply-action's draftCarriesSend needs to verify the send actually landed.
+  it("extracts a ~40-row wrapped draft in full, and it verifies a real send via draftCarriesSend", () => {
+    const words = Array.from({ length: 200 }, (_, i) => `word${i}`);
+    const wordsPerRow = 5;
+    const rows: string[] = [];
+    for (let i = 0; i < words.length; i += wordsPerRow) rows.push(words.slice(i, i + wordsPerRow).join(" "));
+    expect(rows.length).toBeGreaterThan(30); // comfortably past the old 12-line cap
+    expect(rows.length).toBeLessThan(100); // and comfortably under the new one
+    const [first, ...continuationRows] = rows;
+    const lines = wrappedBoxBuffer(`❯ ${first}`, continuationRows.map((r) => `  ${r}`));
+
+    const draft = extractInputDraft(lines);
+    expect(draft).toBe(rows.join(" "));
+
+    const sent = words.join(" "); // what the composer actually typed, single-space separated
+    expect(draftCarriesSend(sent, draft)).toBe(true);
+  });
+
+  // The Latin case above wraps at WORD boundaries, so every fold seam extractInputDraft inserts
+  // happens to coincide with a real space in `sent` — draftCarriesSend's "loosen only the fold's own
+  // seam" logic (reply-action.ts) is never actually exercised by it. CJK text wraps mid-run (no spaces
+  // to break at), so EVERY seam in a real CJK draft is fabricated by the fold, never a genuine space —
+  // this is the case that actually needs the loosening.
+  it("extracts a ~40-row wrapped CJK draft (no natural spaces) verified through the fold-seam path", () => {
+    const PHRASE = "これはとても長いテストメッセージですのでどうぞよろしくお願いします"; // no spaces
+    const sentJa = PHRASE.repeat(Math.ceil(640 / PHRASE.length)).slice(0, 640); // exactly 640 chars
+    const CHARS_PER_ROW = 16; // simulates a narrow pane, where 2-cell-wide CJK glyphs wrap often
+    const rows: string[] = [];
+    for (let i = 0; i < sentJa.length; i += CHARS_PER_ROW) rows.push(sentJa.slice(i, i + CHARS_PER_ROW));
+    expect(rows.length).toBe(40);
+    const [first, ...continuationRows] = rows;
+    const lines = wrappedBoxBuffer(`❯ ${first}`, continuationRows.map((r) => `  ${r}`));
+
+    const draft = extractInputDraft(lines);
+    // Every seam here is FABRICATED by the fold (sentJa has no spaces anywhere) — draftCarriesSend
+    // must treat each one as an unknowable-width gap rather than require sentJa to hold a literal
+    // space at every row boundary.
+    expect(draft).toBe(rows.join(" "));
+    expect(draftCarriesSend(sentJa, draft)).toBe(true);
+  });
+
+  // Bug #76 (finding 2, defense-in-depth): the draft-walk cap (100) exists so a stray line that merely
+  // LOOKS like a border can't pair up with a genuinely-quoted "❯" line dozens of rows away to complete
+  // a bogus box shape. Pin that the cap actually stops such a far-apart match — a real top border, a
+  // real "❯" line, then well over 100 lines of ordinary filler before the (stray-looking) bottom
+  // border must NOT locate a box at all.
+  it("does not pair a far-away ❯ line with a border more than the draft cap apart", () => {
+    const filler = Array.from({ length: 105 }, (_, i) => `filler line ${i}`); // > MAX_DRAFT_LINES (100)
+    const lines = wrappedBoxBuffer("❯ this quote is not really the current draft", filler);
+    expect(extractInputDraft(lines)).toBeNull();
+  });
+
+  // Round-3 finding 2: the two blank-line skips inside locateInputBox step (d) used to be UNBOUNDED
+  // (`while (isBlank) i--`), run before/after the counted continuation walk rather than as part of it
+  // — so a wall of blank lines could stand in for the non-blank filler above and reach an arbitrarily
+  // distant border for free, defeating MAX_DRAFT_LINES entirely for that shape. Both spots now draw
+  // from the SAME `wrapped` counter as the continuation walk itself.
+  it("does not tolerate 105 blank lines between the ❯ line and the bottom border", () => {
+    // These blanks sit exactly where the old free pre-skip used to run: contiguous with the bottom
+    // border, walked BEFORE the (previously) counted loop ever started.
+    const blanks = Array.from({ length: 105 }, () => "");
+    const lines = wrappedBoxBuffer("❯ this line is far from the border", blanks);
+    expect(extractInputDraft(lines)).toBeNull();
+  });
+
+  it("does not tolerate 105 blank lines between the top border and the ❯ line", () => {
+    // These blanks sit where the old free post-prompt skip used to run: between the prompt and the
+    // top border, walked AFTER the "❯" line was already found.
+    const rule = "─".repeat(40);
+    const blanks = Array.from({ length: 105 }, () => "");
+    const lines = splitLines(parseAnsi([rule, ...blanks, "❯ padded draft", rule].join("\n")));
+    expect(extractInputDraft(lines)).toBeNull();
+  });
+
+  it("still tolerates a few blank padding lines between the top border and the prompt", () => {
+    // Existing (pre-fix) behaviour preserved: a small amount of blank padding is well under the cap,
+    // so it's still just tolerated, not treated as suspicious.
+    const rule = "─".repeat(40);
+    const lines = splitLines(parseAnsi([rule, "", "", "❯ padded draft", rule].join("\n")));
+    expect(extractInputDraft(lines)).toBe("padded draft");
+  });
+});
+
+// Finding 1 (field review): isBoxBorder used to delegate to isHorizontalRule, whose whitespace-
+// stripping let a spaced-out prose separator compact into "nothing but rule glyphs". That let a fake
+// dialog buffer complete the FULL border→❯→border shape locateInputBox looks for and get read as a
+// live composer — meaning a guarded reply could type into (and, on the old code path, submit into) a
+// real permission dialog sitting right below it. Traced repro from the review, verbatim.
+describe("a fake box shape built from spaced-out em-dash separators is not an input box", () => {
+  const lines = splitLines(
+    parseAnsi(
+      [
+        "— — —",
+        "❯ approve deployment now",
+        "— — —",
+        "Do you want to proceed?",
+        " ❯ 1. Yes",
+        "   2. No",
+        "",
+        "Esc to cancel · Tab to amend",
+      ].join("\n"),
+    ),
+  );
+
+  it("extractInputDraft finds no draft", () => {
+    expect(extractInputDraft(lines)).toBeNull();
+  });
+
+  it("hasInputBox reports no composer on screen (the dialog owns the keyboard)", () => {
+    expect(hasInputBox(lines)).toBe(false);
+  });
+});
+
+// Bug #76, first failure mode: isBoxBorder used to require 20+ consecutive rule glyphs, which is
+// width-dependent — Herdr's shared grid follows the narrowest attached client, so a split pane's
+// border can render well under 20 glyphs (19 observed). And Claude sometimes splices a session/job
+// name into the TOP border, splitting its run so neither flank reaches 20 even at a normal width.
+describe("locateInputBox at a narrow pane width / with a labelled top border", () => {
+  it("locates a box whose borders are exactly 19 glyphs wide (below the old 20-glyph floor)", () => {
+    const lines = narrowBoxBuffer("❯ narrow pane draft", 19);
+    expect(extractInputDraft(lines)).toBe("narrow pane draft");
+  });
+
+  it("locates a box whose TOP border carries a spliced label, on a narrow pane", () => {
+    // Observed real capture: flanks 5/2 at 43 columns.
+    const topBorder = "───── japanese technical troubleshooting ──";
+    const bottomBorder = "─".repeat(19);
+    const lines = splitLines(
+      parseAnsi([topBorder, "❯ reply about the troubleshooting doc", bottomBorder].join("\n")),
+    );
+    expect(extractInputDraft(lines)).toBe("reply about the troubleshooting doc");
+  });
+
+  // Round-3 finding 1: traced against the bundled renderer's own label-placement math, a top border's
+  // flank can clamp down to exactly 1 glyph (align:"center", or align:"end" with a zero offset).
+  // locateInputBox's step (e) uses isInputBoxTopBorder specifically so this real shape still locates
+  // the box.
+  it("locates a box whose TOP border has a 1-glyph flank (renderer's align:center/end clamp)", () => {
+    const lines = splitLines(
+      parseAnsi(["──── fast mode ─", "❯ reply while fast mode is on", "─".repeat(19)].join("\n")),
+    );
+    expect(extractInputDraft(lines)).toBe("reply while fast mode is on");
+  });
+
+  // Strictness boundary: the looser top-border floor is specific to the renderer's real clamp — it
+  // must NOT reopen the em-dash-prose hole finding 1 closed. Same box shape as the fake-dialog test
+  // above, but as the TOP border of an otherwise well-formed box; still not a box.
+  it("does NOT locate a box whose TOP border is a spaced em-dash separator", () => {
+    const lines = splitLines(parseAnsi(["— — —", "❯ reply text", "─".repeat(19)].join("\n")));
+    expect(extractInputDraft(lines)).toBeNull();
+    expect(hasInputBox(lines)).toBe(false);
+  });
+});
+
+// Round-4 finding: a labelled top border's per-flank minimums alone don't rule out a total width
+// narrower than any bare border the renderer can actually draw — the renderer draws a box's top and
+// bottom border at the SAME width, and the bare bottom border already requires >= 8 columns. Traced
+// bypass buffer from the review, verbatim: a 5-column "─ x ─" top border, an echoed "❯" line, an
+// 8-column bare bottom border (just wide enough to pass on its own), then a real permission dialog
+// below it. Before the shared width floor, this walked footer → status → 8-glyph bottom → echoed ❯ →
+// "─ x ─" as a (loose) top border and reported a composer on screen over a live dialog.
+describe("a labelled top border narrower than any real bare border is not an input box", () => {
+  const lines = splitLines(
+    parseAnsi(
+      [
+        "─ x ─",
+        "❯ approve deployment now",
+        "────────",
+        "Do you want to proceed?",
+        " ❯ 1. Yes",
+        "   2. No",
+        "",
+        "Esc to cancel · Tab to amend",
+      ].join("\n"),
+    ),
+  );
+
+  it("extractInputDraft finds no draft", () => {
+    expect(extractInputDraft(lines)).toBeNull();
+  });
+
+  it("hasInputBox reports no composer on screen (the dialog owns the keyboard)", () => {
+    expect(hasInputBox(lines)).toBe(false);
+  });
+});
+
+// Round-5 finding: the shared width floor above must be measured in DISPLAY CELLS, not UTF-16
+// `.length` — a combining-mark label can read AT or above the floor in `.length` while actually being
+// narrower in real terminal columns. Same bypass shape as the round-4 buffer above, but the top
+// border's `.length` (8) alone would have cleared the OLD (length-based) floor; only measuring in
+// display cells (7, one short) correctly still rejects it.
+describe("a combining-mark top border whose .length clears the floor but whose display width doesn't", () => {
+  // Explicit decomposed form (base "e" + combining acute U+0301), NOT the precomposed "é" glyph —
+  // that would collapse to a single UTF-16 unit and defeat the point of this fixture.
+  const topBorder = "── e" + "́" + " ──"; // .length 8, displayWidth 7
+  const lines = splitLines(
+    parseAnsi(
+      [
+        topBorder,
+        "❯ approve deployment now",
+        "────────",
+        "Do you want to proceed?",
+        " ❯ 1. Yes",
+        "   2. No",
+        "",
+        "Esc to cancel · Tab to amend",
+      ].join("\n"),
+    ),
+  );
+
+  it("extractInputDraft finds no draft", () => {
+    expect(topBorder.length).toBe(8);
+    expect(extractInputDraft(lines)).toBeNull();
+  });
+
+  it("hasInputBox reports no composer on screen (the dialog owns the keyboard)", () => {
+    expect(hasInputBox(lines)).toBe(false);
   });
 });
 

--- a/web/src/lib/harness/claude/chrome.ts
+++ b/web/src/lib/harness/claude/chrome.ts
@@ -9,7 +9,7 @@
 // matched by POSITION (below the box's bottom border), never by its content strings.
 
 import type { StyledLine } from "../../blocks";
-import { isBlank, isBoxBorder, lineText } from "./markers";
+import { isBlank, isBoxBorder, isInputBoxTopBorder, lineText } from "./markers";
 
 // Rows allowed DIRECTLY under the input box's bottom border: the statusline plus its hint row(s)
 // ("← for agents", "⏵⏵ bypass permissions on …"). A statusline is an arbitrary user command's output,
@@ -25,11 +25,21 @@ const MAX_STATUS_LINES = 8;
 const MAX_FOOTER_LINES = 8;
 
 // A long draft WRAPS inside the input box: the "❯ …" prompt line plus continuation lines (indented,
-// no leading "❯") before the bottom border. We scan up past those to find the prompt, but only this
-// many — a bound that keeps the match tight (a borderless buffer can't strip unboundedly) while
-// comfortably covering a very long draft even on a narrow phone pane. A taller box falls back to the
-// raw mirror (safe: at worst the draft stays visible, exactly the pre-wrap-support behaviour).
-const MAX_DRAFT_LINES = 12;
+// no leading "❯") before the bottom border. We scan up past those to find the prompt, bounded by
+// MAX_DRAFT_LINES — but as DEFENSE-IN-DEPTH, not a correctness bound. The caller's read window
+// defaults to 200 lines (COLLIE_READ_LINES, bridge/config.ts) and is client-requestable up to
+// MAX_READ_LINES (10,000, bridge/server.ts), so an unbounded walk would let a stray line that happens
+// to look like a border (see isBoxBorder in markers.ts) pair up with an unrelated quoted "❯" line
+// dozens (or thousands) of lines further up to complete a full (bogus) box shape — the cap, not the
+// border test alone, is what keeps that match from reaching all the way there. Every line the walk
+// crosses counts against this cap, blank or not: a run of blank padding is not a free pass either
+// (see the blank-line skips inside locateInputBox below, both bounded by the same counter). The OLD
+// cap (12) was simply too tight: a real 610-char/25-line CJK draft wraps to ~40 rows at a narrow
+// pane's column count (CJK glyphs are 2 cells wide), well past it, which made locateInputBox return
+// null and stalled the send guard for good (issue #76). Removing the cap entirely was considered and
+// rejected for the reason above. 100 comfortably covers the observed ~40-row case plus a worst case
+// around 70–80 rows at a 19-column pane, with margin, while still capping how far the walk can reach.
+const MAX_DRAFT_LINES = 100;
 
 // Text Claude draws on the "❯" prompt line that is NOT a real user draft — it's a hint the TUI paints
 // when the box is otherwise empty. Must never be surfaced as a recoverable draft. Kept as an array so
@@ -222,9 +232,12 @@ function locateInputBox(texts: string[], end: number): InputBox | null {
 
   // (d) the "❯" prompt line — the FIRST line of the draft. A long draft wraps onto continuation lines
   //     (indented, no "❯") between the prompt and the bottom border, so scan up past them to the
-  //     prompt. Bounded by MAX_DRAFT_LINES, and any box border en route aborts the match (we'd have
-  //     left the box). Blank padding on either side is tolerated defensively.
-  while (i >= 0 && isBlank(texts[i]!)) i--;
+  //     prompt. Bounded by MAX_DRAFT_LINES (see the comment above — defense-in-depth, not a
+  //     correctness bound), and any box border en route aborts the match (we'd have left the box).
+  //     Blank padding is tolerated on either side, but it draws from the SAME budget as real
+  //     continuation lines — a bare `while (isBlank) i--` here used to skip an unlimited run of blank
+  //     lines for free before this loop even started counting, which let a wall of blanks stand in for
+  //     the non-blank filler the draft-walk cap is supposed to bound.
   let wrapped = 0;
   while (
     i >= 0 &&
@@ -238,9 +251,20 @@ function locateInputBox(texts: string[], end: number): InputBox | null {
   if (i < 0 || !texts[i]!.trimStart().startsWith("❯")) return null;
   const prompt = i;
   i--;
-  while (i >= 0 && isBlank(texts[i]!)) i--;
+  // Blank padding between the prompt and the top border (e.g. a blank first line inside a freshly
+  // opened box) — same shared `wrapped` budget as above, for the same reason: this used to be its own
+  // unbounded `while (isBlank) i--`, so a wall of blanks here could reach an arbitrarily distant top
+  // border for free.
+  while (i >= 0 && isBlank(texts[i]!) && wrapped < MAX_DRAFT_LINES) {
+    wrapped++;
+    i--;
+  }
 
-  // (e) top border
-  if (i < 0 || !isBoxBorder(texts[i]!)) return null;
+  // (e) top border — the LAST anchor checked, so it alone gets the looser flank floor
+  //     (isInputBoxTopBorder): the renderer can clamp a labelled top border's flank down to 1 glyph
+  //     (see the comment on isInputBoxTopBorder in markers.ts), and by this point the bottom border,
+  //     the "❯" line, and the draft-walk cap have already pinned the rest of the shape down, so the
+  //     looser test doesn't reopen the false-positive risk a bare 1-glyph flank would elsewhere.
+  if (i < 0 || !isInputBoxTopBorder(texts[i]!)) return null;
   return { top: i, prompt, bottomBorder, statusEnd };
 }

--- a/web/src/lib/harness/claude/markers.test.ts
+++ b/web/src/lib/harness/claude/markers.test.ts
@@ -7,6 +7,7 @@ import {
   isBlank,
   isBoxBorder,
   isHorizontalRule,
+  isInputBoxTopBorder,
   isMultiStepHeader,
   lineText,
 } from "./markers";
@@ -48,6 +49,175 @@ describe("isBoxBorder", () => {
   it("rejects ordinary text and short dashes", () => {
     expect(isBoxBorder("hello world")).toBe(false);
     expect(isBoxBorder("a ── b")).toBe(false); // only two dashes
+  });
+
+  // Bug #76: a bare border's old test required 20+ consecutive rule glyphs ANYWHERE on the line.
+  // That's width-dependent — Herdr's shared grid follows the narrowest attached client, so a split
+  // pane's border can render well under 20 glyphs. The shape test (a trimmed line of nothing but
+  // U+2500, no absolute floor beyond BARE_BORDER_MIN=8) passes at any realistic width.
+  it("matches a bare border at a narrow 19-glyph pane width (below the old 20-glyph floor)", () => {
+    expect(isBoxBorder("─".repeat(19))).toBe(true);
+  });
+
+  it("matches a bare border at exactly the 8-glyph floor", () => {
+    expect(isBoxBorder("─".repeat(8))).toBe(true);
+  });
+
+  it("rejects a bare run below the floor (too short to be a real border)", () => {
+    expect(isBoxBorder("───")).toBe(false); // 3 glyphs — a plausible prose separator, not a border
+    expect(isBoxBorder("─".repeat(7))).toBe(false); // one under the floor
+  });
+
+  // Claude Code sometimes splices a session/job name into the input box's TOP border. The old test
+  // required 20+ UNBROKEN glyphs, but a label splits the run in two, so neither flank reached 20 even
+  // at a normal pane width — this is bug #76's second failure mode. Observed real capture: flanks
+  // 5/2 at 43 columns.
+  it("matches a labelled border (rule + embedded label + rule)", () => {
+    expect(isBoxBorder("───── some job name ──")).toBe(true);
+    expect(isBoxBorder("───── japanese technical troubleshooting ──")).toBe(true); // observed 5/2 flanks
+  });
+
+  // MUST-NOT cases, round 1: text shaped just enough like a labelled border to worry about, but not
+  // one. Em/en dash and friends are a DIFFERENT glyph from the U+2500 isBoxBorder now requires, so
+  // these fail outright rather than merely failing a flank-length floor.
+  it("rejects em-dash prose (a different glyph than the border rule, U+2014 not U+2500)", () => {
+    expect(isBoxBorder("— quoted aside —")).toBe(false);
+  });
+
+  it("rejects an en-dash bullet (different glyph, and no trailing run at all)", () => {
+    expect(isBoxBorder("– list item")).toBe(false);
+  });
+
+  it("rejects a sentence that merely contains dashes", () => {
+    expect(isBoxBorder("foo — bar — baz")).toBe(false);
+    expect(isBoxBorder("This works — mostly — except here")).toBe(false);
+  });
+
+  it("rejects ASCII markdown rules (a different glyph than U+2500 entirely)", () => {
+    expect(isBoxBorder("---")).toBe(false);
+    expect(isBoxBorder("===")).toBe(false);
+    expect(isBoxBorder("--- some heading ---")).toBe(false);
+  });
+
+  // MUST-NOT cases, round 2 (post field-review): isBoxBorder used to delegate its bare-border check to
+  // isHorizontalRule, which is deliberately generic (menu.ts and the select detectors need its WIDE
+  // box-drawing/dash family) and strips ALL interior whitespace before testing. That combination was
+  // unsafe here: a spaced-out prose separator or a table divider could compact into "nothing but rule
+  // glyphs" and pass as an input-box border. isBoxBorder is now decoupled from isHorizontalRule and
+  // restricted to the ONE glyph (U+2500) Claude actually draws its input box with.
+  it("rejects a spaced-out em-dash separator (compacts to a rule under the old shared test)", () => {
+    expect(isBoxBorder("— — —")).toBe(false);
+  });
+
+  it("rejects a spaced-out CJK dash-label separator (horizontal bar U+2015, not U+2500)", () => {
+    expect(isBoxBorder("―― 中略 ――")).toBe(false);
+  });
+
+  it("rejects a spaced table divider (vertical bars, not the border glyph)", () => {
+    expect(isBoxBorder("│ │ │")).toBe(false);
+  });
+
+  it("rejects a labelled shape whose \"label\" is itself only more rule glyphs", () => {
+    expect(isBoxBorder("── ─ ──")).toBe(false);
+  });
+
+  it("rejects a labelled shape whose \"label\" is only whitespace", () => {
+    expect(isBoxBorder("──   ──")).toBe(false);
+  });
+
+  it("rejects a dialog border with corner glyphs — Claude never draws its input box that way", () => {
+    expect(isBoxBorder("╭──────╮")).toBe(false);
+    expect(isBoxBorder("╰──────╯")).toBe(false);
+  });
+});
+
+// Round-3 finding: traced against the bundled Claude Code renderer's own label-placement math, a
+// labelled top border can render with EITHER flank as short as ONE glyph (the renderer's own
+// `Math.max(1, …)` clamp) — isBoxBorder's 2-glyph floor is too strict for that specific line.
+// isInputBoxTopBorder is the ONLY place that looser floor applies (locateInputBox step (e)); every
+// other call site keeps isBoxBorder's stricter test.
+describe("isInputBoxTopBorder", () => {
+  it("accepts everything isBoxBorder already accepts", () => {
+    expect(isInputBoxTopBorder("─".repeat(19))).toBe(true);
+    expect(isInputBoxTopBorder("─".repeat(8))).toBe(true);
+    expect(isInputBoxTopBorder("───── japanese technical troubleshooting ──")).toBe(true);
+  });
+
+  it("accepts a labelled border with a 1-glyph RIGHT flank (renderer's align:center/end clamp)", () => {
+    expect(isInputBoxTopBorder("──── fast mode ─")).toBe(true);
+  });
+
+  it("accepts a labelled border with a 1-glyph LEFT flank", () => {
+    expect(isInputBoxTopBorder("─ fast mode ────")).toBe(true);
+  });
+
+  it("still rejects text that isn't the border glyph at all (wrong codepoint)", () => {
+    expect(isInputBoxTopBorder("— quoted aside —")).toBe(false); // em dash, not U+2500
+    expect(isInputBoxTopBorder("―― 中略 ――")).toBe(false); // horizontal bar, not U+2500
+    expect(isInputBoxTopBorder("│ │ │")).toBe(false); // vertical bar, not U+2500
+    expect(isInputBoxTopBorder("foo — bar — baz")).toBe(false);
+    expect(isInputBoxTopBorder("---")).toBe(false); // ASCII, not U+2500
+  });
+
+  it("still rejects a rule-only or whitespace-only \"label\" even with 1-glyph flanks", () => {
+    expect(isInputBoxTopBorder("─ ─ ─")).toBe(false); // the "label" is itself a rule glyph
+    expect(isInputBoxTopBorder("─   ─")).toBe(false); // the "label" is only whitespace
+  });
+
+  it("still rejects a corner-glyph dialog border", () => {
+    expect(isInputBoxTopBorder("╭──────╮")).toBe(false);
+  });
+});
+
+// Round-4 finding: a labelled border's per-flank minimums alone don't rule out a total width narrower
+// than any bare border the renderer can actually draw — the renderer draws a box's top and bottom
+// border at the SAME width, and the bare bottom border already requires >= BARE_BORDER_MIN (8), so a
+// labelled top border below that total is a physically impossible shape. Both isBoxBorder (2-glyph
+// flank floor) and isInputBoxTopBorder (1-glyph flank floor) share this width floor.
+describe("labelled borders below the shared total-width floor", () => {
+  it("rejects a 5-column labelled border by BOTH predicates, even at loose 1-glyph flanks", () => {
+    expect(isBoxBorder("─ x ─")).toBe(false);
+    expect(isInputBoxTopBorder("─ x ─")).toBe(false);
+  });
+
+  it("rejects a 7-column labelled border by BOTH predicates, even at strict 2-glyph flanks", () => {
+    expect(isBoxBorder("── x ──")).toBe(false);
+    expect(isInputBoxTopBorder("── x ──")).toBe(false);
+  });
+
+  it("accepts an 8-column labelled border (exactly at the floor) with strict 2-glyph flanks", () => {
+    expect(isBoxBorder("── ab ──")).toBe(true);
+    expect(isInputBoxTopBorder("── ab ──")).toBe(true);
+  });
+
+  it("accepts an 8-column labelled border with loose 1-glyph flanks, but ONLY via the loose predicate", () => {
+    expect(isBoxBorder("─ abcd ─")).toBe(false); // flanks are 1 glyph — isBoxBorder still wants 2
+    expect(isInputBoxTopBorder("─ abcd ─")).toBe(true); // meets the shared floor at 8 columns total
+  });
+
+  // Round-5 finding: the floor above must be measured in DISPLAY CELLS (text-width.ts's `displayWidth`),
+  // not UTF-16 `.length` — a CJK label undercounts in `.length` (1 code unit per glyph, 2 cells) and a
+  // combining-mark label overcounts (base + mark are 2 code units but render as ONE cell). CJK session
+  // labels are real in this deployment (observed live labels are sometimes Japanese), so the
+  // undercount direction is the one that actually bites: a legitimate 8-cell CJK-labelled border must
+  // not be rejected just because its `.length` reads as only 6.
+  it("accepts an 8-cell CJK-labelled border whose .length (6) reads under the floor", () => {
+    const border = "─ 中文 ─"; // 1 + 1 + 2 + 2 + 1 + 1 = 8 display cells, but .length is only 6
+    expect(border.length).toBe(6);
+    expect(isInputBoxTopBorder(border)).toBe(true); // 1-glyph flanks — loose predicate only
+  });
+
+  it("rejects a 6-cell CJK-labelled border by both predicates", () => {
+    const border = "─ 中 ─"; // 1 + 1 + 2 + 1 + 1 = 6 display cells
+    expect(isBoxBorder(border)).toBe(false);
+    expect(isInputBoxTopBorder(border)).toBe(false);
+  });
+
+  it("rejects a combining-mark label whose .length (8) reads at the floor but is really 7 cells", () => {
+    const border = "── é ──"; // "é" as base "e" + combining acute — one visual cell, two UTF-16 units
+    expect(border.length).toBe(8);
+    expect(isBoxBorder(border)).toBe(false);
+    expect(isInputBoxTopBorder(border)).toBe(false);
   });
 });
 

--- a/web/src/lib/harness/claude/markers.ts
+++ b/web/src/lib/harness/claude/markers.ts
@@ -5,6 +5,7 @@
 // separate styled segments). Pure functions, no I/O, no React.
 
 import { isBlank, lineText } from "../../blocks";
+import { displayWidth } from "../../text-width";
 import type { PromptFamily } from "../prompt-model";
 
 // `lineText` / `isBlank` are properties of a StyledLine, not of any grammar, so they live in the
@@ -24,15 +25,128 @@ export function isHorizontalRule(text: string): boolean {
   return compact.length >= 3 && RULE_ONLY.test(compact);
 }
 
-// A run of 20+ consecutive rule glyphs anywhere on the line — the signature of a TUI *box border*,
-// which (unlike a pure rule) can carry an embedded label: Claude's input-box top border reads e.g.
-// "──────────… collie upgrades ──". 20 unbroken box-drawing glyphs never occur in ordinary text, so
-// this stays a confident border test even with a label spliced in.
-const RULE_RUN = /[─-╿▁-▔‒-―]{20,}/;
+// A "bare" input-box border: the ONE glyph Claude actually draws its own input-box rules with — U+2500
+// (─) — repeated, nothing else, with NO interior whitespace stripped first (a real bare border has
+// none). Floor of 8 DISPLAY CELLS (terminal columns, via text-width.ts's `displayWidth`) —
+// comfortably below the narrowest observed real capture (19 columns), comfortably above a short
+// prose dash run. Cells, not UTF-16 `.length`: a session/job label spliced into a labelled border
+// can be CJK (real in this deployment — observed live labels are sometimes Japanese), and CJK
+// glyphs are 2 cells but 1 UTF-16 code unit each, so `.length` under-counts an 8-cell CJK-labelled
+// border into a false rejection; a combining-mark label goes the other way (`.length` counts the
+// base and its combining mark separately, `displayWidth` correctly counts the pair as the ONE cell
+// they render as), so `.length` can also over-count a narrower-than-8-cell border into a false
+// acceptance.
+const BARE_BORDER_MIN = 8;
+const BARE_BORDER = /^─+$/;
 
-/** True when the line contains a long unbroken run of rule glyphs (a box border, label or not). */
+// A LABELLED border: a run of U+2500, a label, a run of U+2500 again — the shape Claude splices a
+// session/job name into its input box's TOP border with, e.g.
+// "───── japanese technical troubleshooting ──" (observed flanks 5/2). Flanks are U+2500 ONLY (not
+// the wider rule-glyph family below) and each must be at least 2 glyphs. `isBoxBorder` additionally
+// requires the captured label to contain at least one character that is NEITHER a rule-class glyph
+// nor whitespace — a real word — so a middle of more rule glyphs and spaces ("── ─ ──") or bare
+// whitespace ("──   ──") does not count as a label.
+const LABELLED_BORDER = /^─{2,}\s+(.+)\s+─{2,}$/;
+
+// The generic rule-glyph class (same one isHorizontalRule tests) plus whitespace — used ONLY to
+// reject a LABELLED_BORDER match whose "label" turns out to be more rule glyphs/spaces, not prose.
+const RULE_OR_SPACE_ONLY = /^[─-╿▁-▔‒-―\s]*$/;
+
+// Both LABELLED_BORDER above and LOOSE_LABELLED_BORDER below are additionally required (in
+// isBoxBorder / isInputBoxTopBorder) to have a total DISPLAY WIDTH >= BARE_BORDER_MIN — the SAME
+// floor the bare border already enforces, not a separate, smaller one. The renderer draws a box's top
+// and bottom border at the same width, and the bare bottom border already has to clear
+// BARE_BORDER_MIN, so no real labelled TOP border can physically be narrower than that: a "labelled
+// border" shorter than the narrowest legal bare border (e.g. `─ x ─`, 5 columns) is not a shape the
+// renderer can produce, whatever its flank lengths look like in isolation — per-flank minimums alone
+// don't rule it out, only a shared total-width floor does. (A stronger version — checking a top
+// border's width against the ACTUAL bottom border captured at locateInputBox step (e) — was
+// considered and rejected: labels can hold CJK, so exact equality would need display-width
+// measurement here for only a marginal tightening over this shared floor — which is `displayWidth`
+// anyway, so this floor already pays that cost; see the CJK/combining-mark note on BARE_BORDER_MIN.)
+
+/**
+ * True when the line is specifically a CLAUDE INPUT-BOX border: the one glyph (U+2500) Claude draws
+ * its own box rules with, either bare (BARE_BORDER, any width ≥ BARE_BORDER_MIN) or carrying a single
+ * embedded label (LABELLED_BORDER, each flank ≥ 2 glyphs, with a label that isn't itself just more
+ * rule glyphs and whitespace).
+ *
+ * Deliberately DECOUPLED from `isHorizontalRule` above, which stays generic on purpose — menu.ts and
+ * the select detectors need its wider box-drawing/block-eighth/dash family to recognise a dialog's own
+ * rules. That generality is exactly what made an earlier version of THIS function unsafe: reusing
+ * isHorizontalRule here meant a spaced-out prose separator like "— — —" (isHorizontalRule strips ALL
+ * interior whitespace before testing, so it compacts to "———" and passes) or a `│ │ │` table divider
+ * would both read as an input-box border — letting a stray prose or table line pair up with an
+ * unrelated `❯` line elsewhere on screen to complete the FULL bottom-border → ❯ → top-border shape
+ * `locateInputBox` looks for, defeating that structural guard from the inside instead of being caught
+ * by it. Restricting to the single glyph Claude actually uses closes that hole. A dialog border with
+ * corner glyphs (`╭────╮`) is deliberately NOT an input-box border either — Claude never draws its
+ * input box that way, only its outer chrome/dialogs do, and conflating the two is the same class of
+ * mistake.
+ *
+ * This is layer one of two: the real protection is still structural, not lexical. `locateInputBox`
+ * (chrome.ts) only trusts a border when the full bottom-border → ❯ → top-border shape lines up around
+ * it (plus the draft-walk cap, MAX_DRAFT_LINES in chrome.ts, bounding how far apart the pieces of that
+ * shape may sit), so a lone matching line elsewhere on screen does nothing on its own.
+ */
 export function isBoxBorder(text: string): boolean {
-  return RULE_RUN.test(text);
+  const trimmed = text.trim();
+  // Shared width floor, in DISPLAY CELLS (see the comment above) — not `.length`, which a CJK label
+  // undercounts and a combining-mark label overcounts. For a pure-U+2500 bare border cells == `.length`
+  // (the glyph is 1 cell, 1 UTF-16 unit), so `displayWidth` here changes nothing for that branch; it's
+  // used uniformly with the labelled branch below rather than kept as two different measurements.
+  if (displayWidth(trimmed) < BARE_BORDER_MIN) return false;
+  if (BARE_BORDER.test(trimmed)) return true;
+  const m = LABELLED_BORDER.exec(trimmed);
+  if (m === null) return false;
+  return !RULE_OR_SPACE_ONLY.test(m[1]!); // label must hold a real (non-rule, non-blank) character
+}
+
+// The LOOSER labelled-border shape a Claude input-box TOP border can actually take, per the bundled
+// renderer's own label-placement math (traced from the shipped binary): it picks a left offset `a`
+// clamped `Math.max(1, Math.min(a, borderWidth - labelWidth - 1))` and draws `a` rule glyphs, the
+// label, then the remainder. That clamp's floor of 1 — not 2 — is what a real capture can render:
+// align:"center", or align:"end" with a zero offset, can leave EITHER flank at exactly one glyph
+// (`──── fast mode ─`). Everything else about the shape is unchanged from LABELLED_BORDER: flanks are
+// U+2500 only, the label must hold a real (non-rule, non-blank) character, and — same as
+// LABELLED_BORDER — the total DISPLAY WIDTH must still clear BARE_BORDER_MIN (see the comment on that
+// shared floor above): 1-glyph flanks alone are not enough, since `─ x ─` is 5 columns, narrower than
+// any bare border the renderer can actually draw.
+const LOOSE_LABELLED_BORDER = /^─{1,}\s+(.+)\s+─{1,}$/;
+
+/**
+ * True when the line is a Claude input-box TOP border: everything `isBoxBorder` accepts, plus a
+ * labelled border whose flanks are as short as 1 glyph (LOOSE_LABELLED_BORDER, still subject to the
+ * shared BARE_BORDER_MIN total-width floor) — the shape the renderer's own clamp can produce that
+ * `isBoxBorder`'s 2-glyph floor rejects.
+ *
+ * Used ONLY at `locateInputBox`'s step (e) — the LAST anchor it checks, after the bottom border, the
+ * "❯" prompt line, and the draft-walk cap (MAX_DRAFT_LINES, chrome.ts) have already pinned the rest of
+ * the shape down. That established structure is what pays for the looser floor here: a bare 1-glyph
+ * flank would be far too permissive on its own (a bullet-adjacent "─ text" is ordinary prose), but by
+ * the time step (e) runs, the only open question is whether THIS line, sitting immediately above an
+ * already-confirmed bottom-border→❯ pair (within the same cap), closes the box. `isBoxBorder` keeps
+ * its 2-glyph floor at every OTHER call site (chrome.ts steps a/b/c/d, and menu.ts) — none of them has
+ * that same backstop, so none of them gets the looser test. (Step (d)'s continuation walk in
+ * particular stops as soon as it reaches the "❯" line, before it would ever reach the top border at
+ * all, so it never needs this either.)
+ *
+ * One renderer shape is deliberately left unhandled: when the label is wide enough to overflow the
+ * border width, the renderer's own overflow branch drops the LEFT flank to zero width entirely and
+ * the "border" becomes bare label text with only a trailing rule run — there is no flank left on one
+ * side to test, so it is lexically indistinguishable from ordinary prose ending in a rule-ish run. That
+ * capture simply doesn't match here; `stripChrome` falls back to the raw mirror, which is safe (the
+ * reply guard's pre-flight blocks a send into what still looks like an unrecognised screen, with a
+ * `force` override the user can reach), just not a chrome strip.
+ */
+export function isInputBoxTopBorder(text: string): boolean {
+  if (isBoxBorder(text)) return true;
+  const trimmed = text.trim();
+  // Same shared width floor as isBoxBorder, in display cells — see that comment and BARE_BORDER_MIN.
+  if (displayWidth(trimmed) < BARE_BORDER_MIN) return false;
+  const m = LOOSE_LABELLED_BORDER.exec(trimmed);
+  if (m === null) return false;
+  return !RULE_OR_SPACE_ONLY.test(m[1]!);
 }
 
 // A MULTI-question AskUserQuestion renders a step indicator above the current question — one

--- a/web/src/lib/text-width.test.ts
+++ b/web/src/lib/text-width.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "vitest";
+
+import { displayWidth, WIDE_RANGES, COMBINING_RANGES } from "./text-width";
+
+describe("displayWidth", () => {
+  it("counts ASCII as one column each", () => {
+    expect(displayWidth("abc")).toBe(3);
+  });
+
+  it("counts CJK ideographs/kana as two columns each", () => {
+    expect(displayWidth("日本語")).toBe(6);
+  });
+
+  it("sums mixed ASCII + CJK correctly", () => {
+    expect(displayWidth("ab日本")).toBe(2 + 4);
+  });
+
+  it("counts a combining mark as zero width (rides on its base)", () => {
+    // "e" + COMBINING ACUTE ACCENT (U+0301) — one visual glyph, one base column.
+    expect(displayWidth("é")).toBe(1);
+  });
+
+  it("pins an Ambiguous-width glyph (→) at 1, not 2", () => {
+    // Unicode East Asian Width classifies U+2192 as Ambiguous (A), not Wide — this module treats
+    // every A glyph as narrow (module header). Pinned here so a future table edit that widens it
+    // is a deliberate, reviewed change.
+    expect(displayWidth("→")).toBe(1);
+  });
+});
+
+describe("displayWidth — East Asian Width boundary pins", () => {
+  // Both directions of every boundary, pinned by code point (String.fromCodePoint) rather than by
+  // pasting the literal glyph, so the test source stays readable and unambiguous about exactly
+  // which code point is under test.
+  const w = (cp: number) => displayWidth(String.fromCodePoint(cp));
+
+  it("Hangul Jamo: U+1100 wide, U+115F wide (inside), U+1160 narrow (just past)", () => {
+    expect(w(0x1100)).toBe(2);
+    expect(w(0x115f)).toBe(2);
+    expect(w(0x1160)).toBe(1);
+  });
+
+  it("Fullwidth Forms: U+FF00-FF60 wide, U+FF61+ (halfwidth forms) narrow", () => {
+    expect(w(0xff00)).toBe(2);
+    expect(w(0xff60)).toBe(2);
+    expect(w(0xff61)).toBe(1); // HALFWIDTH IDEOGRAPHIC FULL STOP — narrow by design
+  });
+
+  it("Fullwidth Signs: U+FFE0-FFE6 wide, just outside narrow", () => {
+    expect(w(0xffe0)).toBe(2);
+    expect(w(0xffe6)).toBe(2);
+    expect(w(0xffdf)).toBe(1);
+    expect(w(0xffe7)).toBe(1);
+  });
+
+  it("CJK Unified Ideographs Extension B..F (plane 2): U+20000-2FFFD wide", () => {
+    expect(w(0x20000)).toBe(2);
+    expect(w(0x2fffd)).toBe(2);
+    expect(w(0x1ffff)).toBe(1);
+    expect(w(0x2fffe)).toBe(1);
+  });
+
+  it("CJK Unified Ideographs Extension G (plane 3): U+30000-3FFFD wide", () => {
+    expect(w(0x30000)).toBe(2);
+    expect(w(0x3fffd)).toBe(2);
+  });
+
+  it("EAW=W misc symbols: U+231A-231B and U+2614-2615 wide", () => {
+    expect(w(0x231a)).toBe(2); // WATCH
+    expect(w(0x231b)).toBe(2); // HOURGLASS
+    expect(w(0x2614)).toBe(2); // UMBRELLA WITH RAIN DROPS
+    expect(w(0x2615)).toBe(2); // HOT BEVERAGE
+    expect(w(0x2319)).toBe(1); // just below 231A — narrow
+    expect(w(0x2616)).toBe(1); // just past 2615 — narrow
+  });
+
+  it("Vertical Forms U+FE10-FE19 and Small Form Variants U+FE50-FE6B are wide", () => {
+    expect(w(0xfe10)).toBe(2);
+    expect(w(0xfe19)).toBe(2);
+    expect(w(0xfe50)).toBe(2);
+    expect(w(0xfe6b)).toBe(2);
+  });
+
+  it("Hangul Jamo Extended-A U+A960-A97F is wide", () => {
+    expect(w(0xa960)).toBe(2);
+    expect(w(0xa97c)).toBe(2);
+  });
+
+  it("Kana Supplement / Nushu U+1B000+ is wide", () => {
+    expect(w(0x1b000)).toBe(2); // KATAKANA LETTER ARCHAIC E
+    expect(w(0x1b2fb)).toBe(2); // NUSHU CHARACTER-1B2FB
+  });
+
+  it("emoji sum to their rendered terminal width", () => {
+    expect(displayWidth("🎉🎉🎉")).toBe(6);
+  });
+
+  it("U+3099/U+309A (combining kana marks) are width 0 despite sitting inside a WIDE range", () => {
+    expect(w(0x3099)).toBe(0);
+    expect(w(0x309a)).toBe(0);
+  });
+});
+
+describe("WIDE_RANGES / COMBINING_RANGES — table integrity", () => {
+  // `inRanges`'s linear scan bails the moment `cp` is below the current range's floor — correct
+  // ONLY if the table is sorted ascending by lower bound. This pin exists so a future range added
+  // out of order (easy to do by hand in a 100+ entry table) fails loudly here instead of silently
+  // breaking lookups for every range after the misplaced one.
+  const assertSortedAndNonOverlapping = (ranges: ReadonlyArray<readonly [number, number]>) => {
+    for (let i = 1; i < ranges.length; i++) {
+      const [prevLo, prevHi] = ranges[i - 1]!;
+      const [lo, hi] = ranges[i]!;
+      expect(lo, `range ${i} (0x${lo.toString(16)}) is out of order after 0x${prevLo.toString(16)}`).toBeGreaterThanOrEqual(prevLo);
+      expect(hi, `range ${i} (0x${lo.toString(16)}-0x${hi.toString(16)}) is inverted`).toBeGreaterThanOrEqual(lo);
+      expect(lo, `range ${i} (0x${lo.toString(16)}) overlaps the previous range ending 0x${prevHi.toString(16)}`).toBeGreaterThan(prevHi);
+    }
+  };
+
+  it("WIDE_RANGES is sorted ascending and non-overlapping", () => {
+    assertSortedAndNonOverlapping(WIDE_RANGES);
+  });
+
+  it("COMBINING_RANGES is sorted ascending and non-overlapping", () => {
+    assertSortedAndNonOverlapping(COMBINING_RANGES);
+  });
+});

--- a/web/src/lib/text-width.ts
+++ b/web/src/lib/text-width.ts
@@ -1,0 +1,197 @@
+// East-Asian-aware display width — no dependency.
+//
+// A terminal lays CJK ideographs, Hangul, and fullwidth forms out at TWO column cells;
+// `String.prototype.length` (UTF-16 code units) and even a code-point count both disagree with
+// what the pane's own renderer did. `markers.ts` needs this to measure a candidate input-box
+// border in the same units Claude's renderer draws it in — a border's minimum width is a claim
+// about screen columns, not characters, and a CJK label (`─ 中文 ─`, 8 columns) or a combining-mark
+// label (`── é ──`, 7 columns when decomposed) gets that claim wrong in opposite directions if
+// measured by `.length`. The table below is written as explicit code-point ranges (no
+// `string-width`/`eastasianwidth` package) — it approximates the Unicode East Asian Width
+// property's Wide (W) and Fullwidth (F) categories, which is the same set most terminal emulators'
+// `wcwidth` implementations treat as double-width. Ambiguous (A) glyphs (→ × ※ …) are deliberately
+// left OUT of the wide table and so count as width 1.
+
+// MUST stay sorted ascending by lower bound — `inRanges`'s early-return scan depends on it (a test
+// below pins sortedness so a future edit can't silently break the lookup). Transcribed from
+// Unicode 17.0's EastAsianWidth.txt (https://www.unicode.org/Public/UCD/latest/ucd/EastAsianWidth.txt),
+// W and F categories only, restricted to the blocks a terminal actually renders double-width. The
+// Supplemental Symbols and Pictographs ranges (U+1F300 and up) are intentionally FRAGMENTED, not
+// one blanket span: the same blocks also contain plenty of explicitly-Narrow code points (arrows,
+// chess pieces, box-sextant glyphs, …) interleaved with the Wide emoji — collapsing them into one
+// range would silently mis-widen those. Gaps between consecutive Wide sub-ranges here are
+// reserved/narrow code points on purpose, not omissions.
+const WIDE_RANGES: ReadonlyArray<readonly [number, number]> = [
+  [0x1100, 0x115f], // Hangul Jamo
+  [0x231a, 0x231b],
+  [0x2329, 0x232a],
+  [0x23e9, 0x23ec],
+  [0x23f0, 0x23f0],
+  [0x23f3, 0x23f3],
+  [0x25fd, 0x25fe],
+  [0x2614, 0x2615],
+  [0x2630, 0x2637],
+  [0x2648, 0x2653],
+  [0x267f, 0x267f],
+  [0x268a, 0x268f],
+  [0x2693, 0x2693],
+  [0x26a1, 0x26a1],
+  [0x26aa, 0x26ab],
+  [0x26bd, 0x26be],
+  [0x26c4, 0x26c5],
+  [0x26ce, 0x26ce],
+  [0x26d4, 0x26d4],
+  [0x26ea, 0x26ea],
+  [0x26f2, 0x26f3],
+  [0x26f5, 0x26f5],
+  [0x26fa, 0x26fa],
+  [0x26fd, 0x26fd],
+  [0x2705, 0x2705],
+  [0x270a, 0x270b],
+  [0x2728, 0x2728],
+  [0x274c, 0x274c],
+  [0x274e, 0x274e],
+  [0x2753, 0x2755],
+  [0x2757, 0x2757],
+  [0x2795, 0x2797],
+  [0x27b0, 0x27b0],
+  [0x27bf, 0x27bf],
+  [0x2b1b, 0x2b1c],
+  [0x2b50, 0x2b50],
+  [0x2b55, 0x2b55],
+  [0x2e80, 0x303e], // CJK Radicals Supplement .. CJK Symbols and Punctuation (incl. U+3000-303E)
+  [0x3041, 0x33ff], // Hiragana, Katakana, Bopomofo, Hangul Compat Jamo, CJK strokes/compat
+  [0x3400, 0x4dbf], // CJK Unified Ideographs Extension A
+  [0x4e00, 0x9fff], // CJK Unified Ideographs
+  [0xa000, 0xa4cf], // Yi Syllables / Radicals
+  [0xa960, 0xa97c], // Hangul Jamo Extended-A
+  [0xac00, 0xd7a3], // Hangul Syllables
+  [0xf900, 0xfaff], // CJK Compatibility Ideographs
+  [0xfe10, 0xfe19], // Vertical Forms
+  [0xfe30, 0xfe4f], // CJK Compatibility Forms
+  [0xfe50, 0xfe52], // Small Form Variants (small punctuation, incl. small comma..full stop)
+  [0xfe54, 0xfe66], // Small Form Variants continued (small semicolon..equals sign)
+  [0xfe68, 0xfe6b], // Small Form Variants continued (small reverse solidus..commercial at)
+  [0xff00, 0xff60], // Fullwidth Forms
+  [0xffe0, 0xffe6], // Fullwidth Signs
+  [0x1b000, 0x1b122], // Kana Supplement .. Kana Extended-A (part 1)
+  [0x1b132, 0x1b132], // Hiragana small ko
+  [0x1b150, 0x1b152], // Small Kana Extension (hiragana wi/we/wo)
+  [0x1b155, 0x1b155], // Small Kana Extension (katakana small ko)
+  [0x1b164, 0x1b167], // Small Kana Extension (katakana wi/we/wo/n)
+  [0x1b170, 0x1b2fb], // Nushu
+  [0x1f004, 0x1f004], // Mahjong Tile Red Dragon
+  [0x1f0cf, 0x1f0cf], // Playing Card Black Joker
+  [0x1f18e, 0x1f18e], // Negative Squared AB
+  [0x1f191, 0x1f19a], // Squared Latin abbreviations (CL, WC, …)
+  [0x1f200, 0x1f202], // Squared Katakana / Hiragana
+  [0x1f210, 0x1f23b], // Squared CJK Unified Ideographs
+  [0x1f240, 0x1f248], // Tortoise-shell-bracketed CJK Unified Ideographs
+  [0x1f250, 0x1f251], // Circled Ideograph Advantage/Accept
+  [0x1f260, 0x1f265], // Rounded symbols
+  [0x1f300, 0x1f320], // Miscellaneous Symbols and Pictographs (part 1: weather/celestial)
+  [0x1f32d, 0x1f335], // (hot dog..cactus)
+  [0x1f337, 0x1f37c], // (tulip..baby bottle)
+  [0x1f37e, 0x1f393], // (bottle with popping cork..graduation cap)
+  [0x1f3a0, 0x1f3ca], // (carousel horse..swimmer)
+  [0x1f3cf, 0x1f3d3], // (cricket bat/ball..table tennis)
+  [0x1f3e0, 0x1f3f0], // (house..european castle)
+  [0x1f3f4, 0x1f3f4], // waving black flag
+  [0x1f3f8, 0x1f43e], // (badminton..paw prints, incl. Emoji Modifier Fitzpatrick skin tones)
+  [0x1f440, 0x1f440], // eyes
+  [0x1f442, 0x1f4fc], // (ear..videocassette)
+  [0x1f4ff, 0x1f53d], // (prayer beads..down-pointing red triangle)
+  [0x1f54b, 0x1f54e], // (kaaba..menorah)
+  [0x1f550, 0x1f567], // clock faces
+  [0x1f57a, 0x1f57a], // man dancing
+  [0x1f595, 0x1f596], // hand gestures
+  [0x1f5a4, 0x1f5a4], // black heart
+  [0x1f5fb, 0x1f64f], // (mount fuji..person with folded hands, incl. all face emoji)
+  [0x1f680, 0x1f6c5], // (rocket..left luggage)
+  [0x1f6cc, 0x1f6cc], // sleeping accommodation
+  [0x1f6d0, 0x1f6d2], // (place of worship..shopping trolley)
+  [0x1f6d5, 0x1f6d8], // (hindu temple..landslide)
+  [0x1f6dc, 0x1f6df], // (wireless..ring buoy)
+  [0x1f6eb, 0x1f6ec], // airplane departure/arriving
+  [0x1f6f4, 0x1f6fc], // (scooter..roller skate)
+  [0x1f7e0, 0x1f7eb], // large colored circles/squares
+  [0x1f7f0, 0x1f7f0], // heavy equals sign
+  [0x1f90c, 0x1f93a], // (pinched fingers..fencer)
+  [0x1f93c, 0x1f945], // (wrestlers..goal net)
+  [0x1f947, 0x1f9ff], // (medals..nazar amulet — most of Supplemental Symbols and Pictographs)
+  [0x1fa70, 0x1fa7c], // Symbols and Pictographs Extended-A (part 1)
+  [0x1fa80, 0x1fa8a], // (yo-yo..trombone)
+  [0x1fa8e, 0x1fac6], // (treasure chest..fingerprint)
+  [0x1fac8, 0x1fac8], // hairy creature
+  [0x1facd, 0x1fadc], // (orca..root vegetable)
+  [0x1fadf, 0x1faea], // (splatter..distorted face)
+  [0x1faef, 0x1faf8], // (fight cloud..rightwards pushing hand)
+  [0x20000, 0x2fffd], // CJK Unified Ideographs Extension B..F (plane 2)
+  [0x30000, 0x3fffd], // CJK Unified Ideographs Extension G (plane 3)
+];
+
+// Combining marks and zero-width formatting controls: these attach to (or sit invisibly beside) a
+// base character and add no column width of their own. Not exhaustive of Unicode's Mn/Cf
+// categories — a pragmatic set covering the diacritics and formatting controls that actually show
+// up in agent output (accented Latin, variation selectors, zero-width joiners/spaces).
+const COMBINING_RANGES: ReadonlyArray<readonly [number, number]> = [
+  [0x0300, 0x036f], // Combining Diacritical Marks
+  [0x1ab0, 0x1aff], // Combining Diacritical Marks Extended
+  [0x1dc0, 0x1dff], // Combining Diacritical Marks Supplement
+  [0x200b, 0x200f], // zero-width space, ZWJ/ZWNJ, directional marks
+  [0x2060, 0x2064], // word joiner, invisible math operators
+  [0x20d0, 0x20ff], // Combining Diacritical Marks for Symbols
+  [0x3099, 0x309a], // Combining Katakana-Hiragana Voiced/Semi-Voiced Sound Marks — sit INSIDE the
+  // Hiragana/Katakana WIDE range above (U+3041-33FF) but combine onto a base kana, so they must be
+  // checked (and win) before the wide-range test.
+  [0xfe00, 0xfe0f], // variation selectors
+  [0xfe20, 0xfe2f], // Combining Half Marks
+  [0xfeff, 0xfeff], // zero-width no-break space / BOM
+];
+
+// Ranges above are sorted ascending by lower bound, so a linear scan can bail the moment `cp` is
+// below the current range's floor — no code point in a later (higher) range could match either.
+function inRanges(cp: number, ranges: ReadonlyArray<readonly [number, number]>): boolean {
+  for (const [lo, hi] of ranges) {
+    if (cp < lo) return false;
+    if (cp <= hi) return true;
+  }
+  return false;
+}
+
+// `Intl.Segmenter` is the newest platform API this module depends on (Firefox 125, Safari 14.1).
+// Feature-detected: an engine without it must lose grapheme-cluster precision (falling back to
+// iterating code points, which still handles surrogate pairs correctly via `for...of`), never
+// white-screen the app at module-evaluation time.
+const GRAPHEMES =
+  typeof Intl !== "undefined" && typeof Intl.Segmenter === "function"
+    ? new Intl.Segmenter(undefined, { granularity: "grapheme" })
+    : null;
+
+function clusters(text: string): string[] {
+  if (GRAPHEMES === null) return [...text];
+  return [...GRAPHEMES.segment(text)].map((s) => s.segment);
+}
+
+// A cluster's width is its BASE code point's width — a combining mark riding along in the same
+// cluster (café's "é" as e + combining acute, under Intl.Segmenter) contributes nothing extra, and
+// a combining mark that arrives as its own "cluster" (no Segmenter, or a stray mark with no base)
+// correctly resolves to 0 via COMBINING_RANGES rather than falling through to the width-1 default.
+function clusterWidth(cluster: string): number {
+  const cp = cluster.codePointAt(0);
+  if (cp === undefined) return 0;
+  if (inRanges(cp, COMBINING_RANGES)) return 0;
+  if (inRanges(cp, WIDE_RANGES)) return 2;
+  return 1;
+}
+
+/** East-Asian-aware display width: W/F code points count 2 columns, combining marks 0, else 1.
+ *  Iterates grapheme clusters (feature-detected `Intl.Segmenter`, code points otherwise); a
+ *  cluster's width is its base code point's width. Ambiguous (A) glyphs count 1. */
+export function displayWidth(text: string): number {
+  let width = 0;
+  for (const cluster of clusters(text)) width += clusterWidth(cluster);
+  return width;
+}
+
+export { WIDE_RANGES, COMBINING_RANGES };

--- a/web/src/test/handlers.ts
+++ b/web/src/test/handlers.ts
@@ -129,7 +129,7 @@ export function resetTypedDraft(): void {
 export function recordReply(body: { text?: string; submit?: boolean }): void {
   typedDraft = body.submit ? "" : body.text ?? "";
 }
-// 40 box glyphs clears the 20-glyph border threshold in isBoxBorder (harness/claude/markers.ts).
+// 40 box glyphs is comfortably above isBoxBorder's BARE_BORDER_MIN floor (8, harness/claude/markers.ts).
 const BOX_RULE = "─".repeat(40);
 /**
  * `base` output with the current draft rendered inside a Claude-shaped input box below it. The box is


### PR DESCRIPTION
Fixes #76.

## The bug

The #34 guard locates Claude's input box by the shape `bottom border → ❯ prompt → top border` (`locateInputBox`, chrome.ts). Two of its premises fail on real screens, and both failures end the same way: the box is "not found", the typed text is verifiably sitting in it, and the submit key is withheld forever.

**1. `isBoxBorder` required 20+ consecutive rule glyphs.** That's a width assumption in disguise: Herdr's grid follows the narrowest attached client, so with a 70-col SSH client attached my split panes rendered 19-glyph borders — one short. A session label spliced into the top border (`───── my session name ──`, observed flanks 5/2) splits the run, so neither flank reaches 20 even on a normal pane.

**2. The wrapped-draft scan was capped at 12 lines.** CJK glyphs occupy two cells, so a 610-char / 25-line Japanese message wraps to ~40 rows on a narrow pane. The scan gave up before reaching `❯`, and the paste-placeholder fallback couldn't help either (it also needs a non-null draft).

## Why not just lower the number / raise the cap

Any absolute run-length threshold keeps the hidden width assumption — there is always a pane narrow enough to break it. And the 20-glyph test was doing double duty as false-positive protection, so simply lowering it would let prose separators (`— — —`), table dividers (`│ │ │`), and CJK dash idioms (`―― 中略 ――`) read as borders — during review we constructed a full permission-dialog buffer that completes the border→❯→border shape out of exactly those lines, which would point the submit key at a live dialog. The protection has to come from somewhere other than a big number.

## The fix

Three layers, each with one job:

- **Glyph + shape, not length** (`isBoxBorder`): a border is the one glyph Claude actually draws (U+2500) — bare at ≥ 8 display cells, or `──…── label ──…──` with ≥ 2-glyph flanks and a label containing at least one real (non-rule, non-space) character. Em-dash prose, corner-glyph dialog borders (`╭──╮`), and rule-only "labels" all fail on glyph or shape, at any width.
- **A looser test for the top border only** (`isInputBoxTopBorder`): Claude's own renderer clamps a label's placement to `Math.max(1, …)` (traced from the bundled binary), so a real top border can carry a 1-glyph flank (`──── fast mode ─`). Step (e) is the last anchor — the bottom border, the prompt line, and the walk budget are already established — so it alone affords the looser floor. The renderer's overflow shape (flank 0) is documented as deliberately unhandled: it's lexically indistinguishable from prose, and the raw-mirror fallback is safe.
- **A 100-line walk budget, blanks included** (was 12): defense-in-depth rather than a correctness bound — it covers the observed ~40 rows with margin while keeping a stray rule line from pairing with a quoted `❯` far across the read window. Blank padding draws from the same budget (a free blank-skip was a bypass).

Floors are measured in display cells, not UTF-16 units: a CJK label halves its char count (`─ 中文 ─` is 8 cells but `.length` 6) and combining marks inflate it (`── é ──` decomposed is `.length` 8 but 7 cells). The width helper (`text-width.ts`, new, self-contained) feature-detects `Intl.Segmenter` with a code-point fallback, per 46a85d1 — module-scope construction never throws on older engines.

Every bypass shape found during review is pinned as a must-not test (the fake dialog above, the 5-col `─ x ─` mini-border, its combining-mark variant, far-alignment past the budget), alongside positives for the 19-glyph bare border, the observed 5/2-flank labelled border, 1-glyph flanks, and a 640-char contiguous-Japanese draft wrapped to 40 rows and verified through `draftCarriesSend`'s fold-seam path.
