### PR TITLE
feat(mirror): clip long terminal rule rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to Collie are recorded here. The format follows
 `version` in `herdr-plugin.toml`, `package.json`, and `web/package.json` (enforced by
 `scripts/check-version.sh`). See [`CLAUDE.md`](./CLAUDE.md) → *Versioning* for the bump policy.
 
+## [0.25.1] - 2026-08-08
+
+### Changed
+
+- **Long terminal rule borders clip at the mirror edge** instead of wrapping into several rows; ordinary output keeps normal wrapping (ab23eb1)
+
 ## [0.25.0] - 2026-08-07
 
 ### Added

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,6 +1,6 @@
 id = "herdr.collie"
 name = "Collie"
-version = "0.25.0"
+version = "0.25.1"
 min_herdr_version = "0.7.0"
 description = "Mobile web UI to monitor and reply to your agent herd, served over Tailscale"
 platforms = ["linux", "macos"]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "collie",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "private": true,
   "license": "MIT",
   "description": "Collie — a mobile web UI to monitor and reply to your Herdr agent herd over Tailscale",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "collie-web",
-  "version": "0.25.0",
+  "version": "0.25.1",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/web/src/components/ansi-output.test.tsx
+++ b/web/src/components/ansi-output.test.tsx
@@ -69,6 +69,47 @@ describe("mirror line wrapping", () => {
     expect(cls).toContain("overflow-x-auto");
     expect(cls).not.toContain("whitespace-pre-wrap");
   });
+
+  it("keeps a marked ANSI border to one clipped row without changing its text, styles, links, or find offsets", () => {
+    const border = `  ${"─".repeat(20)}  `;
+    const text = `ordinary prose\n${ESC}[41m${border.slice(0, 12)}${ESC}[44m${border.slice(12)}${ESC}[0m\nsee https://herdr.dev/docs\n`;
+    const { container } = render(<AnsiOutput text={text} query="───" />);
+    const pre = container.querySelector("pre")!;
+    const clipped = pre.querySelector("span.inline-block")!;
+
+    expect(clipped.className).toContain("max-w-full");
+    expect(clipped.className).toContain("overflow-hidden");
+    // `overflow-hidden` gives an inline-block a bottom-edge baseline; align it to the line box's
+    // bottom so the border keeps the terminal grid's one-row line advance.
+    expect(clipped.className).toContain("align-bottom");
+    expect(clipped.className).toContain("whitespace-pre");
+    expect(clipped.className).not.toContain("whitespace-nowrap");
+    expect(clipped.className).toContain("break-normal");
+    expect(clipped.textContent).toBe(border);
+    expect(clipped.children).toHaveLength(2);
+    expect((clipped.children[0] as HTMLElement).style.backgroundColor).toBe("var(--ansi-1)");
+    expect((clipped.children[1] as HTMLElement).style.backgroundColor).toBe("var(--ansi-4)");
+    expect(clipped.querySelector("[data-find-match]")).not.toBeNull();
+    expect(pre.querySelector("a")?.textContent).toBe("https://herdr.dev/docs");
+    expect(pre.textContent).toBe(`ordinary prose\n${border}\nsee https://herdr.dev/docs\n`);
+  });
+
+  it("clips a plain border only while wrapping, leaving ordinary output and wrap-off panning alone", () => {
+    const border = `  ${"─".repeat(20)}  `;
+    const { container: plain } = render(<AnsiOutput text={`${border}\n`} />);
+    expect(plain.querySelector("span.inline-block")?.textContent).toBe(border);
+
+    const { container: wrapped } = render(<AnsiOutput text={`unbroken-${"x".repeat(40)}\n`} />);
+    const wrappedPre = wrapped.querySelector("pre")!;
+    expect(wrappedPre.className).toContain("break-words");
+    expect(wrappedPre.querySelector("span.inline-block")).toBeNull();
+
+    const { container: panned } = render(<AnsiOutput text={`${border}\n`} wrap={false} />);
+    const pannedPre = panned.querySelector("pre")!;
+    expect(pannedPre.className).toContain("overflow-x-auto");
+    expect(pannedPre.querySelector("span.inline-block")).toBeNull();
+    expect(pannedPre.textContent).toBe(`${border}\n`);
+  });
 });
 
 // URLs printed by an agent are plain characters — the mirror finds them and wraps those ranges in

