### PR TITLE
fix(state): stop the session-name poll from scrolling idle claude panes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to Collie are recorded here. The format follows
 `version` in `herdr-plugin.toml`, `package.json`, and `web/package.json` (enforced by
 `scripts/check-version.sh`). See [`CLAUDE.md`](./CLAUDE.md) → *Versioning* for the bump policy.
 
+## [0.26.1] - 2026-08-10
+
+### Fixed
+
+- **Idle Claude panes no longer scroll up and snap back on every poll** — the session-name sniffer read `recent`, which on a pane shorter than the read makes Herdr scroll a full-screen agent to reach the rows above it; it reads the visible grid now (b00e8d1)
+
 ## [0.26.0] - 2026-08-10
 
 ### Added

--- a/HERDR_API.md
+++ b/HERDR_API.md
@@ -40,6 +40,31 @@ the socket assumptions behind the design in [`ARCHITECTURE.md`](./ARCHITECTURE.m
     visible grid, and its renderer hard-wraps prose at the pane width — there are no soft-wrapped
     rows for the unwrap to merge. It only differs on scrollback-accumulating panes (shells: one
     probe measured 199 → 188 lines with logical lines up to 222 cols re-joined).
+  - **A `recent` text read can scroll the pane it reads.** Herdr's agent-automation docs state that
+    for an idle, recognized agent at the bottom of its transcript, `recent` / `recent_unwrapped`
+    reads "automatically use the agent's mouse-scroll interface" when `lines` asks for more than the
+    visible screen, collecting overlapping pages and "returning the viewport to the bottom before
+    completing the read". Claude runs on the alt screen, which has no host scrollback, so that is the
+    only way those rows can be reached — and the operator watches their terminal scroll up and snap
+    back, once per read. Live-probed 2026-08-10 (herdr 0.8.0), idle claude pane, `viewport_rows: 71`:
+
+    | `source` | `lines` | `format` | elapsed | lines returned |
+    |---|---|---|---|---|
+    | `recent` | 70 | `text` | 0.00s | 71 |
+    | `recent` | 71 | `text` | 0.00s | 72 |
+    | `recent` | 72 | `text` | 0.85s | 73 |
+    | `recent` | 400 | `text` | 13.8s | 401 |
+    | `recent` | 200 | `ansi` | 0.00s | 71 |
+    | `recent` | 600 | `ansi` | 0.00s | 71 |
+    | `visible` | 600 | `ansi` | 0.00s | 71 |
+
+    The threshold is exactly `lines > viewport_rows`; one row over is enough. **`format: "ansi"` was
+    never observed to harvest** — that is an observation across the probes above, not a documented
+    guarantee, so don't lean on it. `visible` is immune by construction: it *is* the rendered
+    viewport, clamped to it however large `lines` is, so there is nothing above to collect. A
+    background poll that reads panes on a timer must therefore use `visible`
+    (`bridge/state-engine.ts`); anything asking for scrollback is asking to move the operator's
+    screen, and should be a deliberate, user-initiated read.
   **`format: "text"` returns clean plain text (no ANSI escapes)** → safe to render, no XSS surface.
 - `agent.send` writes literal text only; to submit a reply, follow with an Enter keypress
   (`pane.send_keys {keys: ["Enter"]}`) — submit-key name needs live confirmation per agent.

--- a/bridge/server.ts
+++ b/bridge/server.ts
@@ -454,7 +454,11 @@ async function readPane(
       ? Math.min(linesParam, MAX_READ_LINES)
       : cfg.readLines;
   try {
-    // "ansi" so the client can render a faithful, colored terminal mirror.
+    // "ansi" so the client can render a faithful, colored terminal mirror. It is also, as far as we
+    // have probed, why this read leaves the operator's terminal alone: a `recent` read only harvests
+    // an alt-screen pane — scrolling it up and back — in `text` format. `lines` here is whatever the
+    // web app asked for (600 for the history view), well past any pane's height, so switching this
+    // to "text" would move someone's screen on every revalidate. See HERDR_API.md → `pane.read`.
     const read = await herdr.readPane(paneId, "recent", lines, "ansi");
     const data = paneReadResponse(paneId, read);
     // ETag is derived from the serialised body — if content hasn't changed the client gets a 304

--- a/bridge/state-engine.test.ts
+++ b/bridge/state-engine.test.ts
@@ -357,10 +357,15 @@ describe("StateEngine — session name enrichment", () => {
   class NameHerdr {
     panes: FakePane[] = [];
     texts = new Map<string, string>();
+    // Every readPane call, verbatim. This read is only harmless because of WHICH source it asks for
+    // and how few lines it wants; a fake that swallowed those arguments would let that regress with
+    // every test still green.
+    reads: Array<[string, string, number, string]> = [];
     sessionSnapshot() {
       return Promise.resolve({ version: "0.7.2", protocol: 16, workspaces: [ws("w1", 1)], tabs: [], panes: this.panes });
     }
-    readPane(paneId: string) {
+    readPane(paneId: string, source: string, lines: number, format: string) {
+      this.reads.push([paneId, source, lines, format]);
       return Promise.resolve({ pane_id: paneId, text: this.texts.get(paneId) ?? "", truncated: false, revision: 0 });
     }
   }
@@ -381,6 +386,20 @@ describe("StateEngine — session name enrichment", () => {
     await poll();
     expect(agent("w1:p1").sessionName).toBe("my-feature");
     expect(agent("w1:p2").sessionName).toBeUndefined();
+  });
+
+  // The scroll-jump guard. A `recent` read that wants more rows than the pane shows makes Herdr
+  // harvest the pages above it, and on a full-screen agent that means scrolling the operator's pane
+  // up and back — once per poll, per idle claude pane. Nothing in the types stops the source from
+  // drifting back, and CI can't see the symptom: it only shows on a real terminal.
+  test("reads the visible grid, never recent", async () => {
+    const { herdr, poll } = makeNameEngine();
+    herdr.panes = [pane("w1:p1", "w1", "idle", "claude")];
+    herdr.texts.set("w1:p1", named("pinned"));
+    await poll();
+    // The count is not the safety-critical half — `visible` clamps to the viewport however large it
+    // is — so it is pinned only to keep the whole call in one assertion. Change it freely, here too.
+    expect(herdr.reads).toEqual([["w1:p1", "visible", 40, "text"]]);
   });
 
   test("leaves sessionName absent for an unnamed claude session (plain rule)", async () => {

--- a/bridge/state-engine.ts
+++ b/bridge/state-engine.ts
@@ -13,9 +13,19 @@ import {
 // transition events. Polling (vs the per-pane event subscription) keeps this resync-free: a failed
 // poll just retries next tick, and reconnection needs no special handling. See HERDR_API.md.
 
-// How many recent lines to read per claude pane when sniffing its `/rename` session name. Claude's
-// input box (and the named rule above it) sits at the very tail, so a small window is plenty and
-// keeps the extra per-poll reads cheap.
+// How many lines to read per claude pane when sniffing its `/rename` session name. Claude's input
+// box (and the named rule above it) sits at the very tail, so a small window is plenty and keeps the
+// extra per-poll reads cheap.
+//
+// The source MUST stay `visible`. A `recent` text read asking for more rows than the pane currently
+// shows makes Herdr harvest the pages above the viewport, and on a full-screen agent (Claude runs on
+// the alternate screen, which has no host scrollback) the only way to reach them is to drive the
+// agent's own mouse-scroll interface: Herdr scrolls the pane up page by page, then restores it. The
+// operator watches their terminal jump and snap back — once per poll, per idle claude pane.
+// `visible` cannot do that whatever this count is: it is the rendered viewport, clamped to it. Which
+// is also why this number is free to stay generous — the run below the ❯ prompt is a statusline of
+// unknown height ([ADR 0004](../.adr/0004-the-statusline-run-is-bounded.md)), so headroom is worth
+// more here than a smaller read. See HERDR_API.md → `pane.read`.
 const SESSION_NAME_READ_LINES = 40;
 
 // Claude renders its input box as a horizontal rule, the ❯ prompt line, then a closing rule. After
@@ -29,7 +39,7 @@ const NAMED_RULE = /^[─━]{2,}[ \t]+(\S.*?\S|\S)[ \t]+[─━]+[ \t]*$/;
 const PROMPT_LINE = /^❯/;
 
 /**
- * Pull Claude's own session name (set via `/rename`) out of a pane's recent text, or `undefined` when
+ * Pull Claude's own session name (set via `/rename`) out of a pane's visible text, or `undefined` when
  * the session is unnamed (a plain rule) or the pane isn't showing its input box (a dialog, a working
  * spinner). Claude draws the name INTO the horizontal rule directly above the ❯ prompt, e.g.
  * `────────── my-name ──`; we accept that rule ONLY when the very next line is the ❯ prompt, so a
@@ -337,7 +347,7 @@ export class StateEngine {
   }
 
   /**
-   * Read each claude pane's recent text and attach its `/rename` session name (see
+   * Read each claude pane's visible text and attach its `/rename` session name (see
    * {@link extractClaudeSessionName}) to the view, exactly parallel to `paneLabel`. The name lives
    * only in the pane's rendered text — Herdr's pane metadata doesn't carry it — so this is the one
    * place all panes can pick it up (the web app only holds text for the open pane). Reads run in
@@ -352,7 +362,11 @@ export class StateEngine {
     await Promise.all(
       claude.map(async (a) => {
         try {
-          const read = await this.herdr.readPane(a.paneId, "recent", SESSION_NAME_READ_LINES, "text");
+          // `visible` — never `recent`; see SESSION_NAME_READ_LINES for what a `recent` read does
+          // to the operator's screen. The visible grid is also strictly safer to parse: `recent`
+          // hands back transcript scrollback, where Claude echoes past user messages as `❯ …` lines
+          // that the prompt anchor below would have to discriminate against.
+          const read = await this.herdr.readPane(a.paneId, "visible", SESSION_NAME_READ_LINES, "text");
           const name = extractClaudeSessionName(read.text);
           if (name) this.sessionNames.set(a.paneId, name);
         } catch {

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,6 +1,6 @@
 id = "herdr.collie"
 name = "Collie"
-version = "0.26.0"
+version = "0.26.1"
 min_herdr_version = "0.7.0"
 description = "Mobile web UI to monitor and reply to your agent herd, served over Tailscale"
 platforms = ["linux", "macos"]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "collie",
-  "version": "0.26.0",
+  "version": "0.26.1",
   "private": true,
   "license": "MIT",
   "description": "Collie — a mobile web UI to monitor and reply to your Herdr agent herd over Tailscale",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "collie-web",
-  "version": "0.26.0",
+  "version": "0.26.1",
   "private": true,
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Every idle Claude pane scrolls up and snaps back to the bottom, once per poll, for as long as Collie runs. It is frequent, it is baffling until you know what causes it, and it moves the text under your eyes while you are reading it — none of which this read needs in order to do its job. It takes a pane shorter than 40 rows: `enrichSessionNames` reads each claude pane with `source: "recent"`, `lines: 40`, and Herdr's agent-automation docs say that for an idle, recognised agent a `recent` read asking for more rows than the visible screen "automatically use[s] the agent's mouse-scroll interface", collecting overlapping pages and "returning the viewport to the bottom before completing the read". Claude runs on the alternate screen, which has no host scrollback, so driving the agent's own scroll is the only way to reach those rows — and you watch it happen. My panes were about 70 rows on a 4K screen and this never fired once; moving to 1920x1080 took them to 26–28 rows and it fired on every poll.

The read now asks for `visible` — the rendered viewport, clamped to it however large `lines` is, so there is nothing above it to harvest. Everything else is unchanged: same line count, same extraction, same consumers of `sessionName`. The test fake now records the arguments it receives and pins the source, because this symptom is invisible to CI — it only appears on a physical terminal.

<details><summary>Details, if useful</summary>

Live-probed against herdr 0.8.0, on an idle claude pane with `viewport_rows: 71`:

| `source` | `lines` | `format` | elapsed | lines returned |
|---|---|---|---|---|
| `recent` | 70 | `text` | 0.00s | 71 |
| `recent` | 71 | `text` | 0.00s | 72 |
| `recent` | 72 | `text` | 0.85s | 73 |
| `recent` | 400 | `text` | 13.8s | 401 |
| `recent` | 200 | `ansi` | 0.00s | 71 |
| `recent` | 600 | `ansi` | 0.00s | 71 |
| `visible` | 600 | `ansi` | 0.00s | 71 |

One row over `viewport_rows` is enough. The 401-line result is the giveaway: the pane shows 71 rows and the alternate screen has no scrollback, so the other 330 came from scrolling the agent.

Confirmed blind: with Collie stopped, I fired six `visible` reads and then two `recent`/40 reads back-to-back at a pane I was watching, without knowing the counts beforehand. I saw exactly two scrolls.

`bridge/server.ts` is left alone. Its pane-mirror read is 600 lines, far past any pane height, but it passes `format: "ansi"` and no `ansi` read was ever observed to harvest; it also genuinely wants scrollback, and only runs while someone has that pane open. I left a comment there recording the dependency, since nothing else makes it visible.

The 40 stays 40. With `visible` the count no longer decides anything about scrolling, and the run below the ❯ prompt is a statusline of unknown height (ADR 0004), so the headroom is worth keeping.

`HERDR_API.md` gains the probe table and the rule it implies: a background poll must read `visible`, and anything asking for scrollback is asking to move the operator's screen.

</details>
