### PR TITLE
feat(composer): type into the terminal (completes #77)

### DIFF
--- a/.adr/README.md
+++ b/.adr/README.md
@@ -24,6 +24,26 @@ signal is that you find yourself explaining *why not* rather than *how*.
 - ❌ "Use Vitest for the web suite" — that's just what the repo does; `CLAUDE.md` covers it
 - ❌ Anything already legible from the code, a test name, or a commit message
 
+**The bar is high, and it is meant to be.** These are for the handful of decisions that shape the
+system, not a record of work done. A merged PR is not an occasion for an ADR; neither is a decision
+that merely took some thought, nor one you'd like on the record because it was hard-won. If a
+directory of ADRs reads like a changelog, it has stopped being useful — the signal drowns, and the
+few entries that genuinely close off a road get skimmed past with the rest.
+
+Before adding one, both of these must be true:
+
+1. **Someone has actually argued for the other road, or demonstrably will.** A real PR, a real issue,
+   a proposal you had to talk someone out of. "A future contributor might wonder" is not enough — that
+   is what a comment is for.
+2. **The argument has nowhere better to live.** If it fits at the line that would change, put it
+   there: whoever reopens the question is reading that code, not this directory. An ADR is for
+   reasoning that spans files, or that argues against a road with no single line to attach to.
+
+When in doubt, don't. A comment at the point of change costs nothing and is read by exactly the
+person who needs it; an ADR that didn't need writing dilutes the ones that did. Two candidates were
+turned down on this basis in one day (bundled-font laziness, and the direct-typing lifecycle) — both
+became file-header comments, and both are better for it.
+
 ## Relationship to the other docs
 
 Nothing here restates what lives elsewhere; the point is the *reasoning*, once.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,6 +116,11 @@ the unit name; the Herdr action runs from anywhere.
   still-mounted router (unmounting it ate in-progress composer drafts) and pauses polling through
   `lib/idle.ts`. Don't restore it as a security control or re-describe it as one
   ([ADR 0007](./.adr/0007-the-idle-lock-is-a-pause-not-a-gate.md)).
+- **"Type into terminal" is armed by a named choice and dies with the pane view.** Long-pressing Send
+  opens a menu; the hold never arms it alone. It disarms on a pane switch, a composer lock (gone pane,
+  read-only, idle pause), a hidden page, and a failed batch — never persisted, never restored. Don't
+  lift it, and don't add the reply guard's `composerReady` pre-flight to it; the reasoning for both
+  sits in `web/src/components/send-mode-menu.tsx`'s header.
 - **PWA** via `vite-plugin-pwa` (`web/vite.config.ts`): manifest + `sw.js`, registered manually
   from `virtual:pwa-register` in `main.tsx` (bundled = CSP-safe). Install/SW need a **secure
   context** — over plain HTTP they no-op silently (Chrome insecure-origin flag, or HTTPS, to test).

--- a/web/src/components/composer.test.tsx
+++ b/web/src/components/composer.test.tsx
@@ -259,36 +259,107 @@ describe("Composer — send", () => {
   });
 });
 