--- a/web/src/components/ansi-output.tsx
+++ b/web/src/components/ansi-output.tsx
@@ -328,10 +328,15 @@ export const AnsiOutput = memo(function AnsiOutput({
               </span>
             );
           });
+          const content = line.noWrap && wrap ? (
+            <span className="inline-block max-w-full overflow-hidden align-bottom whitespace-pre break-normal">{segNodes}</span>
+          ) : (
+            segNodes
+          );
           return (
             <Fragment key={li}>
               {li > 0 ? "\n" : null}
-              {segNodes}
+              {content}
             </Fragment>
           );
         })}

--- a/web/src/lib/ansi.ts
+++ b/web/src/lib/ansi.ts
@@ -6,6 +6,8 @@
 
 import type { CSSProperties } from "react";
 
+import { BOX_DRAWING_RULE_GLYPH_CLASS, UNICODE_DASH_RULE_GLYPH_CLASS } from "./rule-glyphs";
+
 export interface AnsiSegment {
   text: string;
   // Raw SGR fields — preserved for testing/inspection and external consumers.
@@ -110,7 +112,7 @@ function applySgr(state: State, codes: number[]): void {
 // A segment that's nothing but box-drawing / horizontal-rule glyphs (ignoring spaces) — i.e. a TUI
 // border or separator, not real content. Conservative on purpose: only Unicode box-drawing and
 // dashes count (not ASCII `-`/`=`), so code and markdown rules in real output stay untouched.
-const RULE_GLYPHS = /^[─-╿‒-―]+$/;
+const RULE_GLYPHS = new RegExp(`^[${BOX_DRAWING_RULE_GLYPH_CLASS}${UNICODE_DASH_RULE_GLYPH_CLASS}]+$`);
 function checkMuted(text: string): boolean {
   const compact = text.replace(/\s+/g, "");
   return compact.length >= 2 && RULE_GLYPHS.test(compact);

--- a/web/src/lib/blocks.test.ts
+++ b/web/src/lib/blocks.test.ts
@@ -3,8 +3,9 @@ import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
 import { parseAnsi, type AnsiSegment } from "./ansi";
-import { splitLines, type StyledLine } from "./blocks";
+import { lineText, splitLines, type StyledLine } from "./blocks";
 import { buildBlocks } from "./harness";
+import { isHorizontalRule } from "./harness/claude/markers";
 
 // Anchored on this file's directory (not `new URL(import.meta.url)`, which Vite rewrites to an asset).
 const PANES_DIR = join(import.meta.dirname, "..", "fixtures", "panes");
@@ -101,6 +102,54 @@ describe("splitLines — exact text preservation", () => {
   });
 });
 
+describe("splitLines — no-wrap terminal borders", () => {
+  // This is the complete horizontal subset of the established Claude rule contract. Keep it
+  // independent from the clipping classifier so adding a Claude-accepted horizontal glyph cannot
+  // silently leave it wrapping. Corners, junctions, and vertical box drawing are deliberately absent.
+  const pureHorizontalRuleGlyphs = [
+    ..."─━┄┅┈┉╌╍═╴╶╸╺╼╾",
+    ...Array.from({ length: 0x2594 - 0x2581 + 1 }, (_, i) => String.fromCodePoint(0x2581 + i)),
+    ..."‒–—―",
+  ];
+
+  it("clips every established pure horizontal rule glyph only at the long-border threshold", () => {
+    for (const glyph of pureHorizontalRuleGlyphs) {
+      // Claude recognizes rules at three glyphs; visual clipping remains intentionally stricter.
+      expect(isHorizontalRule(glyph.repeat(3)), glyph).toBe(true);
+      expect(splitLines(parseAnsi(glyph.repeat(19)))[0]!.noWrap, glyph).toBeUndefined();
+      expect(splitLines(parseAnsi(glyph.repeat(20)))[0]!.noWrap, glyph).toBe(true);
+    }
+  });
+
+  it("marks an ANSI-segmented border", () => {
+    const border = "─".repeat(20);
+    const ansi = splitLines(parseAnsi(`${ESC}[31m${border.slice(0, 10)}${ESC}[34m${border.slice(10)}${ESC}[0m`))[0]!;
+
+    expect(ansi.noWrap).toBe(true);
+    expect(ansi.segments).toHaveLength(2);
+    expect(joinLines([ansi])).toBe(border);
+  });
+
+  it("requires the conservative 20-glyph border threshold", () => {
+    expect(splitLines(parseAnsi("─".repeat(19)))[0]!.noWrap).toBeUndefined();
+    expect(splitLines(parseAnsi("─".repeat(20)))[0]!.noWrap).toBe(true);
+  });
+
+  it.each([
+    ["short Unicode rule", "─".repeat(19)],
+    ["ASCII rule", "-".repeat(40)],
+    ["labeled border", `${"─".repeat(20)} Pi ${"─".repeat(20)}`],
+    ["mixed rule row", "─".repeat(19) + "╌"],
+    ["mixed content", `${"─".repeat(20)}x`],
+    ["corner row", "┌".repeat(40)],
+    ["vertical row", "│".repeat(40)],
+    ["table edge", `┌${"─".repeat(40)}┐`],
+    ["prose", "This ordinary prose should retain its normal wrapping behavior."],
+  ])("does not mark %s", (_name, text) => {
+    expect(splitLines(parseAnsi(text))[0]!.noWrap).toBeUndefined();
+  });
+});
+
 describe("splitLines — round-trips the parser's visible text (find coordinate space)", () => {
   const cases = [
     "hello world",
@@ -153,6 +202,16 @@ describe("buildBlocks — Claude grammars (ctx.agent === 'claude')", () => {
     expect(prompt.prompt.family).toBe("select");
     expect(prompt.prompt.options.map((o) => o.label)).toEqual(["Red", "Green", "Blue", "Chat about this"]);
     expect(blockText(prompt.lines)).toContain("Enter to select"); // the replaced footer lives here
+  });
+
+  it("keeps the plan fixture's long dashed separators as clipped raw rows", () => {
+    const blocks = buildBlocks(fixtureLines("claude--plan-approval.txt"), { agent: "claude" });
+    const raw = blocks[0]!;
+    if (raw.kind !== "raw") throw new Error("expected raw scrollback before the plan prompt");
+
+    const dashedRules = raw.lines.filter((line) => lineText(line).trim().startsWith("╌"));
+    expect(dashedRules).toHaveLength(2);
+    expect(dashedRules.every((line) => line.noWrap)).toBe(true);
   });
 
   it("strips trailing input-box chrome when there is no menu (single raw block)", () => {

--- a/web/src/lib/blocks.ts
+++ b/web/src/lib/blocks.ts
@@ -21,6 +21,7 @@
 // (find covers the raw mirror only).
 
 import type { AnsiSegment } from "./ansi";
+import { PURE_HORIZONTAL_RULE_GLYPH_CLASS } from "./rule-glyphs";
 import type { PromptModel } from "./harness/prompt-model";
 import type { WizardModel } from "./harness/wizard-model";
 import type { PreviewSelectModel } from "./harness/preview-model";
@@ -47,6 +48,8 @@ export type { MenuModel, MenuAction, MenuNav, MenuLeftRight } from "./harness/me
 /** One visual line: the styled segments that make it up, with the line-terminating "\n" removed. */
 export interface StyledLine {
   segments: AnsiSegment[];
+  /** Keep this known terminal-width border on one visual row when the mirror wraps. */
+  noWrap?: true;
 }
 
 /** A run of raw terminal output. Renders as verbatim styled text (the T1 mirror). */
@@ -154,7 +157,7 @@ export function splitLines(segments: AnsiSegment[]): StyledLine[] {
       const end = idx === -1 ? t.length : idx;
       if (end > start) current.push({ ...seg, text: t.slice(start, end) });
       if (idx === -1) break;
-      lines.push({ segments: current });
+      lines.push(styledLine(current));
       current = [];
       start = idx + 1;
     }
@@ -162,8 +165,22 @@ export function splitLines(segments: AnsiSegment[]): StyledLine[] {
 
   // The trailing run (after the last "\n", or the whole input if it had none) is the final line —
   // pushed even when empty so a trailing newline yields a terminating blank line.
-  lines.push({ segments: current });
+  lines.push(styledLine(current));
   return lines;
+}
+
+// A terminal-width horizontal border is visually useless when browser wrapping turns it into several rows.
+// This deliberately accepts only one repeated horizontal rule glyph (apart from terminal padding): labels,
+// mixed rows, corners/tables, prose, and ASCII rules keep the mirror's ordinary wrapping. Twenty glyphs
+// matches the conservative box-border safety threshold used by the terminal grammars.
+const MIN_NO_WRAP_BORDER_LENGTH = 20;
+const PURE_HORIZONTAL_BORDER = new RegExp(
+  `^([${PURE_HORIZONTAL_RULE_GLYPH_CLASS}])\\1{${MIN_NO_WRAP_BORDER_LENGTH - 1},}$`,
+);
+
+function styledLine(segments: AnsiSegment[]): StyledLine {
+  const text = segments.map((segment) => segment.text).join("");
+  return PURE_HORIZONTAL_BORDER.test(text.trim()) ? { segments, noWrap: true } : { segments };
 }
 
 // The two generic StyledLine probes. They live HERE, in the core AST module that imports nothing

--- a/web/src/lib/harness/claude/markers.ts
+++ b/web/src/lib/harness/claude/markers.ts
@@ -5,6 +5,7 @@
 // separate styled segments). Pure functions, no I/O, no React.
 
 import { isBlank, lineText } from "../../blocks";
+import { CLAUDE_RULE_GLYPH_CLASS } from "../../rule-glyphs";
 import type { PromptFamily } from "../prompt-model";
 
 // `lineText` / `isBlank` are properties of a StyledLine, not of any grammar, so they live in the
@@ -16,7 +17,7 @@ export { isBlank, lineText };
 // includes the dashed forms ╌ ╍ ┄ ┅ …), the block eighths used as rules (U+2581–U+2594, e.g. ▁ ▔),
 // and the figure/en/em/horizontal-bar dashes (U+2012–U+2015). ASCII `-`/`=` are deliberately
 // excluded so markdown and code rules in real agent output aren't mistaken for TUI separators.
-const RULE_ONLY = /^[─-╿▁-▔‒-―]+$/;
+const RULE_ONLY = new RegExp(`^[${CLAUDE_RULE_GLYPH_CLASS}]+$`);
 
 /** True when the whole line is a horizontal rule / separator (ignoring surrounding spaces). */
 export function isHorizontalRule(text: string): boolean {
@@ -28,7 +29,7 @@ export function isHorizontalRule(text: string): boolean {
 // which (unlike a pure rule) can carry an embedded label: Claude's input-box top border reads e.g.
 // "──────────… collie upgrades ──". 20 unbroken box-drawing glyphs never occur in ordinary text, so
 // this stays a confident border test even with a label spliced in.
-const RULE_RUN = /[─-╿▁-▔‒-―]{20,}/;
+const RULE_RUN = new RegExp(`[${CLAUDE_RULE_GLYPH_CLASS}]{20,}`);
 
 /** True when the line contains a long unbroken run of rule glyphs (a box border, label or not). */
 export function isBoxBorder(text: string): boolean {

--- a/web/src/lib/rule-glyphs.ts
+++ b/web/src/lib/rule-glyphs.ts
@@ -1,0 +1,22 @@
+// Shared Unicode rule-glyph classes. Claude's grammar intentionally retains its established broad
+// box-drawing contract; visual clipping narrows that to glyphs that are themselves horizontal, so
+// a repeated corner/junction can never be mistaken for a terminal-width border.
+
+/** All box-drawing glyphs accepted by the existing Claude horizontal-rule grammar. */
+export const BOX_DRAWING_RULE_GLYPH_CLASS = "─-╿";
+/** Block eighths used by terminal separators. */
+export const BLOCK_EIGHTH_RULE_GLYPH_CLASS = "▁-▔";
+/** Figure, en, em, and horizontal-bar dashes. ASCII hyphen remains deliberately excluded. */
+export const UNICODE_DASH_RULE_GLYPH_CLASS = "‒-―";
+
+/** The established Claude horizontal-rule contract. */
+export const CLAUDE_RULE_GLYPH_CLASS =
+  BOX_DRAWING_RULE_GLYPH_CLASS + BLOCK_EIGHTH_RULE_GLYPH_CLASS + UNICODE_DASH_RULE_GLYPH_CLASS;
+
+// Horizontal-only members of the box-drawing range: solid, dashed, and double horizontal rules.
+// Corners, junctions, and vertical strokes stay out even when repeated.
+const HORIZONTAL_BOX_RULE_GLYPH_CLASS = "─━┄┅┈┉╌╍═╴╶╸╺╼╾";
+
+/** Glyphs safe to classify as a repeated, standalone horizontal terminal border. */
+export const PURE_HORIZONTAL_RULE_GLYPH_CLASS =
+  HORIZONTAL_BOX_RULE_GLYPH_CLASS + BLOCK_EIGHTH_RULE_GLYPH_CLASS + UNICODE_DASH_RULE_GLYPH_CLASS;


### PR DESCRIPTION
## Summary

Prevent long horizontal terminal rules from wrapping into multiple visual rows on narrow mirror viewports. In wrap-on mode, independently classified rule rows are visually clipped at the mirror edge while their complete contents remain in the DOM.

## Motivation

Terminal-width separator rows can wrap repeatedly on smaller browser viewports, adding distracting visual height and making the surrounding output harder to read.

## Implementation and scope

- Classify a row only when its trimmed content contains at least 20 repetitions of one supported horizontal Unicode rule glyph.
- Preserve outer whitespace and the complete segmented text.
- Exclude ASCII rules, mixed-glyph rows, labels, prose, corners, junctions, vertical borders, and table edges.
- In wrap-on output, constrain only classified raw rows to the mirror width and hide their visual overflow.
- Preserve ANSI styling, links, find-match spans, selection, indentation, and full DOM text without adding an ellipsis.
- Leave ordinary output on its existing wrapping path.
- Leave wrap-off output column-faithful and horizontally pannable.

This is a generic browser-presentation change. It does not change PTY or backend behavior, terminal width, dependencies, input-box detection, or agent adapters.

## Release / compatibility

Includes synchronized `0.25.1` changelog and version metadata.

## Validation

Validated on candidate `3ed0ea7`:

- Root typecheck passed.
- Root tests passed: 534 tests, including control-script lifecycle coverage.
- Web typecheck passed, including the worker configuration.
- Web tests passed: 1,618 tests across 101 files.
- Focused coverage verifies classification boundaries, DOM text and ANSI-style preservation, links and find offsets, ordinary wrapping, and wrap-off panning.
- `scripts/check-version.sh` passed.
- `git diff --check` passed.
- Production build passed with build identity `0.25.1+3ed0ea7.1786218409`.
- Production-CSS validation passed across Chromium, Firefox, and Playwright WebKit at 240px and 2000px widths with 9px, 11px, and 12px fonts.

The browser matrix verified one-row clipping, containment, preserved DOM text and selection, ANSI styling, normal prose and link wrapping, the 19/20 classification threshold, and wrap-off horizontal panning. Playwright WebKit is not native Safari; native Safari and full end-to-end PWA rendering were not tested.
