### PR TITLE
fix(push): Apple refuses the update topic — "collie-update" is an impossible base64 length

### DIFF
--- a/bridge/push.test.ts
+++ b/bridge/push.test.ts
@@ -3,7 +3,7 @@ import { mkdtemp, readFile, rm, stat } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { Push } from "./push.ts";
+import { Push, topicIsSendable } from "./push.ts";
 import type { PushSender, PushSubscription } from "./push.ts";
 import { loadConfig } from "./config.ts";
 
@@ -287,7 +287,7 @@ describe("Push — per-message collapse topic (update must not share the herd sl
 
     // No `urgency` — an update notice is NOT worth punching through Android's power-saving the way a
     // waiting agent is. The absence is the decision; `toEqual` pins it.
-    expect(sends[0]!.options).toEqual({ topic: "collie-update", TTL: 259_200 });
+    expect(sends[0]!.options).toEqual({ topic: "collie-updates", TTL: 259_200 });
     expect(JSON.parse(sends[0]!.payload).data.target).toBe("settings");
   });
 
@@ -316,5 +316,40 @@ describe("Push — per-message collapse topic (update must not share the herd sl
     // A deferred retraction is as bad as a deferred alert — it strands handled work on the lock
     // screen — so a clear is high-urgency too.
     expect(sends[0]!.options.urgency).toBe("high");
+  });
+
+  // Apple decodes the RFC 8030 `Topic` and refuses a length base64 cannot produce (≡ 1 mod 4), where
+  // FCM and Mozilla treat it as opaque. So a topic shortened for tidiness can break Apple delivery
+  // while every other service keeps working, and nothing surfaces it but that service's 400 —
+  // "collie-update" (13) shipped that way from 0.11.0. Assert the topics the code ACTUALLY emits: a
+  // guard that restated the constants would still pass after someone edited one, which is the only
+  // failure it exists to catch.
+  test("every topic the bridge emits is a shape all push services accept", async () => {
+    const cfg = await tempCfg();
+    const { sender, sends } = capturing();
+    const push = new Push(cfg, sender);
+    enable(push, [sub("a")]);
+
+    await push.send({ type: "update", tag: "collie:update", title: "t", body: "b", target: "settings" });
+    await push.send({ title: "claude needs you", body: "…", tag: "collie:herd", paneId: "w1:p1" });
+    await push.send({ type: "clear", tag: "collie:herd" });
+
+    expect(sends.length).toBe(3);
+    for (const { options } of sends) expect(topicIsSendable(options.topic)).toBe(true);
+  });
+
+  test("topicIsSendable rejects the lengths base64 cannot produce — the Apple trap", () => {
+    expect(topicIsSendable("collie-update")).toBe(false); // 13 ≡ 1 (mod 4) — the shipped bug
+    expect(topicIsSendable("collie-herdab")).toBe(false); // 13 too, unrelated wording, fails alike
+    expect(topicIsSendable("collie-update-xyz")).toBe(false); // 17 ≡ 1 (mod 4)
+    expect(topicIsSendable("a")).toBe(false); // 1 ≡ 1 (mod 4)
+  });
+
+  test("topicIsSendable still enforces RFC 8030's alphabet and ceiling", () => {
+    expect(topicIsSendable("collie herd")).toBe(false); // space
+    expect(topicIsSendable("collie.herd")).toBe(false); // dot is not URL-safe base64
+    expect(topicIsSendable("")).toBe(false);
+    expect(topicIsSendable("a".repeat(33))).toBe(false); // over the 32-char ceiling
+    expect(topicIsSendable("a".repeat(32))).toBe(true); // exactly 32, and 32 ≡ 0
   });
 });

