### PR TITLE
feat(mirror): clip long terminal rule rows (completes #79)

### DIFF
--- a/web/src/components/ansi-output.test.tsx
+++ b/web/src/components/ansi-output.test.tsx
@@ -69,6 +69,47 @@ describe("mirror line wrapping", () => {
     expect(cls).toContain("overflow-x-auto");
     expect(cls).not.toContain("whitespace-pre-wrap");
   });
+
+  it("keeps a marked ANSI border to one clipped row without changing its text, styles, links, or find offsets", () => {
+    const border = `  ${"─".repeat(20)}  `;
+    const text = `ordinary prose\n${ESC}[41m${border.slice(0, 12)}${ESC}[44m${border.slice(12)}${ESC}[0m\nsee https://herdr.dev/docs\n`;
+    const { container } = render(<AnsiOutput text={text} query="───" />);
+    const pre = container.querySelector("pre")!;
+    const clipped = pre.querySelector("span.inline-block")!;
+
+    expect(clipped.className).toContain("max-w-full");
+    expect(clipped.className).toContain("overflow-hidden");
+    // `overflow-hidden` gives an inline-block a bottom-edge baseline; align it to the line box's
+    // bottom so the border keeps the terminal grid's one-row line advance.
+    expect(clipped.className).toContain("align-bottom");
+    expect(clipped.className).toContain("whitespace-pre");
+    expect(clipped.className).not.toContain("whitespace-nowrap");
+    expect(clipped.className).toContain("break-normal");
+    expect(clipped.textContent).toBe(border);
+    expect(clipped.children).toHaveLength(2);
+    expect((clipped.children[0] as HTMLElement).style.backgroundColor).toBe("var(--ansi-1)");
+    expect((clipped.children[1] as HTMLElement).style.backgroundColor).toBe("var(--ansi-4)");
+    expect(clipped.querySelector("[data-find-match]")).not.toBeNull();
+    expect(pre.querySelector("a")?.textContent).toBe("https://herdr.dev/docs");
+    expect(pre.textContent).toBe(`ordinary prose\n${border}\nsee https://herdr.dev/docs\n`);
+  });
+
+  it("clips a plain border only while wrapping, leaving ordinary output and wrap-off panning alone", () => {
+    const border = `  ${"─".repeat(20)}  `;
+    const { container: plain } = render(<AnsiOutput text={`${border}\n`} />);
+    expect(plain.querySelector("span.inline-block")?.textContent).toBe(border);
+
+    const { container: wrapped } = render(<AnsiOutput text={`unbroken-${"x".repeat(40)}\n`} />);
+    const wrappedPre = wrapped.querySelector("pre")!;
+    expect(wrappedPre.className).toContain("break-words");
+    expect(wrappedPre.querySelector("span.inline-block")).toBeNull();
+
+    const { container: panned } = render(<AnsiOutput text={`${border}\n`} wrap={false} />);
+    const pannedPre = panned.querySelector("pre")!;
+    expect(pannedPre.className).toContain("overflow-x-auto");
+    expect(pannedPre.querySelector("span.inline-block")).toBeNull();
+    expect(pannedPre.textContent).toBe(`${border}\n`);
+  });
 });
 
 // URLs printed by an agent are plain characters — the mirror finds them and wraps those ranges in

--- a/web/src/components/ansi-output.tsx
+++ b/web/src/components/ansi-output.tsx
@@ -328,10 +328,15 @@ export const AnsiOutput = memo(function AnsiOutput({
               </span>
             );
           });
+          const content = line.noWrap && wrap ? (
+            <span className="inline-block max-w-full overflow-hidden align-bottom whitespace-pre break-normal">{segNodes}</span>
+          ) : (
+            segNodes
+          );
           return (
             <Fragment key={li}>
               {li > 0 ? "\n" : null}
-              {segNodes}
+              {content}
             </Fragment>
           );
         })}

--- a/web/src/lib/ansi.ts
+++ b/web/src/lib/ansi.ts
@@ -6,6 +6,8 @@
 
 import type { CSSProperties } from "react";
 
