### PR TITLE
fix(markdown): render GFM tables instead of collapsing them into a paragraph

### DIFF
--- a/web/src/components/markdown-text.tsx
+++ b/web/src/components/markdown-text.tsx
@@ -90,6 +90,12 @@ const HEADING_CLASS: Record<number, string> = {
   3: "text-sm font-semibold",
 };
 
+const ALIGN_CLASS: Record<string, string> = {
+  left: "text-left",
+  center: "text-center",
+  right: "text-right",
+};
+
 function Block({ block }: { block: MdBlock }) {
   switch (block.kind) {
     case "heading": {
@@ -126,6 +132,41 @@ function Block({ block }: { block: MdBlock }) {
         <blockquote className="border-l-2 pl-2.5 text-muted-foreground italic">
           <Spans spans={block.spans} />
         </blockquote>
+      );
+    case "table":
+      // Columns can't be made to fit a phone, so the table keeps its real widths and pans inside its
+      // own scroller — the same thing a mobile browser does with a table on any normal page.
+      return (
+        <div className="overflow-x-auto">
+          <table className="w-max border-collapse text-xs">
+            <thead>
+              <tr>
+                {block.header.map((cell, i) => (
+                  <th
+                    key={i}
+                    className={`border px-2 py-1 font-semibold ${ALIGN_CLASS[block.align[i] ?? "left"]}`}
+                  >
+                    <Spans spans={cell} />
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {block.rows.map((row, r) => (
+                <tr key={r}>
+                  {row.map((cell, c) => (
+                    <td
+                      key={c}
+                      className={`border px-2 py-1 align-top ${ALIGN_CLASS[block.align[c] ?? "left"]}`}
+                    >
+                      <Spans spans={cell} />
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
       );
     case "rule":
       return <hr className="border-border" />;

--- a/web/src/lib/markdown.test.ts
+++ b/web/src/lib/markdown.test.ts
@@ -214,6 +214,95 @@ describe("parseMarkdown", () => {
     ]);
   });
 
+  // Regression (#72): with no table branch, rows fell through to the paragraph branch, which joins
+  // lines with a space — a table arrived as one run-on line, the one unsupported construct that
+  // degraded into something unreadable rather than merely unformatted.
+  describe("tables", () => {
+    const text = (s: string) => ({ kind: "text", text: s });
+
+    it("parses the pipe-delimited form", () => {
+      const src = ["| Option | Cost |", "| --- | --- |", "| A | low |", "| B | high |"].join("\n");
+      expect(parseMarkdown(src)).toEqual([
+        {
+          kind: "table",
+          align: [null, null],
+          header: [[text("Option")], [text("Cost")]],
+          rows: [
+            [[text("A")], [text("low")]],
+            [[text("B")], [text("high")]],
+          ],
+        },
+      ]);
+    });
+
+    it("parses the form without outer pipes", () => {
+      const src = ["Option | Cost", "--- | ---", "A | low"].join("\n");
+      expect(parseMarkdown(src)).toEqual([
+        {
+          kind: "table",
+          align: [null, null],
+          header: [[text("Option")], [text("Cost")]],
+          rows: [[[text("A")], [text("low")]]],
+        },
+      ]);
+    });
+
+    it("reads column alignment off the delimiter row", () => {
+      const src = ["| l | c | r | n |", "| :-- | :-: | --: | --- |", "| 1 | 2 | 3 | 4 |"].join("\n");
+      const [table] = parseMarkdown(src);
+      expect(table).toMatchObject({ kind: "table", align: ["left", "center", "right", null] });
+    });
+
+    it("inline-parses cells", () => {
+      const src = ["| Flag | Default |", "|------|---------|", "| `--wrap` | **on** |"].join("\n");
+      const [table] = parseMarkdown(src);
+      expect(table).toMatchObject({
+        rows: [[[{ kind: "code", text: "--wrap" }], [{ kind: "bold", spans: [text("on")] }]]],
+      });
+    });
+
+    it("squares off ragged rows against the header", () => {
+      const src = ["| a | b |", "| --- | --- |", "| 1 |", "| 1 | 2 | 3 |"].join("\n");
+      const [table] = parseMarkdown(src);
+      expect(table).toMatchObject({
+        rows: [
+          [[text("1")], []],
+          [[text("1")], [text("2")]],
+        ],
+      });
+    });
+
+    it("treats an escaped pipe as a cell character, not a column break", () => {
+      const src = ["| a | b |", "| --- | --- |", "| x \\| y | z |"].join("\n");
+      const [table] = parseMarkdown(src);
+      expect(table).toMatchObject({ rows: [[[text("x | y")], [text("z")]]] });
+    });
+
+    // The delimiter row is the whole signal: a bare `---` is still a rule, and a paragraph that
+    // happens to contain a pipe is still a paragraph.
+    it("does not eat prose that merely contains a pipe", () => {
+      expect(parseMarkdown("run a | b\nthen c").map((b) => b.kind)).toEqual(["paragraph"]);
+      expect(parseMarkdown("---").map((b) => b.kind)).toEqual(["rule"]);
+    });
+
+    // GFM's own rule, and load-bearing rather than pedantic: without it any prose line holding a
+    // pipe, above any dashed line, becomes a two-column table split at that pipe.
+    it("refuses a delimiter row that doesn't match the header's width", () => {
+      const src = ["a | b | c", "--- | ---", "1 | 2 | 3"].join("\n");
+      expect(parseMarkdown(src).map((b) => b.kind)).toEqual(["paragraph"]);
+    });
+
+    it("refuses a delimiter cell that isn't dashes", () => {
+      expect(parseMarkdown("a | b\n--- | x").map((b) => b.kind)).toEqual(["paragraph"]);
+      expect(parseMarkdown("a | b\n--- | :").map((b) => b.kind)).toEqual(["paragraph"]);
+    });
+
+    it("ends the table at a blank line and starts after a paragraph", () => {
+      const src = ["intro", "| a |", "| --- |", "| 1 |", "", "after"].join("\n");
+      expect(parseMarkdown(src).map((b) => b.kind)).toEqual(["paragraph", "table", "paragraph"]);
+    });
+  });
+
   it("empty input yields no blocks", () => {
     expect(parseMarkdown("")).toEqual([]);
     expect(parseMarkdown("\n\n  \n")).toEqual([]);

--- a/web/src/lib/markdown.ts
+++ b/web/src/lib/markdown.ts
@@ -8,8 +8,12 @@
 // no dependency to a phone bundle that currently has seven.
 //
 // SCOPE. The subset agents actually emit: headings, fenced code, lists, blockquotes, rules,
-// paragraphs; inline bold/italic/code/links. Not GFM tables (they'd need real column layout on a
-// 400px screen — they render as literal text lines for now), not images, not HTML passthrough.
+// paragraphs, GFM tables; inline bold/italic/code/links. Not images, not HTML passthrough.
+//
+// FLAT BY DESIGN. Blocks don't nest: a table or a list inside a blockquote or a list item is read as
+// the outer block's text, so a quoted table still collapses into a run-on line. Closing that means a
+// recursive block parser, which is a different program from this one — and agents put tables at the
+// top level, where the collapse actually hurt (#72).
 //
 // TWO DELIBERATE OMISSIONS, both because this content is code-heavy:
 //  - `_underscore_` emphasis is NOT supported. It would mangle `snake_case_identifiers`, which
@@ -39,7 +43,14 @@ export type MdBlock =
   | { kind: "code"; lang: string; text: string }
   | { kind: "list"; ordered: boolean; items: MdSpan[][] }
   | { kind: "quote"; spans: MdSpan[] }
+  /**
+   * GFM table. `align` is one entry per column (null = unaligned), and every row is padded or
+   * truncated to that width so the renderer never has to reason about ragged input.
+   */
+  | { kind: "table"; align: MdAlign[]; header: MdSpan[][]; rows: MdSpan[][][] }
   | { kind: "rule" };
+
+export type MdAlign = "left" | "center" | "right" | null;
 
 // Only these schemes may become a real link. Everything else (javascript:, data:, vbscript:, or a
 // bare word) renders as plain text — a link is the one place this view could otherwise hand a URL
@@ -114,6 +125,73 @@ const RULE = /^\s*(?:-{3,}|\*{3,}|_{3,})\s*$/;
 const UL_ITEM = /^\s*[-*+]\s+(.*)$/;
 const OL_ITEM = /^\s*\d+[.)]\s+(.*)$/;
 const QUOTE = /^\s*>\s?(.*)$/;
+
+// A table is recognised by its DELIMITER row, never by the header alone: a line of prose containing
+// a pipe is common, `| --- | :-: |` under it is not. Both spellings agents emit are accepted —
+// with outer pipes and without — but the row must carry at least one pipe, so a bare `---` stays a
+// horizontal rule, and every cell must be dashes (optionally colon-flanked), so `|---|:` is not one.
+const TABLE_DELIM = /^\s*\|?(?:\s*:?-+:?\s*\|)+\s*(?::?-+:?\s*\|?)?\s*$/;
+
+/** Split one table row into raw cell strings. `\|` is an escaped pipe, not a column break. */
+function splitRow(line: string): string[] {
+  const cells: string[] = [];
+  let cur = "";
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i]!;
+    if (ch === "\\" && line[i + 1] === "|") {
+      cur += "|";
+      i++;
+    } else if (ch === "|") {
+      cells.push(cur);
+      cur = "";
+    } else cur += ch;
+  }
+  cells.push(cur);
+  // Outer pipes produce empty edge cells; they are punctuation, not columns.
+  if (cells.length > 1 && cells[0]!.trim() === "") cells.shift();
+  if (cells.length > 1 && cells[cells.length - 1]!.trim() === "") cells.pop();
+  return cells.map((c) => c.trim());
+}
+
+function parseAlign(line: string): MdAlign[] {
+  return splitRow(line).map((cell) => {
+    const left = cell.startsWith(":");
+    const right = cell.endsWith(":");
+    if (left && right) return "center";
+    if (right) return "right";
+    if (left) return "left";
+    return null;
+  });
+}
+
+/**
+ * Pad/truncate a BODY row to the header's width, so the renderer can assume a rectangle. Ragged body
+ * rows are legal GFM and agents emit them; a ragged delimiter row is not — see `startsTable`.
+ */
+function fitRow(line: string, width: number): MdSpan[][] {
+  const cells = splitRow(line)
+    .slice(0, width)
+    .map((cell) => parseInline(cell));
+  while (cells.length < width) cells.push([]);
+  return cells;
+}
+
+/**
+ * True when `line` opens a table — i.e. the line under it is a delimiter row of the SAME width.
+ *
+ * The width check is what GFM requires, and it is load-bearing here rather than pedantic: without
+ * it, any prose line containing a pipe that happens to sit above a dashed line becomes a table split
+ * at that pipe. Matching the spec keeps the false positives out.
+ *
+ * Two side doors remain, both rare enough to leave: a header that also parses as a list item
+ * (`1. Name | Value`) is claimed by the list branch, which runs first, and the body loop below takes
+ * any pipe-bearing line — so two tables with no blank line between them merge into one.
+ */
+const startsTable = (line: string, next: string | undefined) =>
+  line.includes("|") &&
+  next !== undefined &&
+  TABLE_DELIM.test(next) &&
+  splitRow(next).length === splitRow(line).length;
 
 /**
  * Parse Markdown into blocks. Pure — no React, no DOM — so the whole grammar is unit-testable and
@@ -190,6 +268,25 @@ export function parseMarkdown(source: string): MdBlock[] {
       continue;
     }
 
+    // Tables come last of the recognised blocks: every other construct wins a line that could be
+    // read as either, and a table is the only one that needs to look ahead.
+    if (startsTable(line, lines[i + 1])) {
+      const header = splitRow(line).map((cell) => parseInline(cell));
+      // Widths already match — `startsTable` refused the row otherwise — so the columns line up
+      // without padding either side.
+      const align = parseAlign(lines[i + 1]!);
+      i += 2;
+      const rows: MdSpan[][][] = [];
+      // The body runs until a blank line or anything that isn't a pipe row — a table that bumps
+      // into a heading or a fence ends there rather than swallowing it.
+      while (i < lines.length && lines[i]!.trim() !== "" && lines[i]!.includes("|")) {
+        rows.push(fitRow(lines[i]!, header.length));
+        i++;
+      }
+      blocks.push({ kind: "table", align, header, rows });
+      continue;
+    }
+
     // Paragraph: consecutive lines until a blank or a line that starts some other block. Joined with
     // a space, since a hard-wrapped paragraph should reflow to the phone's width, not keep its
     // source line breaks.
@@ -202,7 +299,8 @@ export function parseMarkdown(source: string): MdBlock[] {
         FENCE.test(l) ||
         RULE.test(l) ||
         QUOTE.test(l) ||
-        isItem(l)
+        isItem(l) ||
+        startsTable(l, lines[i + 1])
       )
         break;
       para.push(l.trim());


### PR DESCRIPTION
Closes #72.

Table rows had no branch in the block parser, so they fell into the paragraph branch — which joins consecutive lines with a space, so a table lost its line boundaries entirely and arrived as one run-on line. Every other unsupported construct degrades to something still readable; this one did not.

**What changed**

- `MdBlock` gains a `table` kind (`align`, `header`, `rows`); the renderer maps it to a real `<table>` in an `overflow-x-auto` scroller, so wide columns pan rather than squeeze. Still AST → elements — no HTML string is built, so the text-nodes-only boundary holds.
- Recognition hangs on the **delimiter row**, never the header, and the two rows must be the **same width** — GFM's own rule, and load-bearing: without it any prose line holding a pipe, above any dashed line, becomes a two-column table split at that pipe.
- Both spellings agents emit (with and without outer pipes), alignment from `:--`/`:-:`/`--:`, `\|` stays a cell character, ragged *body* rows (legal GFM) squared off to the header width.

**Deliberately left out:** blocks still don't nest, so a table inside a blockquote or list item collapses as before — that needs a recursive block parser, a different program from this one. Agents put tables at the top level, which is where the collapse actually hurt. Recorded in the SCOPE header rather than left to be rediscovered.

11 new tests. No version bump here — the release commit that ships this will carry it.

Thanks @OowhitecatoO for the precise report, including the three spellings and the reason the delimiter row never reached `RULE`.