### PR TITLE
fix(web): mark API requests as XHR so a redirecting identity proxy refuses instead — Variant C/E only

### DIFF
--- a/web/src/lib/api.test.ts
+++ b/web/src/lib/api.test.ts
@@ -12,6 +12,8 @@ import {
   sendReply,
   uploadImage,
   withTimeout,
+  XHR_HEADER,
+  XHR_HEADER_VALUE,
 } from "./api";
 
 // The default happy-path handlers live in test/handlers.ts; here we focus on the write paths and the
@@ -267,5 +269,41 @@ describe("api client — connection-health stamping", () => {
     __resetConnectionHealth(1);
     await expect(fetchSnapshot()).rejects.toThrow(/502/);
     expect(lastHealthyAt()).toBe(1);
+  });
+});
+
+// A proxy that REDIRECTS an unauthenticated request instead of refusing it strips Collie of the only
+// signal `isAuthError` (lib/loaders.ts) can act on: `fetch` follows the cross-origin 302, the call
+// rejects as a TypeError with no status, and the refusal banner — with the Sign-in link that would
+// restore the session — never renders. Marking requests as XHR is what makes such a proxy answer 401
+// instead. Every path that talks to the bridge must carry it, including the two that bypass `req`:
+// fetchPane builds its own header bag, and uploadImage sets none at all so the browser keeps
+// ownership of the multipart boundary.
+describe("api client — XHR marker for identity proxies", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  function captureHeaders() {
+    const seen: Headers[] = [];
+    vi.spyOn(globalThis, "fetch").mockImplementation(async (_input, init) => {
+      seen.push(new Headers(init?.headers));
+      return new Response("{}", { status: 200, headers: { "content-type": "application/json" } });
+    });
+    return seen;
+  }
+
+  it("marks reads, mutations, pane polls and uploads alike", async () => {
+    const seen = captureHeaders();
+    await fetchSnapshot();
+    await sendReply("w1:p1", "hi");
+    await fetchPane("w1:p1");
+    await uploadImage("w1:p1", new File(["x"], "x.png", { type: "image/png" }));
+    expect(seen).toHaveLength(4);
+    for (const headers of seen) expect(headers.get(XHR_HEADER)).toBe(XHR_HEADER_VALUE);
+  });
+
+  it("leaves the multipart upload without a content-type so the boundary survives", async () => {
+    const seen = captureHeaders();
+    await uploadImage("w1:p1", new File(["x"], "x.png", { type: "image/png" }));
+    expect(seen[0].get("content-type")).toBeNull();
   });
 });

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -18,6 +18,30 @@ import type {
 
 export type { NotifyPrefs, UpdateInfo };
 
+/**
+ * Marks every API request as XHR so a fronting identity proxy answers it with a status we can read.
+ *
+ * The refusal banner (components/connection-banner.tsx) is reached only through `isAuthError`
+ * (lib/loaders.ts), which matches 401/403 on an {@link ApiError}. A proxy that answers an
+ * unauthenticated request with a REDIRECT never produces one: `fetch` follows the 302 to the
+ * identity provider's origin, that response carries no CORS headers, and the call rejects as a
+ * `TypeError` — a transport failure with no status. The user then gets the connection banner
+ * ("can't reach Collie") and, worse, loses the Sign-in link that would have fixed it, since a
+ * missing session is precisely the thing it recovers from.
+ *
+ * Measured against Cloudflare Access with no session: a plain request, `Accept: application/json`
+ * and `Sec-Fetch-Mode: cors` all still redirect; only this header flips the answer to a same-origin
+ * 401. `X-Requested-With: XMLHttpRequest` is the conventional "this is XHR, don't redirect me"
+ * signal rather than one vendor's feature — oauth2-proxy and Authelia read it too — so it stays a
+ * single unconditional header with no proxy-specific branching, in keeping with a bridge that gates
+ * on vendor-neutral headers and manages nobody else's front door (ADR 0001).
+ *
+ * Costs nothing against the bridge itself: it is same-origin by design, so no preflight in practice,
+ * and the bridge ignores headers it does not read.
+ */
+export const XHR_HEADER = "x-requested-with";
+export const XHR_HEADER_VALUE = "XMLHttpRequest";
+
 class ApiError extends Error {
   readonly status: number;
   constructor(message: string, status: number) {
@@ -136,7 +160,11 @@ async function doReq<T>(path: string, init?: RequestInit, recover?: Recover<T>):
   const res = await fetch(path, {
     ...init,
     signal: withTimeout(init?.signal, timeoutMs),
-    headers: { "content-type": "application/json", ...init?.headers },
+    headers: {
+      "content-type": "application/json",
+      [XHR_HEADER]: XHR_HEADER_VALUE,
+      ...init?.headers,
+    },
   });
   captureBuild(res);
   if (!res.ok) {
@@ -206,7 +234,10 @@ export async function fetchPane(
   // SEEN_HEADER is what tells the bridge this read came from our own page and may mark the pane
   // seen. A cross-site no-cors GET can't set a custom header, so it can't clear your alerts by
   // guessing pane ids (bridge/server.ts → marksPaneSeen).
-  const headers: Record<string, string> = { "x-collie-seen": "1" };
+  const headers: Record<string, string> = {
+    "x-collie-seen": "1",
+    [XHR_HEADER]: XHR_HEADER_VALUE,
+  };
   if (cached) headers["if-none-match"] = cached.etag;
 
   const res = await fetch(url, { signal: withTimeout(signal, GET_TIMEOUT_MS), headers });
@@ -421,6 +452,9 @@ export function uploadImage(paneId: string, file: File, session?: string): Promi
       const res = await fetch(withSession(`/api/pane/${encodeURIComponent(paneId)}/upload`, session), {
         method: "POST",
         body: fd,
+        // No content-type: the browser sets the multipart boundary. The XHR marker still applies —
+        // an upload refused by a lapsed proxy session must surface as a status, not a redirect.
+        headers: { [XHR_HEADER]: XHR_HEADER_VALUE },
         signal: withTimeout(undefined, UPLOAD_TIMEOUT_MS),
       });
       if (!res.ok) {

--- a/web/src/lib/push.ts
+++ b/web/src/lib/push.ts
@@ -1,4 +1,4 @@
-import { fetchConfig } from "@/lib/api";
+import { fetchConfig, XHR_HEADER, XHR_HEADER_VALUE } from "@/lib/api";
 import type { BridgeConfig } from "@/lib/types";
 
 // Client-side control of Web Push: the browser subscription plus a per-device preference. The bridge
@@ -101,7 +101,7 @@ export async function enablePush(): Promise<EnableResult> {
   }
   await fetch("/api/subscribe", {
     method: "POST",
-    headers: { "content-type": "application/json" },
+    headers: { "content-type": "application/json", [XHR_HEADER]: XHR_HEADER_VALUE },
     body: JSON.stringify(sub),
   });
   setUserDisabled(false);


### PR DESCRIPTION
## The setup this is for

I run Collie in the **Variant C/E** shape: `COLLIE_SKIP_SERVE=1`, no Tailscale on the
host, and a reverse proxy on a *different* machine reaching the
bridge over the LAN, with **Cloudflare Access** in front of that as the identity
layer on a public hostname. The bridge stays gated on `Host`,
`Origin` and `COLLIE_DEVICE_HEADER`, and the proxy injects the device id exactly
as Variant B describes.

That deployment works well, and I'd rather report from it than ask you to
support it.

## What goes wrong

Everything is fine until the Access session lapses. Then Collie shows
**"can't reach Collie"** — the connection banner — and offers no way back in.
The bridge is up, the tunnel is up, the herd is running.

Two things you already built should have handled this, and both are defeated by
the same detail:

- **#31** reserved `/auth/` so an installed PWA has a reachable path to a
  fronting proxy's sign-in page.
- **#30** made a 401/403 render as a refusal rather than an endless reconnect.

Both depend on the proxy answering with a **status**. #30 says as much in its
own scope note — it classifies by status code, and redirect-based sign-in flows
were not part of the question it set out to answer. This is that leftover case,
not a re-litigation of either. Cloudflare Access answers
an unauthenticated request with a **302 to its own origin**
(`https://<team>.cloudflareaccess.com/cdn-cgi/access/login/…`). `fetch` follows
it, that response carries no CORS headers, and the call rejects as a `TypeError`
— a transport failure with no status. So `isAuthError` (`lib/loaders.ts:120`,
matching 401/403 on `ApiError`) is false, `authError` never sets, and the
`AuthErrorBanner` never renders.

The result is the bad case: the user is shown a *network* error, and the Sign-in
link to `/auth/` — the one control that fixes it — is hidden precisely when a
missing session is the problem. The escape hatch exists and is unreachable.

It compounds with the precache behaviour `sw-routes.ts` already documents: the
SW answers the root navigation from the app shell, so no top-level request
reaches the proxy either and the login is never offered. Recovery today means
knowing to type `/auth/` into an address bar. In an installed PWA there isn't
one.

## Why one header fixes it

Measured against Cloudflare Access, same URL and edge, no session cookie:

| request | response |
|---|---|
| plain `GET /api/snapshot` | 302 |
| `Accept: application/json` | 302 |
| `Sec-Fetch-Mode: cors` | 302 |
| **`X-Requested-With: XMLHttpRequest`** | **401** |
| `X-Nonsense: banana` (arbitrary custom header) | 302 |
| `X-Collie-Seen: 1` (a header Collie already sends) | 302 |
| `X-Requested-With: fetch` (right name, wrong value) | 302 |

The last three are the controls, and they matter: it is not "any custom header",
Collie's existing headers don't already trigger it, and the **value is
load-bearing** — it has to be exactly `XMLHttpRequest`. Each row reproduced
twice.

With a readable same-origin 401, `isAuthError` matches and your existing banner
appears, Sign-in link and all. **No new UI, no new setting, no new option** —
this only makes the path you already shipped reachable from a deployment where
it currently isn't.

`X-Requested-With` is the conventional "this is XHR, don't redirect me" signal
rather than a Cloudflare feature; oauth2-proxy and Authelia read it too. So it
stays one unconditional header with no proxy-specific branching.

## It does not touch your setup

This is the part I'd most want checked, so here is the evidence rather than an
assurance:

- **Under Variant A the bug cannot occur.** When the Tailscale path refuses, the
  *bridge itself* answers 403 (`server.ts:179`, `:1182`, `:1184`) — which
  `isAuthError` already matches, so the banner already works there today. This
  only bites when something *in front of* the bridge redirects instead of
  refusing.
- **Nothing server-side reads the header.** The bridge reads `host`, `origin`,
  `tailscale-user-login`, `cfg.deviceHeader`, `if-none-match` and
  `accept-encoding`. `x-requested-with` appears nowhere in `bridge/`, so it is
  inert; `tailscale serve` passes it through untouched.
- **No preflight risk.** Every API URL in the client is relative, so the
  requests are same-origin by construction and the browser never runs a CORS
  check — the non-safelisted header cannot trigger a preflight. (Worth stating
  plainly, since the bridge has no `OPTIONS` handler, so one would have failed
  loudly rather than silently.)
- The Tailscale coverage — `config.test.ts` (`COLLIE_TRUSTED_USER`),
  `server.test.ts` (`checkAccess` with `tailscale-user-login`, matching and
  mismatching identities) and the 49 Tailscale assertions in
  `collie-ctl.test.sh` — passes unchanged.

### On ADR 0001

I read [ADR 0001](.adr/0001-one-managed-front-door.md) before writing this, and
I don't think it argues against this change — but you're the judge of that, so
here is my reasoning explicitly:

Nothing is managed. No sidecar, no lifecycle, no teardown, no third-party CLI
contract enters the repo — the cost that ADR specifically refused. There is no
vendor branch: one unconditional header, in the same vendor-neutral spirit as
`COLLIE_DEVICE_HEADER`. And it is testable without Cloudflare: the assertion is
"the header is present on every API request", which is a unit test in the
existing suite; the behaviour it unlocks (401 → banner) is already covered by
the #30 path.

## What changed

A name/value constant pair and four applications — every path that reaches the
bridge, including the three that bypass `doReq`:

- `doReq` (covers everything through `req`)
- `fetchPane` — builds its own header bag
- `uploadImage` — previously sent **no** headers, since the browser must own the
  multipart boundary; only the marker is added, no `content-type`
- `push.ts` → `POST /api/subscribe` — posts directly

Tests cover the three in `api.ts` — `fetchSnapshot` and `sendReply` for `doReq`,
plus `fetchPane` and `uploadImage` directly — and pin that the upload still
sends no `content-type`. The `push.ts` call carries the header too but has no
unit test, for the reason `push.test.ts` already records: `enablePush` needs a
real `PushManager`, which jsdom lacks, so only the pure key compare is pinned
there. Happy to follow whatever you'd prefer if you want that covered
differently.

I checked that nothing else reaches the bridge: the service worker's only
`fetch` is the `/fonts/` cache route, and there is no `XMLHttpRequest`,
`EventSource`, axios or `sendBeacon` anywhere in `web/src`. So this is the whole
surface, not a sample of it.

**No version bump or CHANGELOG entry**, though I'd happily add one. CLAUDE.md →
*Versioning* reads as mandatory before any functional change, so I wrote a
0.26.1 release commit first — then checked how PRs from forks actually land
here. Of the eight merged, seven leave `package.json`, `web/package.json`,
`herdr-plugin.toml` and `CHANGELOG.md` untouched and let them move in your own
`chore(release):` commits on `main` (the exception is #12, back in July).
Bumping from a PR would presume the next version and collide with that, so I
dropped the commit; `check-version.sh` passes either way, since all four stay
consistent at 0.26.0. Tell me which you'd prefer and I'll match it.

## Testing

Ran the full `ci.yml` sequence locally, in order, on Node 22 (the lineage
`ubuntu-latest` ships) with Bun 1.3.14:

| step | result |
|---|---|
| `scripts/check-version.sh` | ✓ 0.26.0 consistent across the manifest, both `package.json`s and `CHANGELOG.md` |
| `bun run typecheck` (root) | clean |
| `bun run test` (bridge) | **534 tests across 25 files, 0 fail** — includes the `collie-ctl` lifecycle suite |
| `cd web && bun run typecheck` | clean (app + worker tsconfigs) |
| `cd web && bun run test` | **104 files, 1718 tests, 0 fail** |

The two new cases live in `web/src/lib/api.test.ts`, alongside the existing
session-scoping tests and using the same `fetch`-spy idiom:

- `fetchSnapshot`, `sendReply`, `fetchPane` and `uploadImage` all carry the
  marker — between them the `doReq` path and two of its three bypasses;
- the multipart upload still sends **no** `content-type`, so the browser keeps
  ownership of the boundary.

## Offer

You can't test this path, and I can. I run Collie behind Cloudflare Tunnel +
reverse proxy full-time, which is the ingress shape Variant E documents but
nothing in CI exercises. If it's useful, I'm happy to be a standing test bed for
that configuration — verifying releases against it and reporting back, so
Variant C/E gets some real-world signal without adding anything to your CI or
your maintenance surface. Entirely up to you; no expectation either way.

---

*claude-opus-5 on behalf of Ovidiu Julean*
