### PR TITLE
test(ctl): keep resolve_bun inside the missing-tailscale sandbox

### DIFF
--- a/scripts/collie-ctl.test.sh
+++ b/scripts/collie-ctl.test.sh
@@ -196,6 +196,11 @@ test_missing_tailscale_cli() {
   setup_case tailscale-missing
   ln -s "$(command -v dirname)" "${BIN_DIR}/dirname"
   ln -s "$(command -v tr)" "${BIN_DIR}/tr"
+  # A stub bun keeps resolve_bun inside the sandbox. Without it, the absolute-path fallbacks find a
+  # real bun (e.g. /opt/homebrew/bin/bun) and prepend its directory to PATH — which on a Homebrew
+  # Mac also holds the real tailscale, so the "missing CLI" this test stages quietly reappears.
+  printf '#!/bin/sh\nexit 0\n' > "${BIN_DIR}/bun"
+  chmod +x "${BIN_DIR}/bun"
   cat > "${CONFIG_DIR}/.env" <<'EOF'
 COLLIE_PORT=8787
 EOF


### PR DESCRIPTION
## The bug

`test_missing_tailscale_cli` strips `tailscale` from PATH to stage a missing-CLI environment, then asserts `collie-ctl serve` fails. But `collie-ctl.sh`'s `resolve_bun` has absolute-path fallbacks: with no `bun` on the sandboxed PATH it finds a real one (e.g. `/opt/homebrew/bin/bun`) and prepends its directory to PATH — and on a Homebrew Mac that directory also holds the real `tailscale`, so the CLI the test just removed quietly reappears, `serve` succeeds, and the suite fails:

```
FAIL: missing Tailscale CLI reported success
```

Reproduces on any Mac with both bun and tailscale reachable through the fallback paths; CI (ubuntu, no tailscale anywhere) was never affected, which is why it hasn't shown up there.

## The fix

A stub `bun` inside the sandbox bin, so `resolve_bun` resolves without ever escaping the scratch PATH. Five lines, test-only; no behavior change to `collie-ctl.sh` itself.

Verified on the affected machine: root `bun run test` fails before, passes after (`collie-ctl lifecycle tests: passed`).