+import { BOX_DRAWING_RULE_GLYPH_CLASS, UNICODE_DASH_RULE_GLYPH_CLASS } from "./rule-glyphs";
+
 export interface AnsiSegment {
   text: string;
   // Raw SGR fields — preserved for testing/inspection and external consumers.
@@ -110,7 +112,7 @@ function applySgr(state: State, codes: number[]): void {
 // A segment that's nothing but box-drawing / horizontal-rule glyphs (ignoring spaces) — i.e. a TUI
 // border or separator, not real content. Conservative on purpose: only Unicode box-drawing and
 // dashes count (not ASCII `-`/`=`), so code and markdown rules in real output stay untouched.
-const RULE_GLYPHS = /^[─-╿‒-―]+$/;
+const RULE_GLYPHS = new RegExp(`^[${BOX_DRAWING_RULE_GLYPH_CLASS}${UNICODE_DASH_RULE_GLYPH_CLASS}]+$`);
 function checkMuted(text: string): boolean {
   const compact = text.replace(/\s+/g, "");
   return compact.length >= 2 && RULE_GLYPHS.test(compact);

--- a/web/src/lib/blocks.test.ts
+++ b/web/src/lib/blocks.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, it } from "vitest";
 import { parseAnsi, type AnsiSegment } from "./ansi";
 import { lineText, splitLines, type StyledLine } from "./blocks";
 import { buildBlocks } from "./harness";
-import { isHorizontalRule } from "./harness/claude/markers";
+import { isBoxBorder, isHorizontalRule } from "./harness/claude/markers";
 
 // Anchored on this file's directory (not `new URL(import.meta.url)`, which Vite rewrites to an asset).
 const PANES_DIR = join(import.meta.dirname, "..", "fixtures", "panes");
@@ -130,9 +130,19 @@ describe("splitLines — no-wrap terminal borders", () => {
     expect(joinLines([ansi])).toBe(border);
   });
 
-  it("requires the conservative 20-glyph border threshold", () => {
+  it("clips at twenty glyphs and not below", () => {
     expect(splitLines(parseAnsi("─".repeat(19)))[0]!.noWrap).toBeUndefined();
     expect(splitLines(parseAnsi("─".repeat(20)))[0]!.noWrap).toBe(true);
+  });
+
+  // The clip rule and the input-box grammar both call a line a "border", for different consumers
+  // (see rule-glyphs.ts). A labelled border is the case where they must visibly disagree: the guard
+  // has to recognise it, and clipping it would crop the session label out of view. Pinned across
+  // both modules so a future edit to either cannot quietly align them.
+  it("never clips a labelled input-box border the guard depends on", () => {
+    const labelled = `${"─".repeat(20)} japanese technical troubleshooting ${"─".repeat(2)}`;
+    expect(isBoxBorder(labelled)).toBe(true);
+    expect(splitLines(parseAnsi(labelled))[0]!.noWrap).toBeUndefined();
   });
 
   it.each([

--- a/web/src/lib/blocks.test.ts
+++ b/web/src/lib/blocks.test.ts
@@ -3,8 +3,9 @@ import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
 import { parseAnsi, type AnsiSegment } from "./ansi";
-import { splitLines, type StyledLine } from "./blocks";
+import { lineText, splitLines, type StyledLine } from "./blocks";
 import { buildBlocks } from "./harness";
+import { isHorizontalRule } from "./harness/claude/markers";
 
 // Anchored on this file's directory (not `new URL(import.meta.url)`, which Vite rewrites to an asset).
 const PANES_DIR = join(import.meta.dirname, "..", "fixtures", "panes");
@@ -101,6 +102,54 @@ describe("splitLines — exact text preservation", () => {
   });
 });
 
+describe("splitLines — no-wrap terminal borders", () => {
+  // This is the complete horizontal subset of the established Claude rule contract. Keep it
+  // independent from the clipping classifier so adding a Claude-accepted horizontal glyph cannot
+  // silently leave it wrapping. Corners, junctions, and vertical box drawing are deliberately absent.
+  const pureHorizontalRuleGlyphs = [
+    ..."─━┄┅┈┉╌╍═╴╶╸╺╼╾",
+    ...Array.from({ length: 0x2594 - 0x2581 + 1 }, (_, i) => String.fromCodePoint(0x2581 + i)),
+    ..."‒–—―",
+  ];
+
+  it("clips every established pure horizontal rule glyph only at the long-border threshold", () => {
+    for (const glyph of pureHorizontalRuleGlyphs) {
+      // Claude recognizes rules at three glyphs; visual clipping remains intentionally stricter.
+      expect(isHorizontalRule(glyph.repeat(3)), glyph).toBe(true);
+      expect(splitLines(parseAnsi(glyph.repeat(19)))[0]!.noWrap, glyph).toBeUndefined();
+      expect(splitLines(parseAnsi(glyph.repeat(20)))[0]!.noWrap, glyph).toBe(true);
+    }
+  });
+
+  it("marks an ANSI-segmented border", () => {
+    const border = "─".repeat(20);
+    const ansi = splitLines(parseAnsi(`${ESC}[31m${border.slice(0, 10)}${ESC}[34m${border.slice(10)}${ESC}[0m`))[0]!;
+
+    expect(ansi.noWrap).toBe(true);
+    expect(ansi.segments).toHaveLength(2);
+    expect(joinLines([ansi])).toBe(border);
+  });
+
+  it("requires the conservative 20-glyph border threshold", () => {
+    expect(splitLines(parseAnsi("─".repeat(19)))[0]!.noWrap).toBeUndefined();
+    expect(splitLines(parseAnsi("─".repeat(20)))[0]!.noWrap).toBe(true);
+  });
+
+  it.each([
+    ["short Unicode rule", "─".repeat(19)],
+    ["ASCII rule", "-".repeat(40)],
+    ["labeled border", `${"─".repeat(20)} Pi ${"─".repeat(20)}`],
+    ["mixed rule row", "─".repeat(19) + "╌"],
+    ["mixed content", `${"─".repeat(20)}x`],
+    ["corner row", "┌".repeat(40)],
+    ["vertical row", "│".repeat(40)],
+    ["table edge", `┌${"─".repeat(40)}┐`],
+    ["prose", "This ordinary prose should retain its normal wrapping behavior."],
+  ])("does not mark %s", (_name, text) => {
+    expect(splitLines(parseAnsi(text))[0]!.noWrap).toBeUndefined();
+  });
+});
+
 describe("splitLines — round-trips the parser's visible text (find coordinate space)", () => {
   const cases = [
     "hello world",
@@ -153,6 +202,16 @@ describe("buildBlocks — Claude grammars (ctx.agent === 'claude')", () => {
     expect(prompt.prompt.family).toBe("select");
     expect(prompt.prompt.options.map((o) => o.label)).toEqual(["Red", "Green", "Blue", "Chat about this"]);
     expect(blockText(prompt.lines)).toContain("Enter to select"); // the replaced footer lives here
+  });
+
+  it("keeps the plan fixture's long dashed separators as clipped raw rows", () => {
+    const blocks = buildBlocks(fixtureLines("claude--plan-approval.txt"), { agent: "claude" });
+    const raw = blocks[0]!;
+    if (raw.kind !== "raw") throw new Error("expected raw scrollback before the plan prompt");
+
+    const dashedRules = raw.lines.filter((line) => lineText(line).trim().startsWith("╌"));
+    expect(dashedRules).toHaveLength(2);
+    expect(dashedRules.every((line) => line.noWrap)).toBe(true);
   });
 
   it("strips trailing input-box chrome when there is no menu (single raw block)", () => {

--- a/web/src/lib/blocks.ts
+++ b/web/src/lib/blocks.ts
@@ -171,8 +171,19 @@ export function splitLines(segments: AnsiSegment[]): StyledLine[] {
 
 // A terminal-width horizontal border is visually useless when browser wrapping turns it into several rows.
 // This deliberately accepts only one repeated horizontal rule glyph (apart from terminal padding): labels,
-// mixed rows, corners/tables, prose, and ASCII rules keep the mirror's ordinary wrapping. Twenty glyphs
-// matches the conservative box-border safety threshold used by the terminal grammars.
+// mixed rows, corners/tables, prose, and ASCII rules keep the mirror's ordinary wrapping.
+//
+// Twenty stands on two facts of its own, and deliberately cites no other threshold. (1) Nothing in prose,
+// markdown or code runs to twenty IDENTICAL rule glyphs, so the classifier cannot fire on real content.
+// (2) Below roughly twenty columns a row already fits the narrowest mirror without wrapping, so clipping
+// it would buy nothing — the only rows worth clipping are the ones wide enough to wrap.
+//
+// An earlier revision derived this number from the Claude grammar's own 20-glyph box-border run. That run
+// no longer exists: it was a hidden assumption that the pane is at least twenty columns wide, which is
+// exactly what stalled the reply guard on a 19-column pane (issue #76), and markers.ts replaced it with a
+// display-cell floor. Do not re-couple the two. They classify borders for different consumers with
+// opposite failure costs — a false positive there types Enter into the wrong screen, a false positive here
+// crops a short rule — so they share the glyph alphabet in rule-glyphs.ts and nothing else.
 const MIN_NO_WRAP_BORDER_LENGTH = 20;
 const PURE_HORIZONTAL_BORDER = new RegExp(
   `^([${PURE_HORIZONTAL_RULE_GLYPH_CLASS}])\\1{${MIN_NO_WRAP_BORDER_LENGTH - 1},}$`,

--- a/web/src/lib/blocks.ts
+++ b/web/src/lib/blocks.ts
@@ -21,6 +21,7 @@
 // (find covers the raw mirror only).
 
 import type { AnsiSegment } from "./ansi";
+import { PURE_HORIZONTAL_RULE_GLYPH_CLASS } from "./rule-glyphs";
 import type { PromptModel } from "./harness/prompt-model";
 import type { WizardModel } from "./harness/wizard-model";
 import type { PreviewSelectModel } from "./harness/preview-model";
@@ -47,6 +48,8 @@ export type { MenuModel, MenuAction, MenuNav, MenuLeftRight } from "./harness/me
 /** One visual line: the styled segments that make it up, with the line-terminating "\n" removed. */
 export interface StyledLine {
   segments: AnsiSegment[];
+  /** Keep this known terminal-width border on one visual row when the mirror wraps. */
+  noWrap?: true;
 }
 
 /** A run of raw terminal output. Renders as verbatim styled text (the T1 mirror). */
@@ -154,7 +157,7 @@ export function splitLines(segments: AnsiSegment[]): StyledLine[] {
       const end = idx === -1 ? t.length : idx;
       if (end > start) current.push({ ...seg, text: t.slice(start, end) });
       if (idx === -1) break;
-      lines.push({ segments: current });
+      lines.push(styledLine(current));
       current = [];
       start = idx + 1;
     }
@@ -162,8 +165,22 @@ export function splitLines(segments: AnsiSegment[]): StyledLine[] {
 
   // The trailing run (after the last "\n", or the whole input if it had none) is the final line —
   // pushed even when empty so a trailing newline yields a terminating blank line.
-  lines.push({ segments: current });
+  lines.push(styledLine(current));
   return lines;
+}
+
+// A terminal-width horizontal border is visually useless when browser wrapping turns it into several rows.
+// This deliberately accepts only one repeated horizontal rule glyph (apart from terminal padding): labels,
+// mixed rows, corners/tables, prose, and ASCII rules keep the mirror's ordinary wrapping. Twenty glyphs
+// matches the conservative box-border safety threshold used by the terminal grammars.
+const MIN_NO_WRAP_BORDER_LENGTH = 20;
+const PURE_HORIZONTAL_BORDER = new RegExp(
+  `^([${PURE_HORIZONTAL_RULE_GLYPH_CLASS}])\\1{${MIN_NO_WRAP_BORDER_LENGTH - 1},}$`,
+);
+
+function styledLine(segments: AnsiSegment[]): StyledLine {
+  const text = segments.map((segment) => segment.text).join("");
+  return PURE_HORIZONTAL_BORDER.test(text.trim()) ? { segments, noWrap: true } : { segments };
 }
 
 // The two generic StyledLine probes. They live HERE, in the core AST module that imports nothing

--- a/web/src/lib/harness/claude/markers.ts
+++ b/web/src/lib/harness/claude/markers.ts
@@ -5,6 +5,7 @@
 // separate styled segments). Pure functions, no I/O, no React.
 
 import { isBlank, lineText } from "../../blocks";
+import { CLAUDE_RULE_GLYPH_CLASS } from "../../rule-glyphs";
 import { displayWidth } from "../../text-width";
 import type { PromptFamily } from "../prompt-model";
 
@@ -17,7 +18,7 @@ export { isBlank, lineText };
 // includes the dashed forms ╌ ╍ ┄ ┅ …), the block eighths used as rules (U+2581–U+2594, e.g. ▁ ▔),
 // and the figure/en/em/horizontal-bar dashes (U+2012–U+2015). ASCII `-`/`=` are deliberately
 // excluded so markdown and code rules in real agent output aren't mistaken for TUI separators.
-const RULE_ONLY = /^[─-╿▁-▔‒-―]+$/;
+const RULE_ONLY = new RegExp(`^[${CLAUDE_RULE_GLYPH_CLASS}]+$`);
 
 /** True when the whole line is a horizontal rule / separator (ignoring surrounding spaces). */
 export function isHorizontalRule(text: string): boolean {

--- a/web/src/lib/harness/claude/markers.ts
+++ b/web/src/lib/harness/claude/markers.ts
@@ -51,7 +51,7 @@ const LABELLED_BORDER = /^─{2,}\s+(.+)\s+─{2,}$/;
 
 // The generic rule-glyph class (same one isHorizontalRule tests) plus whitespace — used ONLY to
 // reject a LABELLED_BORDER match whose "label" turns out to be more rule glyphs/spaces, not prose.
-const RULE_OR_SPACE_ONLY = /^[─-╿▁-▔‒-―\s]*$/;
+const RULE_OR_SPACE_ONLY = new RegExp(`^[${CLAUDE_RULE_GLYPH_CLASS}\\s]*$`);
 
 // Both LABELLED_BORDER above and LOOSE_LABELLED_BORDER below are additionally required (in
 // isBoxBorder / isInputBoxTopBorder) to have a total DISPLAY WIDTH >= BARE_BORDER_MIN — the SAME

--- a/web/src/lib/rule-glyphs.ts
+++ b/web/src/lib/rule-glyphs.ts
@@ -1,6 +1,23 @@
 // Shared Unicode rule-glyph classes. Claude's grammar intentionally retains its established broad
 // box-drawing contract; visual clipping narrows that to glyphs that are themselves horizontal, so
 // a repeated corner/junction can never be mistaken for a terminal-width border.
+//
+// THIS FILE IS THE WHOLE SHARED SURFACE, AND IT IS MEANT TO STAY THAT WAY. Two things in this
+// codebase decide whether a line is a border, and the obvious tidy-up — one predicate, one
+// threshold — is the change to refuse:
+//
+//   · `markers.ts` (isBoxBorder / isInputBoxTopBorder) asks whether this is CLAUDE'S INPUT BOX, to
+//     decide whether the reply guard may press Enter. Its false positive types a message into a
+//     screen that is not the input box. It is therefore the narrowest possible test — U+2500 only,
+//     floored in display cells — and not one of these constants.
+//   · `blocks.ts` (PURE_HORIZONTAL_BORDER) asks whether this row is TOO WIDE TO WRAP NICELY, to
+//     decide whether to clip it. Its false positive crops a short rule. It can afford a broad glyph
+//     set and a plain repetition count.
+//
+// Same word, different question, and the costs of being wrong are not comparable. markers.ts:86–103
+// records what happened the last time one of these tests was reused for the other job — a spaced-out
+// prose separator read as an input-box border and defeated the structural guard from the inside.
+// Share the alphabet here; never share a predicate or a threshold.
 
 /** All box-drawing glyphs accepted by the existing Claude horizontal-rule grammar. */
 export const BOX_DRAWING_RULE_GLYPH_CLASS = "─-╿";

--- a/web/src/lib/rule-glyphs.ts
+++ b/web/src/lib/rule-glyphs.ts
@@ -1,0 +1,22 @@
+// Shared Unicode rule-glyph classes. Claude's grammar intentionally retains its established broad
+// box-drawing contract; visual clipping narrows that to glyphs that are themselves horizontal, so
+// a repeated corner/junction can never be mistaken for a terminal-width border.
+
+/** All box-drawing glyphs accepted by the existing Claude horizontal-rule grammar. */
+export const BOX_DRAWING_RULE_GLYPH_CLASS = "─-╿";
+/** Block eighths used by terminal separators. */
+export const BLOCK_EIGHTH_RULE_GLYPH_CLASS = "▁-▔";
+/** Figure, en, em, and horizontal-bar dashes. ASCII hyphen remains deliberately excluded. */
+export const UNICODE_DASH_RULE_GLYPH_CLASS = "‒-―";
+
+/** The established Claude horizontal-rule contract. */
+export const CLAUDE_RULE_GLYPH_CLASS =
+  BOX_DRAWING_RULE_GLYPH_CLASS + BLOCK_EIGHTH_RULE_GLYPH_CLASS + UNICODE_DASH_RULE_GLYPH_CLASS;
+
+// Horizontal-only members of the box-drawing range: solid, dashed, and double horizontal rules.
+// Corners, junctions, and vertical strokes stay out even when repeated.
+const HORIZONTAL_BOX_RULE_GLYPH_CLASS = "─━┄┅┈┉╌╍═╴╶╸╺╼╾";
+
+/** Glyphs safe to classify as a repeated, standalone horizontal terminal border. */
+export const PURE_HORIZONTAL_RULE_GLYPH_CLASS =
+  HORIZONTAL_BOX_RULE_GLYPH_CLASS + BLOCK_EIGHTH_RULE_GLYPH_CLASS + UNICODE_DASH_RULE_GLYPH_CLASS;


### PR DESCRIPTION
Completes @en-ver's #79 on top of #78, which landed first. Their commit is cherry-picked with authorship preserved; the rework sits in a second commit.

## Why this isn't just a merge of #79

#79 and #78 were opened two minutes apart and both edited `markers.ts`. #78 **deletes** the 20-glyph `RULE_RUN` — that run was a hidden "the pane is at least twenty columns wide" assumption, and a 19-column pane stalling the reply guard on it is issue #76. #79's rewrite of that same constant is therefore dead code, dropped here. Its `RULE_ONLY` extraction stands.

## The rework

- **Re-anchor the clip threshold.** #79 justified its `20` by citing the box-border run #78 removes, so the comment is now false, not merely stale. Twenty is still correct on two facts of its own: nothing in prose runs to twenty *identical* rule glyphs, and below ~20 columns a row already fits the narrowest mirror unwrapped, so clipping buys nothing.
- **Keep the two border tests apart, on purpose.** The tree now holds two things that decide whether a line is a "border", which reads as an invitation to unify them. It shouldn't be taken. `markers.ts` decides whether the reply guard may press Enter and is wrong by typing into the wrong screen; `blocks.ts` decides whether a row is too wide to wrap and is wrong by cropping a short rule. `markers.ts:86-103` already records what happened the last time one was reused for the other. `rule-glyphs.ts` now states the rule at the shared surface — share the alphabet, never a predicate or a threshold — and a new test pins the labelled border (recognised by the guard, never clipped) across both modules so neither drifts into the other.
- **Fold `RULE_OR_SPACE_ONLY` onto the shared class**, finishing what #79 set out to do: no literal glyph class is left in `markers.ts`.
- **Drop the 0.25.1 bump.** `main` carries several unreleased features and #77 bumps too; one release commit cuts them together.

## Verification

Backend 534 pass · ctl lifecycle passed · web 103 files / 1696 tests pass · both typechecks clean.

Closes #79.