-describe("Composer — Immediate key mode", () => {
-  function activateImmediateMode() {
-    fireEvent.contextMenu(screen.getByRole("button", { name: /hold send for immediate/i }));
-    return screen.getByPlaceholderText(/type keys/i);
+describe("Composer — typing into the terminal", () => {
+  /** The entry point: the named "Type" toggle in the Controls row, beside Keys. */
+  function startDirectTyping() {
+    fireEvent.click(screen.getByRole("button", { name: /^type into terminal$/i }));
+    return screen.getByPlaceholderText(/type into the terminal/i);
   }
 
   it("focuses the textarea synchronously so the activation gesture opens the phone keyboard", () => {
     renderComposer();
 
-    expect(activateImmediateMode()).toHaveFocus();
+    expect(startDirectTyping()).toHaveFocus();
   });
 
-  it("re-focuses from pointerup after the hold timer so mobile browsers open the keyboard", () => {
-    vi.useFakeTimers();
-    try {
-      renderComposer();
-      const button = screen.getByRole("button", { name: /hold send for immediate/i });
-      fireEvent.pointerDown(button, { button: 0, clientX: 10, clientY: 10 });
-      act(() => vi.advanceTimersByTime(450));
-      const box = screen.getByPlaceholderText(/type keys/i);
+  // The entry point must be a deliberate press and nothing else: it sits in a row of dock toggles,
+  // so it must not send, and it must not leave a half-open dock covering the keyboard it needs.
+  it("arms from the Controls row without sending, and closes an open dock", async () => {
+    let replyCalls = 0;
+    server.use(replyHandler(() => replyCalls++));
+    renderComposer();
+    fireEvent.click(screen.getByRole("button", { name: /^keys$/i }));
+    expect(screen.getByRole("button", { name: /close keys/i })).toBeInTheDocument();
 
-      act(() => box.blur());
-      expect(box).not.toHaveFocus();
-      fireEvent.pointerUp(button, { button: 0, clientX: 10, clientY: 10 });
+    fireEvent.click(screen.getByRole("button", { name: /^type into terminal$/i }));
 
-      expect(box).toHaveFocus();
-    } finally {
-      vi.runOnlyPendingTimers();
-      vi.useRealTimers();
+    expect(screen.getByPlaceholderText(/type into the terminal/i)).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /close keys/i })).toBeNull();
+    expect(replyCalls).toBe(0);
+    expect(screen.getByRole("button", { name: /^type into terminal$/i })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+  });
+
+  it("shows the armed strip and stops from it", async () => {
+    renderComposer();
+    startDirectTyping();
+
+    const strip = screen.getByText(/typing into terminal/i);
+    expect(strip).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /^stop$/i }));
+
+    await waitFor(() =>
+      expect(screen.queryByPlaceholderText(/type into the terminal/i)).toBeNull(),
+    );
+  });
+
+  // The other half of the same rule: the composer locking (pane gone, device demoted to read-only,
+  // or the idle pause) means the view is no longer live either.
+  it("stops when the composer locks under it", async () => {
+    function Harness() {
+      const [gone, setGone] = useState(false);
+      return (
+        <>
+          <button type="button" onClick={() => setGone(true)}>
+            lock it
+          </button>
+          <Composer
+            paneId="w1:p1"
+            agent="claude"
+            isShell={false}
+            gone={gone}
+            readOnly={false}
+            dialogPresent={false}
+            text="pane output"
+            terminalDraft={null}
+            rawTerminalDraft={null}
+            prefs={{ wrap: true, fontSize: 11, rawTerminal: false }}
+            setWrap={vi.fn()}
+            stepFontSize={vi.fn()}
+            setRawTerminal={vi.fn()}
+            onSent={vi.fn()}
+          />
+        </>
+      );
     }
+    const router = createMemoryRouter([{ path: "/", element: <Harness /> }]);
+    render(<RouterProvider router={router} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /^type into terminal$/i }));
+    expect(screen.getByPlaceholderText(/type into the terminal/i)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "lock it" }));
+
+    await waitFor(() =>
+      expect(screen.queryByPlaceholderText(/type into the terminal/i)).toBeNull(),
+    );
+  });
+
+  // The mirror stops tracking the pane when the page is backgrounded, so the next keystroke would
+  // go into a terminal the user is not looking at.
+  it("stops when the page is hidden", async () => {
+    renderComposer();
+    startDirectTyping();
+
+    Object.defineProperty(document, "visibilityState", { value: "hidden", configurable: true });
+    fireEvent(document, new Event("visibilitychange"));
+
+    await waitFor(() =>
+      expect(screen.queryByPlaceholderText(/type into the terminal/i)).toBeNull(),
+    );
+    Object.defineProperty(document, "visibilityState", { value: "visible", configurable: true });
   });
 
   it("sends committed keyboard text as literal ordered keys with no implicit Enter", async () => {
@@ -303,8 +374,8 @@ describe("Composer — Immediate key mode", () => {
     );
     renderComposerWithStatus({ dialogPresent: true });
 
-    const box = activateImmediateMode();
-    expect(screen.getByRole("button", { name: /exit immediate key mode/i })).toHaveAttribute(
+    const box = startDirectTyping();
+    expect(screen.getByRole("button", { name: /^type into terminal$/i })).toHaveAttribute(
       "aria-pressed",
       "true",
     );
@@ -314,7 +385,7 @@ describe("Composer — Immediate key mode", () => {
     expect(keyCalls.flat()).not.toContain("Enter");
     expect(replyCalls).toBe(0);
     expect(box).toHaveValue("");
-    expect(screen.getByTestId("status")).toHaveTextContent(/immediate mode on/i);
+    expect(screen.getByTestId("status")).toHaveTextContent(/typing into the terminal/i);
   });
 
   it("sends a swiped/IME-composed word once when composition commits", async () => {
@@ -326,7 +397,7 @@ describe("Composer — Immediate key mode", () => {
       }),
     );
     renderComposer();
-    const box = activateImmediateMode();
+    const box = startDirectTyping();
 
     fireEvent.compositionStart(box);
     fireEvent.input(box, {
@@ -359,7 +430,7 @@ describe("Composer — Immediate key mode", () => {
       }),
     );
     renderComposer();
-    const box = activateImmediateMode();
+    const box = startDirectTyping();
 
     fireEvent.keyDown(box, { key: "Backspace" });
     await waitFor(() => expect(keyCalls).toEqual([["Backspace"]]));
@@ -397,27 +468,27 @@ describe("Composer — Immediate key mode", () => {
   it("exits on a tap of the highlighted keyboard button", async () => {
     const user = userEvent.setup();
     renderComposer();
-    const box = activateImmediateMode();
+    const box = startDirectTyping();
 
     fireEvent.blur(box); // dismissing the Android keyboard does not silently disarm the mode
-    expect(screen.getByPlaceholderText(/type keys/i)).toBeInTheDocument();
-    await user.click(screen.getByRole("button", { name: /exit immediate key mode/i }));
+    expect(screen.getByPlaceholderText(/type into the terminal/i)).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: /stop typing into terminal/i }));
 
     expect(screen.getByPlaceholderText(/type a reply/i)).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /hold send for immediate/i })).toHaveAttribute(
+    expect(screen.getByRole("button", { name: "Send" })).toHaveAttribute(
       "aria-pressed",
       "false",
     );
   });
 
-  it("stops Immediate mode when a key batch is refused", async () => {
+  it("stops direct typing when a key batch is refused", async () => {
     server.use(
       http.post(/\/api\/pane\/[^/]+\/keys$/, () =>
         HttpResponse.json({ ok: false, error: "pane unavailable" }, { status: 500 }),
       ),
     );
     renderComposerWithStatus();
-    const box = activateImmediateMode();
+    const box = startDirectTyping();
 
     fireEvent.change(box, { target: { value: "b" } });
 
@@ -432,10 +503,11 @@ describe("Composer — Immediate key mode", () => {
     const box = screen.getByPlaceholderText(/type a reply/i);
     await user.type(box, "keep this draft");
 
-    fireEvent.contextMenu(screen.getByRole("button", { name: "Send" }));
+    // The refusal belongs on the named choice, where there is somewhere to explain it.
+    fireEvent.click(screen.getByRole("button", { name: /^type into terminal$/i }));
 
     expect(screen.getByPlaceholderText(/type a reply/i)).toHaveValue("keep this draft");
-    expect(screen.queryByPlaceholderText(/type keys/i)).not.toBeInTheDocument();
+    expect(screen.queryByPlaceholderText(/type into the terminal/i)).not.toBeInTheDocument();
     expect(screen.getByTestId("status")).toHaveTextContent(/send or clear the draft/i);
   });
 
@@ -468,7 +540,7 @@ describe("Composer — Immediate key mode", () => {
     }
     const router = createMemoryRouter([{ path: "/", element: <Harness /> }]);
     render(<RouterProvider router={router} />);
-    activateImmediateMode();
+    startDirectTyping();
 
     fireEvent.click(screen.getByRole("button", { name: "Switch pane" }));
 

--- a/web/src/components/composer.test.tsx
+++ b/web/src/components/composer.test.tsx
@@ -259,6 +259,224 @@ describe("Composer — send", () => {
   });
 });
 
+describe("Composer — Immediate key mode", () => {
+  function activateImmediateMode() {
+    fireEvent.contextMenu(screen.getByRole("button", { name: /hold send for immediate/i }));
+    return screen.getByPlaceholderText(/type keys/i);
+  }
+
+  it("focuses the textarea synchronously so the activation gesture opens the phone keyboard", () => {
+    renderComposer();
+
+    expect(activateImmediateMode()).toHaveFocus();
+  });
+
+  it("re-focuses from pointerup after the hold timer so mobile browsers open the keyboard", () => {
+    vi.useFakeTimers();
+    try {
+      renderComposer();
+      const button = screen.getByRole("button", { name: /hold send for immediate/i });
+      fireEvent.pointerDown(button, { button: 0, clientX: 10, clientY: 10 });
+      act(() => vi.advanceTimersByTime(450));
+      const box = screen.getByPlaceholderText(/type keys/i);
+
+      act(() => box.blur());
+      expect(box).not.toHaveFocus();
+      fireEvent.pointerUp(button, { button: 0, clientX: 10, clientY: 10 });
+
+      expect(box).toHaveFocus();
+    } finally {
+      vi.runOnlyPendingTimers();
+      vi.useRealTimers();
+    }
+  });
+
+  it("sends committed keyboard text as literal ordered keys with no implicit Enter", async () => {
+    const keyCalls: string[][] = [];
+    let replyCalls = 0;
+    server.use(
+      http.post(/\/api\/pane\/[^/]+\/keys$/, async ({ request }) => {
+        keyCalls.push(((await request.json()) as { keys: string[] }).keys);
+        return HttpResponse.json({ ok: true });
+      }),
+      replyHandler(() => replyCalls++),
+    );
+    renderComposerWithStatus({ dialogPresent: true });
+
+    const box = activateImmediateMode();
+    expect(screen.getByRole("button", { name: /exit immediate key mode/i })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    fireEvent.change(box, { target: { value: "b a" } });
+
+    await waitFor(() => expect(keyCalls).toEqual([["b", "Space", "a"]]));
+    expect(keyCalls.flat()).not.toContain("Enter");
+    expect(replyCalls).toBe(0);
+    expect(box).toHaveValue("");
+    expect(screen.getByTestId("status")).toHaveTextContent(/immediate mode on/i);
+  });
+
+  it("sends a swiped/IME-composed word once when composition commits", async () => {
+    const keyCalls: string[][] = [];
+    server.use(
+      http.post(/\/api\/pane\/[^/]+\/keys$/, async ({ request }) => {
+        keyCalls.push(((await request.json()) as { keys: string[] }).keys);
+        return HttpResponse.json({ ok: true });
+      }),
+    );
+    renderComposer();
+    const box = activateImmediateMode();
+
+    fireEvent.compositionStart(box);
+    fireEvent.input(box, {
+      target: { value: "swipe" },
+      data: "swipe",
+      inputType: "insertCompositionText",
+      isComposing: true,
+    });
+    expect(keyCalls).toEqual([]);
+    fireEvent.compositionEnd(box, { data: "swipe" });
+
+    await waitFor(() => expect(keyCalls).toEqual([["s", "w", "i", "p", "e"]]));
+    // Gboard may emit the committed value once more as an ordinary input after compositionend.
+    fireEvent.input(box, {
+      target: { value: "swipe" },
+      data: "swipe",
+      inputType: "insertText",
+      isComposing: false,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(keyCalls).toEqual([["s", "w", "i", "p", "e"]]);
+  });
+
+  it("sends terminal keys that do not change the textarea value", async () => {
+    const keyCalls: string[][] = [];
+    server.use(
+      http.post(/\/api\/pane\/[^/]+\/keys$/, async ({ request }) => {
+        keyCalls.push(((await request.json()) as { keys: string[] }).keys);
+        return HttpResponse.json({ ok: true });
+      }),
+    );
+    renderComposer();
+    const box = activateImmediateMode();
+
+    fireEvent.keyDown(box, { key: "Backspace" });
+    await waitFor(() => expect(keyCalls).toEqual([["Backspace"]]));
+    fireEvent.keyDown(box, { key: "Enter" });
+    await waitFor(() => expect(keyCalls).toEqual([["Backspace"], ["Enter"]]));
+
+    // Android can omit keydown for its virtual Backspace and expose only beforeinput.
+    fireEvent(
+      box,
+      new InputEvent("beforeinput", {
+        bubbles: true,
+        cancelable: true,
+        inputType: "deleteContentBackward",
+      }),
+    );
+    await waitFor(() =>
+      expect(keyCalls).toEqual([["Backspace"], ["Enter"], ["Backspace"]]),
+    );
+
+    // Gboard can mark its virtual Enter as composing while it commits the current candidate.
+    fireEvent(
+      box,
+      new InputEvent("beforeinput", {
+        bubbles: true,
+        cancelable: true,
+        inputType: "insertParagraph",
+        isComposing: true,
+      }),
+    );
+    await waitFor(() =>
+      expect(keyCalls).toEqual([["Backspace"], ["Enter"], ["Backspace"], ["Enter"]]),
+    );
+  });
+
+  it("exits on a tap of the highlighted keyboard button", async () => {
+    const user = userEvent.setup();
+    renderComposer();
+    const box = activateImmediateMode();
+
+    fireEvent.blur(box); // dismissing the Android keyboard does not silently disarm the mode
+    expect(screen.getByPlaceholderText(/type keys/i)).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: /exit immediate key mode/i }));
+
+    expect(screen.getByPlaceholderText(/type a reply/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /hold send for immediate/i })).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+  });
+
+  it("stops Immediate mode when a key batch is refused", async () => {
+    server.use(
+      http.post(/\/api\/pane\/[^/]+\/keys$/, () =>
+        HttpResponse.json({ ok: false, error: "pane unavailable" }, { status: 500 }),
+      ),
+    );
+    renderComposerWithStatus();
+    const box = activateImmediateMode();
+
+    fireEvent.change(box, { target: { value: "b" } });
+
+    const replyBox = await screen.findByPlaceholderText(/type a reply/i);
+    await waitFor(() => expect(replyBox).not.toHaveFocus());
+    expect(screen.getByTestId("status")).toHaveTextContent(/pane unavailable/i);
+  });
+
+  it("refuses activation while a buffered reply exists", async () => {
+    const user = userEvent.setup();
+    renderComposerWithStatus();
+    const box = screen.getByPlaceholderText(/type a reply/i);
+    await user.type(box, "keep this draft");
+
+    fireEvent.contextMenu(screen.getByRole("button", { name: "Send" }));
+
+    expect(screen.getByPlaceholderText(/type a reply/i)).toHaveValue("keep this draft");
+    expect(screen.queryByPlaceholderText(/type keys/i)).not.toBeInTheDocument();
+    expect(screen.getByTestId("status")).toHaveTextContent(/send or clear the draft/i);
+  });
+
+  it("resets when the composer changes panes", () => {
+    function Harness() {
+      const [paneId, setPaneId] = useState("w1:p1");
+      return (
+        <>
+          <button type="button" onClick={() => setPaneId("w1:p2")}>
+            Switch pane
+          </button>
+          <Composer
+            paneId={paneId}
+            agent="claude"
+            isShell={false}
+            gone={false}
+            readOnly={false}
+            dialogPresent={false}
+            text="pane output"
+            terminalDraft={null}
+            rawTerminalDraft={null}
+            prefs={{ wrap: true, fontSize: 11, rawTerminal: false }}
+            setWrap={vi.fn()}
+            stepFontSize={vi.fn()}
+            setRawTerminal={vi.fn()}
+            onSent={vi.fn()}
+          />
+        </>
+      );
+    }
+    const router = createMemoryRouter([{ path: "/", element: <Harness /> }]);
+    render(<RouterProvider router={router} />);
+    activateImmediateMode();
+
+    fireEvent.click(screen.getByRole("button", { name: "Switch pane" }));
+
+    expect(screen.getByPlaceholderText(/type a reply/i)).toBeInTheDocument();
+    expect(screen.queryByPlaceholderText(/type keys/i)).not.toBeInTheDocument();
+  });
+});
+
 // .adr/0009: a modal that owns the keyboard has no input box, so the reply path's PRE-FLIGHT refuses
 // before typing anything. The composer's job is to keep the draft, say why, and offer one deliberate
 // override — which still runs the type-then-verify guard behind it.

--- a/web/src/components/composer.tsx
+++ b/web/src/components/composer.tsx
@@ -5,6 +5,7 @@ import { Check, ImagePlus, Keyboard, Loader2, Send, Settings2, Slash, X, Zap } f
 
 import type { DisplayPrefs } from "@/hooks/use-display-prefs";
 import { usePendingConfirm } from "@/hooks/use-pending-confirm";
+import { useImmediateInput } from "@/hooks/use-immediate-input";
 import { setStatus } from "@/lib/status";
 import { Button } from "@/components/ui/button";
 import { ChatInput } from "@/components/ui/chat/chat-input";
@@ -228,6 +229,18 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const fileRef = useRef<HTMLInputElement>(null);
+  const immediate = useImmediateInput({
+    paneKey: `${session ?? ""}\0${paneId}`,
+    inputRef,
+    replyDraft: input,
+    canActivate: () => !(locked || sending || uploading),
+    sendKeys: pressKeys,
+    onActivate: () => {
+      sendConfirm.reset();
+      forceConfirm.reset();
+    },
+    focusInput: focusInputEnd,
+  });
   const sentTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const lastSentTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   // What we last sent, and when — so we can recognise our OWN reply momentarily echoing on the "❯"
@@ -291,7 +304,10 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
   // is SAFE on its own — it lives on the "❯" line and its preview re-derives after a reload — so it
   // never holds. When held, the self-updater shows the "tap to update" banner instead and updates once
   // the hold clears (see lib/self-update.ts). Keyed by pane so panes don't clobber each other's hold.
-  useHoldReload(`composer:${paneId}`, input.trim() !== "" || uploading);
+  useHoldReload(
+    `composer:${paneId}`,
+    input.trim() !== "" || immediate.active || immediate.value !== "" || immediate.busy || uploading,
+  );
 
   // Preview appearance latch. A STABLE, non-echo, not-already-handled draft flips the preview on —
   // this is the ONLY gate that waits for the 1.5s stability, so a blip or an in-flight send never
@@ -337,6 +353,7 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
   function takeOverDraft() {
     if (effectiveRaw === null) return;
     const draft = effectiveRaw;
+    immediate.deactivateSilently();
     updateInput((prev) => (prev.trim() ? `${prev.trimEnd()}\n${draft}` : draft));
     setHandledKey(normalizeDraft(draft));
     setPreviewLatched(false);
@@ -524,6 +541,7 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
   // Insert "/cmd " into the composer (arg-taking commands) and focus it. Appends to any draft already
   // typed (with a separating space) rather than clobbering it; an empty draft just gets set.
   function insertCommand(value: string) {
+    immediate.deactivateSilently();
     updateInput((prev) => (prev.trim() ? `${prev.trimEnd()} ${value}` : value));
     focusInputEnd();
   }
@@ -537,6 +555,7 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
       const res = await api.uploadImage(paneId, file, session);
       if (res.ok) {
         const path = res.path;
+        immediate.deactivateSilently();
         updateInput((prev) => (prev.trim() ? `${prev.trimEnd()} ${path}` : path));
         focusInputEnd();
         setStatus("Image added — path in message", "success");
@@ -561,7 +580,7 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
   // Only intercepts when the clipboard actually carries an image file — a plain text paste (the
   // common case) falls through untouched.
   function onPasteImage(e: ClipboardEvent<HTMLTextAreaElement>) {
-    if (locked) return;
+    if (locked || immediate.active) return;
     const items = e.clipboardData.items;
     for (let i = 0; i < items.length; i++) {
       const item = items[i];
@@ -709,7 +728,7 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
             variant="ghost"
             size="icon"
             className="rounded-full text-muted-foreground"
-            disabled={uploading || locked}
+            disabled={uploading || locked || immediate.active}
             onPointerDown={(e) => e.preventDefault()}
             onClick={() => fileRef.current?.click()}
             aria-label="Attach image"
@@ -718,28 +737,43 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
           </Button>
           <ChatInput
             ref={inputRef}
-            value={input}
-            onChange={(e) => updateInput(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
-                e.preventDefault();
-                onSendClick();
-              }
-            }}
+            value={immediate.active ? immediate.value : input}
+            onChange={immediate.active ? immediate.onChange : (e) => updateInput(e.target.value)}
+            onCompositionStart={immediate.active ? immediate.onCompositionStart : undefined}
+            onCompositionEnd={immediate.active ? immediate.onCompositionEnd : undefined}
+            onKeyDown={
+              immediate.active
+                ? immediate.onKeyDown
+                : (e) => {
+                    if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+                      e.preventDefault();
+                      onSendClick();
+                    }
+                  }
+            }
             onPaste={onPasteImage}
             placeholder={
               gone
                 ? "Pane is gone"
                 : readOnly
                   ? "Read-only — device not authorised"
-                  : isShell
-                    ? "Type a shell command…"
-                    : "Type a reply…"
+                  : immediate.active
+                    ? "Type keys to send immediately"
+                    : isShell
+                      ? "Type a shell command…"
+                      : "Type a reply…"
+            }
+            autoCorrect={immediate.active ? "off" : undefined}
+            spellCheck={immediate.active ? false : undefined}
+            className={
+              immediate.active
+                ? "border-primary focus-visible:border-primary focus-visible:ring-primary/30"
+                : undefined
             }
             disabled={locked}
             rows={1}
           />
-          {forcingSend ? (
+          {!immediate.active && forcingSend ? (
             // The pre-flight refused and the user is being offered the override. Labelled for what it
             // actually does — TYPE the text into whatever is on screen — not "send", because the
             // submit key is still conditional on the verify step behind it.
@@ -752,7 +786,7 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
             >
               Type anyway?
             </Button>
-          ) : confirmingSend ? (
+          ) : !immediate.active && confirmingSend ? (
             <Button
               variant="destructive"
               className="h-11 shrink-0 rounded-full px-4 text-sm font-semibold"
@@ -764,13 +798,28 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
             </Button>
           ) : (
             <Button
+              {...immediate.longPress}
               size="icon"
-              className="size-11 shrink-0 rounded-full"
-              onClick={onSendClick}
-              disabled={locked || !input.trim() || sending}
-              aria-label="Send"
+              className="size-11 shrink-0 select-none rounded-full [-webkit-touch-callout:none]"
+              onClick={immediate.active ? () => immediate.deactivate() : onSendClick}
+              // Keep the empty button pointer-active: holding that exact Send icon is how Immediate
+              // mode is entered. A plain empty tap remains a no-op through send().
+              disabled={locked || sending}
+              aria-label={
+                immediate.active
+                  ? "Exit immediate key mode"
+                  : locked || input.trim()
+                    ? "Send"
+                    : "Hold Send for immediate key mode"
+              }
+              aria-pressed={immediate.active}
+              title={
+                immediate.active ? "Immediate key mode — tap to exit" : "Hold for Immediate mode"
+              }
             >
-              {sending ? (
+              {immediate.active ? (
+                <Keyboard className="size-4" />
+              ) : sending ? (
                 <Loader2 className="size-4 animate-spin" />
               ) : justSent ? (
                 <Check className="size-4" />

--- a/web/src/components/composer.tsx
+++ b/web/src/components/composer.tsx
@@ -1,11 +1,11 @@
 import { forwardRef, useEffect, useImperativeHandle, useRef, useState } from "react";
 import type { ChangeEvent, ClipboardEvent, ReactNode } from "react";
 import { useRevalidator } from "react-router";
-import { Check, ImagePlus, Keyboard, Loader2, Send, Settings2, Slash, X, Zap } from "lucide-react";
+import { Check, ImagePlus, Keyboard, Loader2, Send, Settings2, Slash, Terminal, X, Zap } from "lucide-react";
 
 import type { DisplayPrefs } from "@/hooks/use-display-prefs";
 import { usePendingConfirm } from "@/hooks/use-pending-confirm";
-import { useImmediateInput } from "@/hooks/use-immediate-input";
+import { useDirectTyping } from "@/hooks/use-direct-typing";
 import { setStatus } from "@/lib/status";
 import { Button } from "@/components/ui/button";
 import { ChatInput } from "@/components/ui/chat/chat-input";
@@ -23,6 +23,7 @@ import { isSelfEcho, normalizeDraft } from "@/hooks/use-terminal-draft";
 import { adapterFor } from "@/lib/harness";
 import { sendGuardedReply } from "@/lib/reply-action";
 import { TerminalDraftPreview } from "@/components/terminal-draft-preview";
+import { DirectTypingStrip } from "@/components/direct-typing-strip";
 
 export interface ComposerHandle {
   /** Focus the input and put the caret at the end — used by the mirror-tap-to-focus in AgentChat. */
@@ -229,11 +230,16 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const fileRef = useRef<HTMLInputElement>(null);
-  const immediate = useImmediateInput({
+  const direct = useDirectTyping({
     paneKey: `${session ?? ""}\0${paneId}`,
     inputRef,
     replyDraft: input,
     canActivate: () => !(locked || sending || uploading),
+    // `locked` covers a gone pane, a read-only device, and the idle pause. A LOST CONNECTION is
+    // deliberately not added here: the mode already disarms on a failed batch, which is the same
+    // event observed directly rather than inferred from a timer, and it fires whether or not any
+    // banner has decided the connection counts as lost yet.
+    suspended: locked,
     sendKeys: pressKeys,
     onActivate: () => {
       sendConfirm.reset();
@@ -306,7 +312,7 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
   // the hold clears (see lib/self-update.ts). Keyed by pane so panes don't clobber each other's hold.
   useHoldReload(
     `composer:${paneId}`,
-    input.trim() !== "" || immediate.active || immediate.value !== "" || immediate.busy || uploading,
+    input.trim() !== "" || direct.active || direct.value !== "" || direct.busy || uploading,
   );
 
   // Preview appearance latch. A STABLE, non-echo, not-already-handled draft flips the preview on —
@@ -353,7 +359,7 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
   function takeOverDraft() {
     if (effectiveRaw === null) return;
     const draft = effectiveRaw;
-    immediate.deactivateSilently();
+    direct.deactivateSilently();
     updateInput((prev) => (prev.trim() ? `${prev.trimEnd()}\n${draft}` : draft));
     setHandledKey(normalizeDraft(draft));
     setPreviewLatched(false);
@@ -541,7 +547,7 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
   // Insert "/cmd " into the composer (arg-taking commands) and focus it. Appends to any draft already
   // typed (with a separating space) rather than clobbering it; an empty draft just gets set.
   function insertCommand(value: string) {
-    immediate.deactivateSilently();
+    direct.deactivateSilently();
     updateInput((prev) => (prev.trim() ? `${prev.trimEnd()} ${value}` : value));
     focusInputEnd();
   }
@@ -555,7 +561,7 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
       const res = await api.uploadImage(paneId, file, session);
       if (res.ok) {
         const path = res.path;
-        immediate.deactivateSilently();
+        direct.deactivateSilently();
         updateInput((prev) => (prev.trim() ? `${prev.trimEnd()} ${path}` : path));
         focusInputEnd();
         setStatus("Image added — path in message", "success");
@@ -580,7 +586,7 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
   // Only intercepts when the clipboard actually carries an image file — a plain text paste (the
   // common case) falls through untouched.
   function onPasteImage(e: ClipboardEvent<HTMLTextAreaElement>) {
-    if (locked || immediate.active) return;
+    if (locked || direct.active) return;
     const items = e.clipboardData.items;
     for (let i = 0; i < items.length; i++) {
       const item = items[i];
@@ -651,8 +657,15 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
             this one; folding them behind the ⚙ gives the mirror that row back. The gear is icon-only
             and NOT flex-1 — it's a settings affordance, not a peer of the three action toggles, and
             keeping it narrow leaves the labelled buttons their width on a 390px phone. */}
-        <div className="mb-2 flex items-center gap-2">
-          <SectionLabel>Controls</SectionLabel>
+        {/* The "Controls" tag is lifted OUT of the row's flex flow and floated just above it. In
+            flow it was a fixed ~60px of a 390px phone width spent on a word that never changes,
+            which is what squeezed the toggles; absolute costs nothing and the row gets the width
+            back. `pt-3` on the row reserves the space it occupies so it can't collide with whatever
+            sits above. */}
+        <div className="relative mb-2 flex items-center gap-2 pt-3">
+          <SectionLabel className="absolute left-0 top-0 text-[10px] leading-none opacity-80">
+            Controls
+          </SectionLabel>
           {/* Keys and Quick are TOGGLES for the in-flow dock above (not overlays): tap to open, tap
               again to close. aria-expanded ties each to the dock; secondary variant marks it pressed
               while open. Both share the single-valued `drawer`, so opening one closes the other. */}
@@ -666,6 +679,39 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
           >
             <Keyboard className="size-4" />
             Keys
+          </Button>
+          {/* "Type into terminal" lives HERE, beside Keys, rather than on the Send button.
+              It is the same problem split in half: Keys exists because the phone keyboard cannot
+              send Esc/Tab/arrows/chords, this exists because it cannot send bare printable letters —
+              so someone who wants to press `b` looks in this row first. It is also used in bursts
+              (a picker, a y/n prompt) and then not for days, which is the wrong shape for a
+              permanent fixture on the app's most-used control: a split Send button cost a third of
+              the primary action's width every day to serve a mode used on a few of them.
+              Unlike its neighbours this toggles state instead of opening a dock — the armed strip
+              above the input is what makes that visible. Arming is still an explicit NAMED choice,
+              which is what keeps an accidental touch from quietly wiring the keyboard to a live
+              terminal; see use-direct-typing.ts for the rest of that argument. */}
+          <Button
+            variant={direct.active ? "secondary" : "ghost"}
+            size="sm"
+            className="h-8 flex-1 gap-1.5 text-muted-foreground"
+            disabled={locked || sending}
+            aria-pressed={direct.active}
+            aria-label="Type into terminal"
+            onClick={() => {
+              if (direct.active) {
+                direct.deactivate();
+                return;
+              }
+              // Close whatever dock is open first: the mode needs the phone keyboard, and a dock
+              // holding half the viewport is the thing in its way. Routed through requestDrawer so a
+              // staged key queue still gets its discard confirm (ADR 0005).
+              requestDrawer(null);
+              direct.activate();
+            }}
+          >
+            <Terminal className="size-4" />
+            Type
           </Button>
           <Button
             variant={drawer === "quick" ? "secondary" : "ghost"}
@@ -719,6 +765,9 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
             onTakeOver={adapter?.draftIsOpaque?.(effectiveRaw) ? null : takeOverDraft}
           />
         )}
+        {/* Armed indicator for direct typing. In the same in-flow slot as the "You sent:" strip,
+            deliberately NOT only on the button and textarea — see the component. */}
+        {direct.active && <DirectTypingStrip onStop={() => direct.deactivate()} />}
         <div className="flex items-end gap-2">
           {/* Attach image — messenger-style, left of the input, always available (previously buried
               in the keyboard-only quick-key strip). preventDefault keeps the textarea focused so the
@@ -728,7 +777,7 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
             variant="ghost"
             size="icon"
             className="rounded-full text-muted-foreground"
-            disabled={uploading || locked || immediate.active}
+            disabled={uploading || locked || direct.active}
             onPointerDown={(e) => e.preventDefault()}
             onClick={() => fileRef.current?.click()}
             aria-label="Attach image"
@@ -737,13 +786,13 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
           </Button>
           <ChatInput
             ref={inputRef}
-            value={immediate.active ? immediate.value : input}
-            onChange={immediate.active ? immediate.onChange : (e) => updateInput(e.target.value)}
-            onCompositionStart={immediate.active ? immediate.onCompositionStart : undefined}
-            onCompositionEnd={immediate.active ? immediate.onCompositionEnd : undefined}
+            value={direct.active ? direct.value : input}
+            onChange={direct.active ? direct.onChange : (e) => updateInput(e.target.value)}
+            onCompositionStart={direct.active ? direct.onCompositionStart : undefined}
+            onCompositionEnd={direct.active ? direct.onCompositionEnd : undefined}
             onKeyDown={
-              immediate.active
-                ? immediate.onKeyDown
+              direct.active
+                ? direct.onKeyDown
                 : (e) => {
                     if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
                       e.preventDefault();
@@ -757,23 +806,23 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
                 ? "Pane is gone"
                 : readOnly
                   ? "Read-only — device not authorised"
-                  : immediate.active
-                    ? "Type keys to send immediately"
+                  : direct.active
+                    ? "Type into the terminal…"
                     : isShell
                       ? "Type a shell command…"
                       : "Type a reply…"
             }
-            autoCorrect={immediate.active ? "off" : undefined}
-            spellCheck={immediate.active ? false : undefined}
+            autoCorrect={direct.active ? "off" : undefined}
+            spellCheck={direct.active ? false : undefined}
             className={
-              immediate.active
+              direct.active
                 ? "border-primary focus-visible:border-primary focus-visible:ring-primary/30"
                 : undefined
             }
             disabled={locked}
             rows={1}
           />
-          {!immediate.active && forcingSend ? (
+          {!direct.active && forcingSend ? (
             // The pre-flight refused and the user is being offered the override. Labelled for what it
             // actually does — TYPE the text into whatever is on screen — not "send", because the
             // submit key is still conditional on the verify step behind it.
@@ -786,7 +835,7 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
             >
               Type anyway?
             </Button>
-          ) : !immediate.active && confirmingSend ? (
+          ) : !direct.active && confirmingSend ? (
             <Button
               variant="destructive"
               className="h-11 shrink-0 rounded-full px-4 text-sm font-semibold"
@@ -798,26 +847,14 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
             </Button>
           ) : (
             <Button
-              {...immediate.longPress}
               size="icon"
-              className="size-11 shrink-0 select-none rounded-full [-webkit-touch-callout:none]"
-              onClick={immediate.active ? () => immediate.deactivate() : onSendClick}
-              // Keep the empty button pointer-active: holding that exact Send icon is how Immediate
-              // mode is entered. A plain empty tap remains a no-op through send().
+              className="size-11 shrink-0 rounded-full"
+              onClick={direct.active ? () => direct.deactivate() : onSendClick}
               disabled={locked || sending}
-              aria-label={
-                immediate.active
-                  ? "Exit immediate key mode"
-                  : locked || input.trim()
-                    ? "Send"
-                    : "Hold Send for immediate key mode"
-              }
-              aria-pressed={immediate.active}
-              title={
-                immediate.active ? "Immediate key mode — tap to exit" : "Hold for Immediate mode"
-              }
+              aria-label={direct.active ? "Stop typing into terminal" : "Send"}
+              aria-pressed={direct.active}
             >
-              {immediate.active ? (
+              {direct.active ? (
                 <Keyboard className="size-4" />
               ) : sending ? (
                 <Loader2 className="size-4 animate-spin" />

--- a/web/src/components/composer.tsx
+++ b/web/src/components/composer.tsx
@@ -7,6 +7,7 @@ import type { DisplayPrefs } from "@/hooks/use-display-prefs";
 import { usePendingConfirm } from "@/hooks/use-pending-confirm";
 import { useDirectTyping } from "@/hooks/use-direct-typing";
 import { setStatus } from "@/lib/status";
+import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { ChatInput } from "@/components/ui/chat/chat-input";
 import { NavTray } from "@/components/nav-tray";
@@ -79,6 +80,12 @@ interface ComposerProps {
 // in-flow dock (they change how the mirror LOOKS, so the mirror has to stay visible while you flip
 // them). Find moved the other way — to the header, where its find bar already takes over the row.
 type ComposerDrawer = "quick" | "cmd" | "keys" | "display" | null;
+
+// The Controls row's "on" look, authored once so an open dock and an armed mode can never drift
+// apart. `hover:` is pinned to the same tint: without it, hovering an already-on control repaints it
+// with the ghost variant's hover background and it reads as switching off under the cursor.
+const CONTROL_ON = "bg-control-on text-control-on-foreground hover:bg-control-on";
+const CONTROL_OFF = "text-muted-foreground";
 
 // Pause after clearing a stranded terminal draft so the TUI settles before pane.send_text.
 const TUI_SETTLE_MS = 350;
@@ -670,9 +677,9 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
               again to close. aria-expanded ties each to the dock; secondary variant marks it pressed
               while open. Both share the single-valued `drawer`, so opening one closes the other. */}
           <Button
-            variant={drawer === "keys" ? "secondary" : "ghost"}
+            variant="ghost"
             size="sm"
-            className="h-8 flex-1 gap-1.5 text-muted-foreground"
+            className={cn("h-8 flex-1 gap-1.5", drawer === "keys" ? CONTROL_ON : CONTROL_OFF)}
             disabled={locked}
             aria-expanded={drawer === "keys"}
             onClick={() => requestDrawer(drawer === "keys" ? null : "keys")}
@@ -692,9 +699,9 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
               which is what keeps an accidental touch from quietly wiring the keyboard to a live
               terminal; see use-direct-typing.ts for the rest of that argument. */}
           <Button
-            variant={direct.active ? "secondary" : "ghost"}
+            variant="ghost"
             size="sm"
-            className="h-8 flex-1 gap-1.5 text-muted-foreground"
+            className={cn("h-8 flex-1 gap-1.5", direct.active ? CONTROL_ON : CONTROL_OFF)}
             disabled={locked || sending}
             aria-pressed={direct.active}
             aria-label="Type into terminal"
@@ -714,9 +721,9 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
             Type
           </Button>
           <Button
-            variant={drawer === "quick" ? "secondary" : "ghost"}
+            variant="ghost"
             size="sm"
-            className="h-8 flex-1 gap-1.5 text-muted-foreground"
+            className={cn("h-8 flex-1 gap-1.5", drawer === "quick" ? CONTROL_ON : CONTROL_OFF)}
             disabled={locked}
             aria-expanded={drawer === "quick"}
             onClick={() => requestDrawer(drawer === "quick" ? null : "quick")}
@@ -739,9 +746,9 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
           {/* Display prefs. Not gated on `locked`: wrap/font/raw-terminal are local view state, so a
               read-only device or a gone pane can still make its mirror readable. */}
           <Button
-            variant={drawer === "display" ? "secondary" : "ghost"}
+            variant="ghost"
             size="icon"
-            className="size-8 shrink-0 text-muted-foreground"
+            className={cn("size-8 shrink-0", drawer === "display" ? CONTROL_ON : CONTROL_OFF)}
             aria-label="Display settings"
             aria-expanded={drawer === "display"}
             onClick={() => requestDrawer(drawer === "display" ? null : "display")}
@@ -768,22 +775,16 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
         {/* Armed indicator for direct typing. In the same in-flow slot as the "You sent:" strip,
             deliberately NOT only on the button and textarea — see the component. */}
         {direct.active && <DirectTypingStrip onStop={() => direct.deactivate()} />}
-        <div className="flex items-end gap-2">
-          {/* Attach image — messenger-style, left of the input, always available (previously buried
-              in the keyboard-only quick-key strip). preventDefault keeps the textarea focused so the
-              picker opens without the soft keyboard collapsing first. */}
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon"
-            className="rounded-full text-muted-foreground"
-            disabled={uploading || locked || direct.active}
-            onPointerDown={(e) => e.preventDefault()}
-            onClick={() => fileRef.current?.click()}
-            aria-label="Attach image"
-          >
-            {uploading ? <Loader2 className="size-4 animate-spin" /> : <ImagePlus className="size-4" />}
-          </Button>
+        {/* gap-3, not gap-2: with the attach button moved inside the field this row is only the
+            field and Send, and the old spacing left them looking joined. */}
+        <div className="flex items-end gap-3">
+          {/* The input and its attach button share one box: the button is positioned INSIDE the
+              field, messenger-style, rather than sitting beside it as a third control in the row.
+              It used to occupy a full-height slot to the left, which spent the widest part of the
+              composer on the least-used action; inside the field it costs nothing but a strip of
+              padding the text was not using anyway. `pr-11` on the textarea reserves that strip so a
+              long line can never run underneath the icon. */}
+          <div className="relative min-w-0 flex-1">
           <ChatInput
             ref={inputRef}
             value={direct.active ? direct.value : input}
@@ -814,14 +815,38 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
             }
             autoCorrect={direct.active ? "off" : undefined}
             spellCheck={direct.active ? false : undefined}
-            className={
-              direct.active
-                ? "border-primary focus-visible:border-primary focus-visible:ring-primary/30"
-                : undefined
-            }
+            className={cn(
+              // Room for the attach button tucked into the bottom-right of the field. `block`
+              // matters: a textarea is inline-level by default, so the wrapper inherits a few px of
+              // baseline gap beneath it and the absolutely-positioned button hangs past the field's
+              // bottom edge.
+              "block pr-11",
+              direct.active &&
+                "border-primary focus-visible:border-primary focus-visible:ring-primary/30",
+            )}
             disabled={locked}
             rows={1}
           />
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              // bottom-1, not centred: the field grows upward as the draft wraps, and a vertically
+              // centred button would drift up with it, away from the thumb and away from the send
+              // button it pairs with. Pinned to the bottom it stays put at any height.
+              className="absolute bottom-1 right-1 size-9 rounded-full text-muted-foreground"
+              disabled={uploading || locked || direct.active}
+              onPointerDown={(e) => e.preventDefault()}
+              onClick={() => fileRef.current?.click()}
+              aria-label="Attach image"
+            >
+              {uploading ? (
+                <Loader2 className="size-4 animate-spin" />
+              ) : (
+                <ImagePlus className="size-4" />
+              )}
+            </Button>
+          </div>
           {!direct.active && forcingSend ? (
             // The pre-flight refused and the user is being offered the override. Labelled for what it
             // actually does — TYPE the text into whatever is on screen — not "send", because the

--- a/web/src/components/direct-typing-strip.tsx
+++ b/web/src/components/direct-typing-strip.tsx
@@ -1,0 +1,32 @@
+import { Keyboard } from "lucide-react";
+
+// The armed indicator for direct typing, in the same in-flow slot as the "You sent:" strip.
+//
+// WHY THIS EXISTS ON TOP OF THE RESTYLED BUTTON AND TEXTAREA. Those two are exactly the elements a
+// user stops looking at once they start typing, so they fail the glance-back test: come back to the
+// phone twenty seconds later and nothing in your field of view says the next keystroke goes straight
+// into a running agent. This strip sits where the eye already goes for composer state, cannot scroll
+// away, and says what is happening in words.
+//
+// WHEN THIS REACHES THE PACK BRANCH IT MUST NAME THE HOST. On v1 every write surface carries a
+// HostChip, because a write names its target; a mode that streams keystrokes into a terminal without
+// saying WHICH machine would be the one write path that doesn't. That component does not exist on
+// main, so the chip goes in at the merge, next to the label below.
+export function DirectTypingStrip({ onStop }: { onStop: () => void }) {
+  return (
+    <div className="flex items-center gap-2 px-1 pb-1 text-xs text-primary">
+      <Keyboard className="size-3.5 shrink-0" />
+      <span className="min-w-0 flex-1 truncate">
+        <span className="font-medium">Typing into terminal</span>
+        <span className="text-muted-foreground"> — keys go straight through</span>
+      </span>
+      <button
+        type="button"
+        onClick={onStop}
+        className="shrink-0 rounded-md px-2 py-0.5 font-medium underline-offset-2 transition-colors hover:underline active:bg-muted"
+      >
+        Stop
+      </button>
+    </div>
+  );
+}

--- a/web/src/hooks/use-direct-typing.ts
+++ b/web/src/hooks/use-direct-typing.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import type {
   ChangeEvent,
   CompositionEvent as ReactCompositionEvent,
@@ -6,7 +6,6 @@ import type {
   RefObject,
 } from "react";
 
-import { useLongPress } from "@/hooks/use-long-press";
 import { useOrderedKeySender } from "@/hooks/use-ordered-key-sender";
 import { textToKeySequence } from "@/lib/key-queue";
 import { setStatus } from "@/lib/status";
@@ -34,28 +33,59 @@ function keyForKeyDown(key: string): string | undefined {
   return SPECIAL_KEYS[key];
 }
 
-interface ImmediateInputOptions {
+interface DirectTypingOptions {
   paneKey: string;
   inputRef: RefObject<HTMLTextAreaElement | null>;
   replyDraft: string;
   canActivate: () => boolean;
+  /** True while the view the mode belongs to has stopped being live: a gone pane, a read-only
+   *  device, or the idle pause. Arming survives none of them — see the disarm effect below. */
+  suspended: boolean;
   sendKeys: (keys: string[]) => Promise<boolean>;
   onActivate: () => void;
   focusInput: () => void;
 }
 
-// The normal composer textarea's direct-terminal mode. It owns the activation gesture, transient
-// Android IME composition value, pane-boundary reset and special-key capture; transport ordering
-// stays in useOrderedKeySender so this hook never permits concurrent one-shot Herdr writes.
-export function useImmediateInput({
+// The composer textarea's direct-terminal mode: what you type goes to the pane as keystrokes,
+// with no trailing Enter. This hook owns the armed state, the transient Android IME composition
+// value, the pane-boundary reset, special-key capture, and the lifecycle rules that disarm it.
+// Transport ordering stays in useOrderedKeySender so this hook never permits concurrent one-shot
+// Herdr writes.
+//
+// It does NOT own the entry point. Arming is an explicit NAMED choice — the "Type" toggle in the
+// composer's Controls row, beside Keys.
+//
+// WHY A NAMED CHOICE AND NOT A GESTURE. The submitted version of this feature armed the mode on a
+// bare long press of the Send button. That reads as a saving of one tap, but the tap is priced per
+// SESSION, not per keystroke: you arm once and then type many keys. What it actually buys is an
+// accidental hold — a pocket, a fumbled scroll, a hesitation over Send with a destructive command in
+// the box — silently pointing the phone keyboard at a live terminal with nothing on screen having
+// asked. This surface's safety story is "you see what is about to go on the wire" (ADR 0005), and a
+// mode you can enter without reading anything sits outside it. A labelled toggle you press on purpose
+// is the cheapest thing that stays inside it. Don't reintroduce a hold as a shortcut.
+//
+// WHY THE MODE DIES WITH THE VIEW. What stands in for a review step here is that you are LOOKING at
+// the pane while you type into it — this is the one write path with no reviewable payload, by design
+// (reviewing each keystroke would defeat it). That condition can quietly stop being true: the mirror
+// is polled, and the poll stops on an idle pause (ADR 0007), on a backgrounded tab, on a pane going
+// away. Hence the disarms below. Never persisted, never restored: there is no path by which this is
+// already armed when you arrive at a screen.
+//
+// Two apparent omissions that are deliberate. A lost connection is NOT a separate trigger — it
+// surfaces as a failed batch, which already disarms, observed directly rather than inferred from a
+// timer. And the reply guard's `composerReady` pre-flight is NOT run on these keystrokes: it refuses
+// to type into an unrecognised screen, and typing into an unrecognised screen is the whole point.
+// Don't "harden" this path by adding it.
+export function useDirectTyping({
   paneKey,
   inputRef,
   replyDraft,
   canActivate,
+  suspended,
   sendKeys,
   onActivate,
   focusInput,
-}: ImmediateInputOptions) {
+}: DirectTypingOptions) {
   const [active, setActive] = useState(false);
   const [value, setValue] = useState("");
   const composing = useRef(false);
@@ -76,7 +106,7 @@ export function useImmediateInput({
     // A buffered reply and live keystrokes cannot safely share one field. Keep the durable draft
     // exactly where it is and make the user send or clear it before arming direct terminal input.
     if (replyDraft.length > 0) {
-      setStatus("Send or clear the draft before starting Immediate mode.", "info");
+      setStatus("Send or clear the draft before typing into the terminal.", "info");
       return;
     }
     onActivate();
@@ -84,7 +114,7 @@ export function useImmediateInput({
     composing.current = false;
     committedComposition.current = null;
     setActive(true);
-    setStatus("Immediate mode on — keys send as you type.", "success");
+    setStatus("Typing into the terminal — keys send as you type.", "success");
     // Focus synchronously while the long-press/contextmenu gesture still carries browser user
     // activation; a deferred focus selects the field but mobile browsers may refuse to open their
     // software keyboard once that activation has expired. The existing callback still runs after
@@ -103,22 +133,33 @@ export function useImmediateInput({
 
   function deactivate() {
     clearMode();
-    setStatus("Immediate mode off", "info");
+    setStatus("Back to sending replies", "info");
   }
 
   function deactivateSilently() {
     clearMode();
   }
 
-  // A normal tap keeps the Send button's existing meaning. Holding toggles Immediate mode;
-  // useLongPress suppresses the synthesized click after the hold, including Android's contextmenu.
-  const longPressAction = active ? deactivate : activate;
-  const focusAfterLongPress = useCallback(() => {
-    inputRef.current?.focus();
-  }, [inputRef]);
-  const longPress = useLongPress(canActivate() ? longPressAction : undefined, {
-    onReleaseAfterLongPress: focusAfterLongPress,
-  });
+  // Arming dies with the view it belongs to. A backgrounded tab, an idle pause and a lost bridge
+  // all mean the same thing: the mirror on screen has stopped tracking the pane, and the next
+  // keystroke would go into a terminal the user is no longer actually looking at. Disarm rather
+  // than hold the mode open across the gap — the cost is one re-arm, the alternative is typing
+  // blind. Never persisted, never restored — see the lifecycle note in send-mode-menu.tsx.
+  useEffect(() => {
+    if (!active || !suspended) return;
+    clearMode();
+    setStatus("Stopped typing into the terminal — the pane view was interrupted.", "info");
+  }, [active, suspended]);
+
+  useEffect(() => {
+    if (!active) return;
+    const onVisibility = () => {
+      if (document.visibilityState !== "hidden") return;
+      clearMode();
+    };
+    document.addEventListener("visibilitychange", onVisibility);
+    return () => document.removeEventListener("visibilitychange", onVisibility);
+  }, [active]);
 
   // Direct input never crosses a pane boundary. Reset also invalidates keys accumulated behind an
   // in-flight call; the call already on the wire captured the old pane and cannot be recalled.
@@ -196,7 +237,7 @@ export function useImmediateInput({
     active,
     value,
     busy: sender.busy,
-    longPress,
+    activate,
     deactivate,
     deactivateSilently,
     onChange,

--- a/web/src/hooks/use-immediate-input.ts
+++ b/web/src/hooks/use-immediate-input.ts
@@ -1,0 +1,207 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type {
+  ChangeEvent,
+  CompositionEvent as ReactCompositionEvent,
+  KeyboardEvent as ReactKeyboardEvent,
+  RefObject,
+} from "react";
+
+import { useLongPress } from "@/hooks/use-long-press";
+import { useOrderedKeySender } from "@/hooks/use-ordered-key-sender";
+import { textToKeySequence } from "@/lib/key-queue";
+import { setStatus } from "@/lib/status";
+
+// Physical-keyboard events that do not change a textarea value still need wire names. Printable
+// text, spaces and line breaks normally arrive through the input/change path instead.
+const SPECIAL_KEYS: Readonly<Record<string, string>> = {
+  Escape: "Escape",
+  Tab: "Tab",
+  ArrowUp: "Up",
+  ArrowDown: "Down",
+  ArrowLeft: "Left",
+  ArrowRight: "Right",
+};
+
+function keyForInputType(inputType: string): string | null {
+  if (inputType === "deleteContentBackward") return "Backspace";
+  if (inputType === "insertLineBreak" || inputType === "insertParagraph") return "Enter";
+  return null;
+}
+
+function keyForKeyDown(key: string): string | undefined {
+  if (key === "Backspace") return "Backspace";
+  if (key === "Enter") return "Enter";
+  return SPECIAL_KEYS[key];
+}
+
+interface ImmediateInputOptions {
+  paneKey: string;
+  inputRef: RefObject<HTMLTextAreaElement | null>;
+  replyDraft: string;
+  canActivate: () => boolean;
+  sendKeys: (keys: string[]) => Promise<boolean>;
+  onActivate: () => void;
+  focusInput: () => void;
+}
+
+// The normal composer textarea's direct-terminal mode. It owns the activation gesture, transient
+// Android IME composition value, pane-boundary reset and special-key capture; transport ordering
+// stays in useOrderedKeySender so this hook never permits concurrent one-shot Herdr writes.
+export function useImmediateInput({
+  paneKey,
+  inputRef,
+  replyDraft,
+  canActivate,
+  sendKeys,
+  onActivate,
+  focusInput,
+}: ImmediateInputOptions) {
+  const [active, setActive] = useState(false);
+  const [value, setValue] = useState("");
+  const composing = useRef(false);
+  const committedComposition = useRef<string | null>(null);
+  const sender = useOrderedKeySender(sendKeys, () => {
+    setActive(false);
+    setValue("");
+    composing.current = false;
+    committedComposition.current = null;
+    // Stop the phone keyboard too: otherwise continued typing after a transport failure silently
+    // becomes a buffered Reply, which is a different action with an eventual Enter attached. Defer
+    // past the activation focus timer so even an immediate failure cannot be re-focused behind us.
+    setTimeout(() => inputRef.current?.blur(), 0);
+  });
+
+  function activate() {
+    if (!canActivate()) return;
+    // A buffered reply and live keystrokes cannot safely share one field. Keep the durable draft
+    // exactly where it is and make the user send or clear it before arming direct terminal input.
+    if (replyDraft.length > 0) {
+      setStatus("Send or clear the draft before starting Immediate mode.", "info");
+      return;
+    }
+    onActivate();
+    setValue("");
+    composing.current = false;
+    committedComposition.current = null;
+    setActive(true);
+    setStatus("Immediate mode on — keys send as you type.", "success");
+    // Focus synchronously while the long-press/contextmenu gesture still carries browser user
+    // activation; a deferred focus selects the field but mobile browsers may refuse to open their
+    // software keyboard once that activation has expired. The existing callback still runs after
+    // React swaps the controlled value so selection lands at the end.
+    inputRef.current?.focus();
+    focusInput();
+  }
+
+  function clearMode() {
+    setActive(false);
+    setValue("");
+    composing.current = false;
+    committedComposition.current = null;
+    focusInput();
+  }
+
+  function deactivate() {
+    clearMode();
+    setStatus("Immediate mode off", "info");
+  }
+
+  function deactivateSilently() {
+    clearMode();
+  }
+
+  // A normal tap keeps the Send button's existing meaning. Holding toggles Immediate mode;
+  // useLongPress suppresses the synthesized click after the hold, including Android's contextmenu.
+  const longPressAction = active ? deactivate : activate;
+  const focusAfterLongPress = useCallback(() => {
+    inputRef.current?.focus();
+  }, [inputRef]);
+  const longPress = useLongPress(canActivate() ? longPressAction : undefined, {
+    onReleaseAfterLongPress: focusAfterLongPress,
+  });
+
+  // Direct input never crosses a pane boundary. Reset also invalidates keys accumulated behind an
+  // in-flight call; the call already on the wire captured the old pane and cannot be recalled.
+  useEffect(() => {
+    setActive(false);
+    setValue("");
+    composing.current = false;
+    committedComposition.current = null;
+    sender.reset();
+  }, [paneKey, sender.reset]);
+
+  // Android virtual Backspace/Enter can arrive as beforeinput without a useful keydown. A native
+  // listener is intentional: React's synthetic beforeinput omits these events on some engines.
+  useEffect(() => {
+    const inputEl = inputRef.current;
+    if (!active || inputEl === null) return;
+    const onBeforeInput = (event: InputEvent) => {
+      const key = keyForInputType(event.inputType);
+      if (key === null) return;
+      // Backspace inside an active IME edits the candidate; Enter commits/submits and must still reach
+      // the terminal. Gboard commonly marks that insertParagraph event as composing.
+      if (event.isComposing && key === "Backspace") return;
+      event.preventDefault();
+      sender.enqueue([key]);
+    };
+    inputEl.addEventListener("beforeinput", onBeforeInput);
+    return () => inputEl.removeEventListener("beforeinput", onBeforeInput);
+  }, [active, inputRef, sender.enqueue]);
+
+  function onChange(event: ChangeEvent<HTMLTextAreaElement>) {
+    const next = event.target.value;
+    setValue(next);
+    const inputEvent = event.nativeEvent as InputEvent;
+    if (inputEvent.isComposing || composing.current) return;
+
+    // Gboard can follow compositionend with one ordinary input carrying the same committed word.
+    // Drop that prefix rather than sending a swipe twice, while preserving any suffix typed in the
+    // same event (commonly the auto-inserted space before the next swiped word).
+    const committed = committedComposition.current;
+    if (committed !== null) {
+      committedComposition.current = null;
+      const remainder = next.startsWith(committed) ? next.slice(committed.length) : next;
+      if (remainder.length > 0) sender.enqueue(textToKeySequence(remainder));
+      setValue("");
+      return;
+    }
+
+    if (next.length === 0) return;
+    sender.enqueue(textToKeySequence(next));
+    setValue("");
+  }
+
+  function onCompositionStart() {
+    composing.current = true;
+    committedComposition.current = null;
+  }
+
+  function onCompositionEnd(event: ReactCompositionEvent<HTMLTextAreaElement>) {
+    composing.current = false;
+    const committed = event.currentTarget.value || event.data;
+    if (committed.length === 0) return;
+    committedComposition.current = committed;
+    sender.enqueue(textToKeySequence(committed));
+    setValue("");
+  }
+
+  function onKeyDown(event: ReactKeyboardEvent<HTMLTextAreaElement>) {
+    const key = keyForKeyDown(event.key);
+    if (key === undefined) return;
+    event.preventDefault();
+    sender.enqueue([key]);
+  }
+
+  return {
+    active,
+    value,
+    busy: sender.busy,
+    longPress,
+    deactivate,
+    deactivateSilently,
+    onChange,
+    onCompositionStart,
+    onCompositionEnd,
+    onKeyDown,
+  };
+}

--- a/web/src/hooks/use-long-press.test.ts
+++ b/web/src/hooks/use-long-press.test.ts
@@ -10,6 +10,9 @@ const DELAY = 450;
 function down(x = 0, y = 0, button = 0): ReactPointerEvent {
   return { button, clientX: x, clientY: y } as unknown as ReactPointerEvent;
 }
+function pointerEndEvent(): ReactPointerEvent {
+  return { preventDefault: vi.fn() } as unknown as ReactPointerEvent;
+}
 function clickEvent(): ReactMouseEvent {
   return { preventDefault: vi.fn(), stopPropagation: vi.fn() } as unknown as ReactMouseEvent;
 }
@@ -38,6 +41,25 @@ describe("useLongPress", () => {
     act(() => result.current.onPointerDown(down()));
     act(() => vi.advanceTimersByTime(DELAY - 1));
     expect(onLongPress).not.toHaveBeenCalled();
+  });
+
+  it("runs the completion callback from pointerup's trusted gesture after a fired hold", () => {
+    const onLongPress = vi.fn();
+    const onReleaseAfterLongPress = vi.fn();
+    const { result } = renderHook(() =>
+      useLongPress(onLongPress, { onReleaseAfterLongPress }),
+    );
+    act(() => result.current.onPointerDown(down()));
+    act(() => vi.advanceTimersByTime(DELAY));
+    expect(onReleaseAfterLongPress).not.toHaveBeenCalled();
+
+    const up = pointerEndEvent();
+    act(() => result.current.onPointerUp(up));
+    expect(up.preventDefault).toHaveBeenCalled();
+    expect(onReleaseAfterLongPress).toHaveBeenCalledTimes(1);
+
+    act(() => result.current.onClickCapture(clickEvent()));
+    expect(onReleaseAfterLongPress).toHaveBeenCalledTimes(1);
   });
 
   it("cancels on pointerup before the delay (a normal tap)", () => {
@@ -125,13 +147,17 @@ describe("useLongPress", () => {
 
   // Android long-press / desktop right-click reach us as a `contextmenu` event, not (or not only) the
   // hold timer. These cover that trigger and its idempotency against the timer.
-  it("opens via contextmenu and prevents the native menu (Android long-press / right-click)", () => {
+  it("opens and completes via contextmenu (Android long-press / right-click)", () => {
     const onLongPress = vi.fn();
-    const { result } = renderHook(() => useLongPress(onLongPress));
+    const onReleaseAfterLongPress = vi.fn();
+    const { result } = renderHook(() =>
+      useLongPress(onLongPress, { onReleaseAfterLongPress }),
+    );
     const e = contextMenuEvent();
     act(() => result.current.onContextMenu(e));
     expect(e.preventDefault).toHaveBeenCalled();
     expect(onLongPress).toHaveBeenCalledTimes(1);
+    expect(onReleaseAfterLongPress).toHaveBeenCalledTimes(1);
   });
 
   it("opens via contextmenu even when a pointercancel already killed the hold timer", () => {

--- a/web/src/hooks/use-long-press.ts
+++ b/web/src/hooks/use-long-press.ts
@@ -13,6 +13,9 @@ const MOVE_CANCEL_PX = 16;
 interface LongPressOptions {
   delayMs?: number;
   moveTolerance?: number;
+  // Runs from the trusted pointer/contextmenu event that ends a completed hold. Use this for browser
+  // APIs (notably opening a phone keyboard) that reject calls made from the hold timer itself.
+  onReleaseAfterLongPress?: () => void;
 }
 
 /**
@@ -36,12 +39,17 @@ interface LongPressOptions {
  */
 export function useLongPress(
   onLongPress: (() => void) | undefined,
-  { delayMs = LONG_PRESS_MS, moveTolerance = MOVE_CANCEL_PX }: LongPressOptions = {},
+  {
+    delayMs = LONG_PRESS_MS,
+    moveTolerance = MOVE_CANCEL_PX,
+    onReleaseAfterLongPress,
+  }: LongPressOptions = {},
 ) {
   const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const startPos = useRef<{ x: number; y: number } | null>(null);
   // A long-press fired on the in-progress gesture → suppress the ensuing click so it doesn't navigate.
   const fired = useRef(false);
+  const releaseHandled = useRef(false);
 
   const clear = useCallback(() => {
     if (timer.current !== null) {
@@ -64,6 +72,12 @@ export function useLongPress(
     onLongPress();
   }, [onLongPress, clear]);
 
+  const finish = useCallback(() => {
+    if (!fired.current || releaseHandled.current) return;
+    releaseHandled.current = true;
+    onReleaseAfterLongPress?.();
+  }, [onReleaseAfterLongPress]);
+
   const onPointerDown = useCallback(
     (e: ReactPointerEvent) => {
       if (!onLongPress) return;
@@ -71,6 +85,7 @@ export function useLongPress(
       // so a repeat that reaches us via `contextmenu` (desktop right-click's pointerdown is button 2)
       // can open again rather than being blocked by the previous gesture's still-set flag.
       fired.current = false;
+      releaseHandled.current = false;
       // Primary pointer only (0 for touch/pen too) — ignore right-click / secondary contacts for the
       // hold timer (right-click still opens via onContextMenu below).
       if (e.button !== 0) return;
@@ -92,6 +107,18 @@ export function useLongPress(
     [clear, moveTolerance],
   );
 
+  const finishPointerGesture = useCallback(
+    (e?: ReactPointerEvent) => {
+      clear();
+      if (!fired.current) return;
+      // Do not let the button's pointer-up default action reclaim focus after the completion callback
+      // moves it elsewhere (the exact ordering that otherwise closes a newly-opened phone keyboard).
+      e?.preventDefault();
+      finish();
+    },
+    [clear, finish],
+  );
+
   // Android Chrome raises `contextmenu` at the end of a long-press (desktop does on right-click). When
   // actions are enabled we (1) preventDefault so the native menu never hijacks the gesture, and (2)
   // trigger the sheet — this is the fallback path when a native `pointercancel` already killed the
@@ -102,24 +129,30 @@ export function useLongPress(
       if (!onLongPress) return;
       e.preventDefault();
       fire();
+      finish();
     },
-    [onLongPress, fire],
+    [onLongPress, fire, finish],
   );
 
-  const onClickCapture = useCallback((e: ReactMouseEvent) => {
-    if (!fired.current) return;
-    fired.current = false;
-    // Capture phase runs before the element's own bubble-phase onClick; stopping here cancels it.
-    e.preventDefault();
-    e.stopPropagation();
-  }, []);
+  const onClickCapture = useCallback(
+    (e: ReactMouseEvent) => {
+      if (!fired.current) return;
+      finish();
+      fired.current = false;
+      releaseHandled.current = false;
+      // Capture phase runs before the element's own bubble-phase onClick; stopping here cancels it.
+      e.preventDefault();
+      e.stopPropagation();
+    },
+    [finish],
+  );
 
   return {
     onPointerDown,
     onPointerMove,
-    onPointerUp: clear,
-    onPointerLeave: clear,
-    onPointerCancel: clear,
+    onPointerUp: finishPointerGesture,
+    onPointerLeave: finishPointerGesture,
+    onPointerCancel: finishPointerGesture,
     onContextMenu,
     onClickCapture,
   };

--- a/web/src/hooks/use-ordered-key-sender.test.ts
+++ b/web/src/hooks/use-ordered-key-sender.test.ts
@@ -1,0 +1,86 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { useOrderedKeySender } from "./use-ordered-key-sender";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+describe("useOrderedKeySender", () => {
+  it("keeps one call in flight and batches everything typed behind it", async () => {
+    const first = deferred<boolean>();
+    const send = vi
+      .fn<(keys: string[]) => Promise<boolean>>()
+      .mockImplementationOnce(() => first.promise)
+      .mockResolvedValue(true);
+    const { result } = renderHook(() => useOrderedKeySender(send, vi.fn()));
+
+    act(() => result.current.enqueue(["a"]));
+    await waitFor(() => expect(send).toHaveBeenCalledWith(["a"]));
+
+    act(() => {
+      result.current.enqueue(["b"]);
+      result.current.enqueue(["c", "d"]);
+    });
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(result.current.busy).toBe(true);
+
+    first.resolve(true);
+    await waitFor(() => expect(send).toHaveBeenNthCalledWith(2, ["b", "c", "d"]));
+    await waitFor(() => expect(result.current.busy).toBe(false));
+  });
+
+  it("splits a large committed string into bounded ordered requests", async () => {
+    const send = vi.fn<(keys: string[]) => Promise<boolean>>().mockResolvedValue(true);
+    const { result } = renderHook(() => useOrderedKeySender(send, vi.fn()));
+    const keys = Array.from({ length: 70 }, (_, i) => String(i % 10));
+
+    act(() => result.current.enqueue(keys));
+
+    await waitFor(() => expect(send).toHaveBeenCalledTimes(2));
+    expect(send.mock.calls[0][0]).toEqual(keys.slice(0, 64));
+    expect(send.mock.calls[1][0]).toEqual(keys.slice(64));
+    await waitFor(() => expect(result.current.busy).toBe(false));
+  });
+
+  it("stops and discards queued keys after a failed batch", async () => {
+    const first = deferred<boolean>();
+    const send = vi.fn<(keys: string[]) => Promise<boolean>>().mockReturnValue(first.promise);
+    const onFailure = vi.fn();
+    const { result } = renderHook(() => useOrderedKeySender(send, onFailure));
+
+    act(() => result.current.enqueue(["a"]));
+    await waitFor(() => expect(send).toHaveBeenCalledTimes(1));
+    act(() => result.current.enqueue(["b"]));
+
+    first.resolve(false);
+    await waitFor(() => expect(onFailure).toHaveBeenCalledTimes(1));
+    expect(send).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(result.current.busy).toBe(false));
+  });
+
+  it("reset drops queued keys without cancelling the batch already on the wire", async () => {
+    const first = deferred<boolean>();
+    const send = vi
+      .fn<(keys: string[]) => Promise<boolean>>()
+      .mockImplementationOnce(() => first.promise)
+      .mockResolvedValue(true);
+    const { result } = renderHook(() => useOrderedKeySender(send, vi.fn()));
+
+    act(() => result.current.enqueue(["old"]));
+    await waitFor(() => expect(send).toHaveBeenCalledTimes(1));
+    act(() => {
+      result.current.enqueue(["discard"]);
+      result.current.reset();
+    });
+
+    first.resolve(true);
+    await waitFor(() => expect(result.current.busy).toBe(false));
+    expect(send).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/src/hooks/use-ordered-key-sender.ts
+++ b/web/src/hooks/use-ordered-key-sender.ts
@@ -1,0 +1,87 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+// Bound one request when an IME or paste commits a large string at once. The remainder stays queued
+// behind it, preserving order without handing the bridge an unbounded JSON array.
+const MAX_BATCH = 64;
+
+// Serialize bursts of keys through Herdr's one-shot RPC. Ordering is guaranteed inside one
+// `send_keys` array, but not across concurrent connections, so one batch stays in flight while any
+// later input accumulates into the next batch. This is transport backpressure, not a typing delay:
+// the first key leaves immediately and a slow round trip merely makes the following batch larger.
+export function useOrderedKeySender(
+  send: (keys: string[]) => Promise<boolean>,
+  onFailure: () => void,
+) {
+  const pending = useRef<string[]>([]);
+  const inFlight = useRef(false);
+  const generation = useRef(0);
+  const mounted = useRef(true);
+  const sendRef = useRef(send);
+  const failureRef = useRef(onFailure);
+  const pumpRef = useRef<() => void>(() => {});
+  const [busy, setBusy] = useState(false);
+
+  sendRef.current = send;
+  failureRef.current = onFailure;
+
+  const pump = useCallback(() => {
+    if (inFlight.current || pending.current.length === 0) return;
+
+    const batch = pending.current.splice(0, MAX_BATCH);
+    const batchGeneration = generation.current;
+    inFlight.current = true;
+
+    const flush = async () => {
+      try {
+        let ok = false;
+        try {
+          ok = await sendRef.current(batch);
+        } catch {
+          // A thrown transport failure has the same stop-now semantics as a false verdict.
+        }
+        if (!ok && batchGeneration === generation.current) {
+          // A failure makes the target's input state unknown. Stop immediately and discard anything
+          // that had not reached the wire rather than resuming blind after a transient error.
+          pending.current = [];
+          generation.current += 1;
+          failureRef.current();
+        }
+      } finally {
+        inFlight.current = false;
+        if (pending.current.length > 0) {
+          pumpRef.current();
+        } else if (mounted.current) {
+          setBusy(false);
+        }
+      }
+    };
+    void flush();
+  }, []);
+  pumpRef.current = pump;
+
+  const enqueue = useCallback((keys: string[]) => {
+    if (keys.length === 0) return;
+    pending.current.push(...keys);
+    if (mounted.current) setBusy(true);
+    pumpRef.current();
+  }, []);
+
+  // Invalidate queued work when the pane changes. An RPC already in flight cannot be recalled, but
+  // it captured the old target before the reset; no unsent key is allowed to leak into the new pane.
+  const reset = useCallback(() => {
+    generation.current += 1;
+    pending.current = [];
+    if (!inFlight.current && mounted.current) setBusy(false);
+  }, []);
+
+  useEffect(
+    () => () => {
+      mounted.current = false;
+      generation.current += 1;
+      pending.current = [];
+    },
+    [],
+  );
+
+  return { enqueue, reset, busy };
+}

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -47,6 +47,18 @@
   --popover-foreground: light-dark(oklch(0.145 0 0), oklch(0.985 0 0));
   --primary: light-dark(oklch(0.205 0 0), oklch(0.922 0 0));
   --primary-foreground: light-dark(oklch(0.985 0 0), oklch(0.205 0 0));
+  /* The "this control is ON" tint — a very light sky. Its own token pair rather than reusing
+     --secondary because the two say different things: secondary is a quieter surface, this is a
+     STATE, and the row needs the difference legible at a glance (an open dock, an armed mode). Kept
+     low-chroma so a row of grey controls doesn't turn into a traffic light when two are on.
+
+     The light half is tuned by CHROMA, not luminance: at "very light sky" lightness the tint is only
+     ~1.2:1 against the page by WCAG, and no value that still reads as light sky does better — what
+     makes it visible is that it is the one saturated thing in a neutral row. Don't "fix" that number
+     by darkening it into a mid blue. Text on the tint is what has to clear a contrast bar, and does:
+     7.3:1 light, 9.2:1 dark. */
+  --control-on: light-dark(oklch(0.90 0.06 235), oklch(0.32 0.05 240));
+  --control-on-foreground: light-dark(oklch(0.38 0.12 245), oklch(0.89 0.06 235));
   --secondary: light-dark(oklch(0.94 0 0), oklch(0.269 0 0));
   --secondary-foreground: light-dark(oklch(0.205 0 0), oklch(0.985 0 0));
   /* Light --muted is a step BELOW --background so the header/composer chrome band still reads as a
@@ -147,6 +159,8 @@
   --color-popover-foreground: var(--popover-foreground);
   --color-primary: var(--primary);
   --color-primary-foreground: var(--primary-foreground);
+  --color-control-on: var(--control-on);
+  --color-control-on-foreground: var(--control-on-foreground);
   --color-secondary: var(--secondary);
   --color-secondary-foreground: var(--secondary-foreground);
   --color-muted: var(--muted);

--- a/web/src/lib/key-queue.test.ts
+++ b/web/src/lib/key-queue.test.ts
@@ -7,6 +7,7 @@ import {
   modifierLabel,
   nextModMode,
   normalizeBaseChar,
+  textToKeySequence,
 } from "./key-queue";
 
 describe("composeKey", () => {
@@ -124,5 +125,28 @@ describe("normalizeBaseChar", () => {
     expect(normalizeBaseChar("")).toBeNull();
     expect(normalizeBaseChar(" ")).toBeNull();
     expect(normalizeBaseChar("\t")).toBeNull();
+  });
+});
+
+describe("textToKeySequence", () => {
+  it("preserves literal character order and case without adding Enter", () => {
+    expect(textToKeySequence("b")).toEqual(["b"]);
+    expect(textToKeySequence("Ab!")).toEqual(["A", "b", "!"]);
+  });
+
+  it("uses verified names for whitespace keys", () => {
+    expect(textToKeySequence("a b\tc\nd")).toEqual([
+      "a",
+      "Space",
+      "b",
+      "Tab",
+      "c",
+      "Enter",
+      "d",
+    ]);
+  });
+
+  it("normalises CRLF and CR to one explicit Enter each", () => {
+    expect(textToKeySequence("a\r\nb\rc")).toEqual(["a", "Enter", "b", "Enter", "c"]);
   });
 });

--- a/web/src/lib/key-queue.ts
+++ b/web/src/lib/key-queue.ts
@@ -1,7 +1,7 @@
-// Pure model for the nav-tray key queue: compose a set of modifiers onto a base key, label a key
-// for a chip, flag danger keys, cycle a modifier's three-state mode, and normalise the one-char key
-// input. No React, no I/O — every string this produces is what goes on the wire to Herdr's
-// `pane.send_keys` (see HERDR_API.md).
+// Pure model for the nav-tray key queue and the composer's immediate-input mode: compose a set of
+// modifiers onto a base key, turn typed text into ordered Herdr keys, label keys for chips, flag
+// danger keys, cycle modifier state, and normalise the one-char chord input. No React, no I/O —
+// every string this produces is what goes on the wire to Herdr's `pane.send_keys`.
 
 // The modifiers Collie surfaces in the tray. Multi-modifier chords in ANY order — `ctrl+shift+p`,
 // the triple `ctrl+alt+shift+p`, `alt+Up` — are now LIVE-VERIFIED against Herdr (0.7.3 sandbox +
@@ -108,4 +108,17 @@ export function normalizeBaseChar(raw: string): string | null {
   const code = ch.charCodeAt(0);
   if (code < 0x21 || code > 0x7e) return null;
   return ch.toLowerCase();
+}
+
+// Turn text committed by a phone keyboard into one ordered `pane.send_keys` array. Ordinary
+// characters stay literal and case-preserving; whitespace whose literal wire behaviour is not
+// verified uses Herdr's named keys. A newline the user explicitly typed becomes Enter, but no
+// trailing Enter is ever added. Normalise pasted CRLF/CR first so one visual line break is one key.
+export function textToKeySequence(text: string): string[] {
+  return Array.from(text.replace(/\r\n?/g, "\n"), (char) => {
+    if (char === " ") return "Space";
+    if (char === "\t") return "Tab";
+    if (char === "\n") return "Enter";
+    return char;
+  });
 }


### PR DESCRIPTION
Completes @aspiers' #77. Their commit is cherry-picked with authorship preserved; the entry point and armed presentation are reworked on top.

Fixes #74.

## What ships

A **"Type" toggle in the Controls row, beside Keys.** While on, what you type goes to the pane as keystrokes with no trailing Enter, so a TUI that wants bare letters (`b`, `q`) can be driven from a phone.

## What changed from #77, and why

**Entry is a named toggle, not a gesture.** The submitted version armed on a bare long press of Send. That reads as saving a tap, but the tap is per *session* — you arm once and type many keys — and what it actually buys is an accidental hold quietly pointing the phone keyboard at a live terminal. A split Send button was built next and rejected too: a third of the primary action's width, spent every day, for a mode used in bursts. Keys is the real sibling — it exists because a phone keyboard can't send Esc/Tab/arrows/chords, this exists because it can't send bare printable letters — so someone hunting for `b` finds it where they already looked.

**It dies with the pane view.** Added disarms on a hidden page and on a composer lock (gone pane, read-only device, idle pause), alongside #77's pane-switch and failed-batch cases. The mirror is polled and the poll stops in all of them, so the next keystroke would land in a terminal nobody is watching. A lost connection is deliberately *not* a separate trigger: it already surfaces as a failed batch, observed directly rather than inferred from a timer.

**Armed state gets a strip in the document flow** above the input — the button and textarea are exactly what you stop looking at once typing starts.

**Renamed from "Immediate mode"**, which named the latency rather than the destination.

The pump (ordered, bounded 64-key batches over Herdr's one-connection-per-RPC transport), the Android/IME capture, and the fail-stop are @aspiers' work, untouched.

## Also in here

A composer layout pass the fourth toggle forced: an "on" control carries a light-sky state tint (`--control-on`), the "Controls" tag floats out of the row's flex flow to buy back ~60px of a 390px phone, and attach moves inside the field messenger-style with Send gaining a little air.

## Verification

Backend 534 · ctl lifecycle passed · web 104 files / 1716 tests · both typechecks clean. Driven on a real browser at 390px in both themes; geometry and contrast measured rather than eyeballed.

**Untested:** Android/Gboard IME. jsdom only simulates that event stream — swipe-typing a word and Backspace mid-word are the paths to exercise on a real device.

No version bump; the release commit follows.