--- a/bridge/push.ts
+++ b/bridge/push.ts
@@ -13,7 +13,14 @@ export type PushSubscription = { endpoint: string; keys: { p256dh: string; auth:
 // default TTL and NO collapse key, so an offline device replays every queued herd update on reconnect.
 //   • `topic` is a collapse key — the push service keeps only the LATEST message per device with this
 //     topic, so a reconnecting phone gets one current summary instead of a burst of stale ones. Must
-//     match [A-Za-z0-9_-] and be ≤32 chars ("collie-herd" is valid).
+//     match [A-Za-z0-9_-] and be ≤32 chars ("collie-herd" is valid) — and, for Apple, must also be a
+//     LENGTH BASE64 CAN PRODUCE: never ≡ 1 (mod 4). RFC 8030 §5.4 only calls the topic URL-safe
+//     base64; Apple enforces that by decoding it, while FCM and Mozilla treat it as opaque. A
+//     13-character topic decodes nowhere (base64 turns 3 bytes into 4 chars, so a trailing group of
+//     one is impossible) and APNs answers 400 `{"reason":"BadWebPushTopic"}` for every endpoint.
+//     Measured, not inferred: "collie-update" (13) and "collie-herdab" (13) both fail, while
+//     "collie-updat" (12), "collie-herd" (11) and "collie-updates" (14) all succeed — so it is the
+//     arithmetic, not a length cap and not the wording. `topicIsSendable` pins this below.
 //   • `TTL` (seconds) bounds how long the service holds an undelivered message: 6h is long enough to
 //     reach a briefly-offline phone but short enough that a day-old "needs you" doesn't resurface.
 //   • `urgency: "high"` is load-bearing on Android, and its absence was a silent alert-eater:
@@ -30,8 +37,17 @@ const SEND_OPTIONS = { TTL: 21_600, topic: "collie-herd", urgency: "high" } as c
 // Update-available pushes ride their OWN collapse topic (and a longer TTL). The `topic` — NOT the
 // client-side `tag` — is the push service's collapse key: sharing "collie-herd" would make an offline
 // device's queued herd summary and an update push silently overwrite each other. 3-day TTL, since an
-// update stays relevant far longer than a transient "needs you".
-const UPDATE_SEND_OPTIONS = { TTL: 259_200, topic: "collie-update" } as const;
+// update stays relevant far longer than a transient "needs you". The trailing "s" is not a typo:
+// "collie-update" is 13 characters, which Apple refuses outright — see the base64 note above.
+const UPDATE_SEND_OPTIONS = { TTL: 259_200, topic: "collie-updates" } as const;
+
+/** Whether a collapse topic is one every push service will accept: RFC 8030's alphabet and 32-char
+ *  ceiling, plus the length base64 can actually produce (Apple decodes it; ≡ 1 mod 4 is impossible).
+ *  Exported for the test that guards the constants above — a topic edited for tidiness would
+ *  otherwise break Apple delivery silently, since nothing surfaces it but the push service's log. */
+export function topicIsSendable(topic: string): boolean {
+  return /^[A-Za-z0-9_-]+$/.test(topic) && topic.length <= 32 && topic.length % 4 !== 1;
+}
 
 // How many consecutive same-origin-witnessed failures retire a subscription (see broadcast()).
 // Broadcasts are event-driven — several in an active hour — so five clears a stale device within a


### PR DESCRIPTION
## What's broken

Every *update-available* push is rejected by APNs with
`400 {"reason":"BadWebPushTopic"}`, for every Apple subscription. Agent alerts
on `collie-herd` deliver normally, so push looks healthy — the only symptom is
that Apple operators never hear about a new release.

I hit this on a self-hosted deployment with Apple-only subscriptions, after
0.25.0 started logging the push service's real reason. Before that it was an
unexplained retry.

## Root cause

RFC 8030 §5.4 describes the collapse topic as URL-safe base64. **Apple enforces
that by decoding it**; FCM and Mozilla treat it as an opaque string. Base64 turns
3 bytes into 4 characters, so a trailing group of one character is impossible —
no valid base64 string has a length ≡ 1 (mod 4).

`collie-update` is 13 characters. `collie-herd` is 11, which happens to be fine,
which is why only half the feature broke.

Measured against a live Apple subscription, one variable at a time:

| topic | len | len mod 4 | TTL | urgency | APNs |
|---|---|---|---|---|---|
| `collie-herd` | 11 | 3 | 21 600 | high | ✅ 201 |
| `collie-herd` | 11 | 3 | **259 200** | **omitted** | ✅ 201 |
| `collie-updat` | 12 | 0 | 21 600 | high | ✅ 201 |
| `collie-updates` | 14 | 2 | 21 600 | high | ✅ 201 |
| `collie-update` | 13 | **1** | 21 600 | high | ❌ 400 `BadWebPushTopic` |
| `collie-herdab` | 13 | **1** | 21 600 | high | ❌ 400 `BadWebPushTopic` |
| `collie-update-xyz` | 17 | **1** | 21 600 | high | ❌ 400 `BadWebPushTopic` |

Those rows exist to kill the alternative explanations, since the two option sets
differ in three ways and only one matters:

- **Not the TTL** — the 3-day value succeeds on a working topic (row 2).
- **Not the missing `Urgency`** — omitting it succeeds on a working topic (row 2).
- **Not the wording** — `collie-herdab` fails identically to `collie-update`.
- **Not a length cap** — 14 characters succeeds where 13 fails.

## The fix

```ts
const UPDATE_SEND_OPTIONS = { TTL: 259_200, topic: "collie-updates" } as const;
```

One character. `collie-herd` needs no change. Nothing else in the codebase reads
the topic — the client and service worker collapse on the separate `tag`, and
`update.ts`'s `collie-update-check` is an unrelated User-Agent.

I've extended the comment above the constants, because this is exactly the
constraint someone tidies away: shortening a topic by one character can break
Apple delivery while every other service keeps working, and nothing surfaces it
but that service's log line.

## The guard

`topicIsSendable` is pure and exported for the test, following
`isReservedAuthPath` in `server.ts`. The test asserts the topics the code
**actually emits** through a capturing sender, not the constants restated — a
guard that restated them would still pass after someone edited one, which is the
only regression it exists to catch. I verified that by reverting the constant
locally: the guard fails, and passes again when restored.

The predicate keeps RFC 8030's alphabet and 32-char ceiling and adds the
mod-4 rule, so it encodes "sendable to every service", not "sendable to Apple".

## Testing

Full `ci.yml` sequence, in order, on Node 22 (the lineage `ubuntu-latest` ships)
with Bun 1.3.14:

| step | result |
|---|---|
| `scripts/check-version.sh` | ✓ 0.27.0 consistent |
| `bun run typecheck` (root) | clean |
| `bun run test` (bridge) | **548 tests across 26 files, 0 fail** — includes the `collie-ctl` lifecycle suite |
| `cd web && bun run typecheck` | clean (app + worker tsconfigs) |
| `cd web && bun run test` | **104 files, 1718 tests, 0 fail** |

The change is confined to `bridge/`; the web suite is included above for
completeness rather than because it exercises anything new here.

No version bump or CHANGELOG entry, matching how fork PRs land here — those move
in your own `chore(release):` commits. Happy to add one if you'd prefer.

---

*claude-opus-5 on behalf of Ovidiu Julean*
