### PR TITLE
Name a pane by its terminal title, so a project's herd stops reading as N identical rows

### DIFF
--- a/bridge/activity.test.ts
+++ b/bridge/activity.test.ts
@@ -7,6 +7,7 @@ import {
   ActivityLedger,
   coerceActivityFile,
   meaningfulTabLabel,
+  meaningfulTerminalTitle,
   PRUNE_AFTER_MS,
 } from "./activity.ts";
 
@@ -58,6 +59,71 @@ describe("meaningfulTabLabel", () => {
     expect(meaningfulTabLabel("  deploy  ", 2)).toBe("deploy");
     // …and a padded positional default is still recognised as positional.
     expect(meaningfulTabLabel("  1  ", 1)).toBeUndefined();
+  });
+});
+
+describe("meaningfulTerminalTitle", () => {
+  const title = (t: string | null | undefined, stripped?: string | null) =>
+    meaningfulTerminalTitle(t, stripped, "claude", "moonward_os");
+
+  test("keeps a real title", () => {
+    expect(title("Reviewing the auth diff")).toBe("Reviewing the auth diff");
+  });
+
+  test("strips the status glyph Herdr leaves behind", () => {
+    // Live-observed 2026-08-15 (herdr 0.8.0): the raw title keeps its spinner frame and so does
+    // Herdr's "stripped" form, because Herdr only knows the settled glyph.
+    expect(title("◐ Custom UI for Collie", "◐ Custom UI for Collie")).toBe("Custom UI for Collie");
+    expect(title("✳ Read Notes From Underground", "Read Notes From Underground")).toBe(
+      "Read Notes From Underground",
+    );
+  });
+
+  test("is stable as the spinner advances — the whole point", () => {
+    // Every frame of the rotation must land on ONE label, or the row's name flickers each poll.
+    const frames = ["◐", "◑", "◒", "◓", "✳", "✻", "✽", "✢", "*", "·"];
+    const labels = new Set(frames.map((f) => title(`${f} Reconcile the book lists`)));
+    expect(labels).toEqual(new Set(["Reconcile the book lists"]));
+  });
+
+  test("leaves a title that merely opens with punctuation alone", () => {
+    // The glyph rule requires a symbol from the spinner blocks; these are neither.
+    expect(title("(main) vim src/app.ts")).toBe("(main) vim src/app.ts");
+    expect(title("~/dev/collie — bun test")).toBe("~/dev/collie — bun test");
+  });
+
+  test("drops a title that is only a spinner frame — it names nothing", () => {
+    expect(title("◐")).toBeUndefined();
+    expect(title("◐   ")).toBeUndefined();
+    expect(title("✳ ◐")).toBeUndefined();
+  });
+
+  test("drops a title that repeats what the row already shows", () => {
+    // Herdr falls back to the process name when nothing sets a title.
+    expect(title("claude")).toBeUndefined();
+    expect(title("Claude")).toBeUndefined();
+    expect(title("moonward_os")).toBeUndefined();
+    expect(title("  MOONWARD_OS  ")).toBeUndefined();
+  });
+
+  test("treats blank, whitespace-only and absent titles as absent", () => {
+    expect(title("")).toBeUndefined();
+    expect(title("   ")).toBeUndefined();
+    expect(title(undefined)).toBeUndefined();
+    expect(title(null)).toBeUndefined();
+    expect(title(null, null)).toBeUndefined();
+  });
+
+  test("takes Herdr's strip as a head start when it is the shorter of the two", () => {
+    expect(title("✳ Reconcile the book lists", "Reconcile the book lists")).toBe(
+      "Reconcile the book lists",
+    );
+  });
+
+  test("works on an older server that reports no stripped form at all", () => {
+    expect(meaningfulTerminalTitle("◐ Fixing the parser", undefined, "claude", "collie")).toBe(
+      "Fixing the parser",
+    );
   });
 
   test("a zero tab count (workspace missing from the poll) is treated as single-tab", () => {

--- a/bridge/activity.test.ts
+++ b/bridge/activity.test.ts
@@ -106,6 +106,23 @@ describe("meaningfulTerminalTitle", () => {
     expect(title("  MOONWARD_OS  ")).toBeUndefined();
   });
 
+  test("drops a shell's locator title — it restates the cwd the row already shows", () => {
+    // Live-observed 2026-08-15: an unattended shell pane reports bash's `\u@\h:\w` verbatim.
+    expect(title("altan@bluefin:~/projects/workspace-sprqvntrs/tgl")).toBeUndefined();
+    expect(title("user@host: ~/x")).toBeUndefined(); // Debian's variant spaces after the colon.
+    expect(title("user@host")).toBeUndefined(); // …and some configs print no path at all.
+    expect(title("◐ user@host:~")).toBeUndefined(); // the glyph strip runs first.
+  });
+
+  test("keeps a shell title that names the command it is running", () => {
+    // The locator is dropped because it restates the cwd; a command title is the work itself.
+    expect(title("vim foo.ts")).toBe("vim foo.ts");
+    expect(title("htop")).toBe("htop");
+    expect(title("make")).toBe("make");
+    // Both halves of a locator are space-free, so a title that merely mentions an address stays.
+    expect(title("foo@bar baz")).toBe("foo@bar baz");
+  });
+
   test("treats blank, whitespace-only and absent titles as absent", () => {
     expect(title("")).toBeUndefined();
     expect(title("   ")).toBeUndefined();

--- a/bridge/activity.ts
+++ b/bridge/activity.ts
@@ -73,6 +73,10 @@ const LEADING_STATUS_GLYPH = new RegExp(`^[${STATUS_GLYPH_CLASS}]{1,2}\\s+`, "u"
 /** A title with no prose in it at all — a bare spinner frame, which names nothing. Needed separately
  *  because the strip above requires trailing whitespace, so `"◐"` alone would otherwise survive. */
 const GLYPHS_ONLY = new RegExp(`^[${STATUS_GLYPH_CLASS}\\s]+$`, "u");
+/** A shell's default OSC title — bash's `\u@\h:\w` and friends: `user@host`, optionally `:` and a
+ *  path (Debian puts a space after the colon). Neither half may contain a space, `@` or `:`, so a
+ *  title that merely mentions an address (`foo@bar baz`, `re: user@host`) is not one of these. */
+const SHELL_LOCATOR = /^[^\s@:]+@[^\s@:]+(:.*)?$/;
 
 /**
  * A terminal title worth putting on screen, or `undefined` when it says nothing.
@@ -88,6 +92,13 @@ const GLYPHS_ONLY = new RegExp(`^[${STATUS_GLYPH_CLASS}\\s]+$`, "u");
  * A title is dropped when it repeats what the row already shows: the agent's own name (Herdr falls
  * back to the process name, so an agent that sets no title reports `claude`), or the workspace
  * label that is line one of every row. Case-insensitive, because neither comparison is about case.
+ *
+ * A shell's locator title (`altan@bluefin:~/projects/collie`) is dropped for the same reason: it is
+ * not what the process is doing, it is a restatement of the cwd the row already carries on that very
+ * line — longer, and rewritten on every `cd`. Dropped unconditionally rather than only when the path
+ * matches: the row's cwd is the fresher of the two (a locator only updates at the next prompt), and
+ * `\w`'s `~` belongs to a user the bridge cannot resolve a HOME for. Titles a shell sets for a
+ * running command (`vim foo.ts`, `htop`) are not locators and survive — those are the work.
  *
  * Pure + exported so the rule is unit-tested and lives in ONE place, exactly as
  * {@link meaningfulTabLabel} is.
@@ -111,6 +122,7 @@ export function meaningfulTerminalTitle(
 
   const cleaned = shortest.replace(LEADING_STATUS_GLYPH, "").trim();
   if (!cleaned) return undefined;
+  if (SHELL_LOCATOR.test(cleaned)) return undefined;
 
   const fold = cleaned.toLowerCase();
   if (fold === agent.trim().toLowerCase()) return undefined;

--- a/bridge/activity.ts
+++ b/bridge/activity.ts
@@ -59,6 +59,65 @@ export function meaningfulTabLabel(
   return trimmed;
 }
 
+// A leading status glyph on an OSC title, e.g. Claude's `◐ Reviewing the diff`. The classes are the
+// symbol blocks a harness draws a spinner from — Geometric Shapes (◐◑◒◓), Miscellaneous Symbols,
+// Dingbats (✳✻✽✢), Misc Symbols and Arrows, emoji — plus the bare `*` and `·` some use.
+//
+// The trailing `\s` is the safety, and it is why this is a whitelist of BLOCKS rather than of
+// individual frames: a status glyph is always followed by a space before the title text, so
+// requiring one lets this strip spinner frames nobody has observed yet without eating a title that
+// merely OPENS with punctuation (`(main) vim`, `— draft`). Bounded to 2 glyphs; no real prefix is
+// longer, and an unbounded run on hostile input would scan the whole string.
+const STATUS_GLYPH_CLASS = "■-◿☀-⛿✀-➿⬀-⯿\\u{1F300}-\\u{1FAFF}*·";
+const LEADING_STATUS_GLYPH = new RegExp(`^[${STATUS_GLYPH_CLASS}]{1,2}\\s+`, "u");
+/** A title with no prose in it at all — a bare spinner frame, which names nothing. Needed separately
+ *  because the strip above requires trailing whitespace, so `"◐"` alone would otherwise survive. */
+const GLYPHS_ONLY = new RegExp(`^[${STATUS_GLYPH_CLASS}\\s]+$`, "u");
+
+/**
+ * A terminal title worth putting on screen, or `undefined` when it says nothing.
+ *
+ * Herdr reports the pane's OSC title and its own stripped form. The stripped form is NOT usable
+ * directly: it removes the settled `✳` but leaves Claude's rotating spinner frames (live-observed
+ * 2026-08-15 in one snapshot — `✳ Read Notes From Underground` stripped, `◐ Custom UI for Collie…`
+ * not). Since those frames advance on every poll, binding a row's label to it makes every working
+ * agent's name flicker. So Collie strips the glyph itself, on whichever of the two strings is
+ * already the shorter — Herdr having done the job is a fine head start, it just can't be trusted to
+ * have finished it.
+ *
+ * A title is dropped when it repeats what the row already shows: the agent's own name (Herdr falls
+ * back to the process name, so an agent that sets no title reports `claude`), or the workspace
+ * label that is line one of every row. Case-insensitive, because neither comparison is about case.
+ *
+ * Pure + exported so the rule is unit-tested and lives in ONE place, exactly as
+ * {@link meaningfulTabLabel} is.
+ */
+export function meaningfulTerminalTitle(
+  title: string | null | undefined,
+  stripped: string | null | undefined,
+  agent: string,
+  workspaceLabel: string,
+): string | undefined {
+  // Prefer whichever string is shorter once trimmed — that is Herdr's strip when it fired, and the
+  // raw title when it didn't. Comparing length rather than trusting `stripped` to exist keeps an
+  // older server (which omits it entirely) on the same path.
+  const candidates = [title, stripped]
+    .map((s) => s?.trim())
+    .filter((s): s is string => !!s)
+    .sort((a, b) => a.length - b.length);
+  const shortest = candidates[0];
+  if (!shortest) return undefined;
+  if (GLYPHS_ONLY.test(shortest)) return undefined;
+
+  const cleaned = shortest.replace(LEADING_STATUS_GLYPH, "").trim();
+  if (!cleaned) return undefined;
+
+  const fold = cleaned.toLowerCase();
+  if (fold === agent.trim().toLowerCase()) return undefined;
+  if (fold === workspaceLabel.trim().toLowerCase()) return undefined;
+  return cleaned;
+}
+
 /**
  * Coerce an untrusted parsed value into an {@link ActivityFile}, dropping anything malformed and
  * anything older than {@link PRUNE_AFTER_MS}. Pure + exported so the file-shape and prune handling

--- a/bridge/herdr-client.ts
+++ b/bridge/herdr-client.ts
@@ -48,6 +48,21 @@ interface WirePane {
   /** User-set pane label (herdr `pane.rename`). Present only once set — the key disappears when
    *  cleared with `label: null`, so absent/null both read as "no label". */
   label?: string | null;
+  /**
+   * The pane's OSC title, as the process running in it set it, and Herdr's own attempt at stripping
+   * a leading status glyph off it. Both optional: older servers omit them.
+   *
+   * Carried on the PANE — not only on `session.snapshot`'s `agents[]` — which is why reading it
+   * costs nothing architecturally: agents stay derived from `panes`, one code path (see
+   * {@link WireSnapshot}).
+   *
+   * `terminal_title_stripped` is NOT a drop-in for display. Herdr strips the settled `✳` but leaves
+   * Claude's rotating spinner frames in place (live-observed in one snapshot: `✳ Read Notes From
+   * Underground` stripped, `◐ Custom UI for Collie…` not). Those frames advance on every poll, so a
+   * label bound straight to it churns. `meaningfulTerminalTitle` does the strip Collie can rely on.
+   */
+  terminal_title?: string | null;
+  terminal_title_stripped?: string | null;
   revision: number;
   /**
    * The agent's OWN session identity, as the agent reported it to Herdr (herdr ≥ 0.7.2). For Claude

--- a/bridge/state-engine.ts
+++ b/bridge/state-engine.ts
@@ -1,4 +1,4 @@
-import { meaningfulTabLabel } from "./activity.ts";
+import { meaningfulTabLabel, meaningfulTerminalTitle } from "./activity.ts";
 import type { HerdrClient } from "./herdr-client.ts";
 import {
   type AgentStatus,
@@ -215,10 +215,19 @@ export class StateEngine {
         // The tab's label, denormalised alongside workspaceLabel so no client has to join tabs[].
         // Dropped when it's Herdr's positional default in a single-tab space — see meaningfulTabLabel.
         const tabLabel = meaningfulTabLabel(tabById.get(p.tab_id)?.label, ws?.tab_count ?? 0);
+        const workspaceLabel = ws?.label ?? p.workspace_id;
+        // What the pane says it is doing. Dropped when it only repeats the agent name or the
+        // project already on line one — see meaningfulTerminalTitle.
+        const terminalTitle = meaningfulTerminalTitle(
+          p.terminal_title,
+          p.terminal_title_stripped,
+          agent,
+          workspaceLabel,
+        );
         return {
           paneId: p.pane_id,
           workspaceId: p.workspace_id,
-          workspaceLabel: ws?.label ?? p.workspace_id,
+          workspaceLabel,
           workspaceNumber: ws?.number ?? 0,
           tabId: p.tab_id,
           agent,
@@ -229,6 +238,7 @@ export class StateEngine {
           // A user-set pane label (herdr pane.rename); omitted when unset so "absent stays absent".
           ...(typeof p.label === "string" && p.label.length > 0 ? { paneLabel: p.label } : {}),
           ...(tabLabel ? { tabLabel } : {}),
+          ...(terminalTitle ? { terminalTitle } : {}),
           // How the agent named its session. BOTH kinds are kept: Claude and Codex report an `id`,
           // while pi reports a `path` (its herdr integration prefers `agent_session_path` whenever
           // the session manager has a file open). Keeping only `id` — as this did until journals

--- a/bridge/types.ts
+++ b/bridge/types.ts
@@ -59,6 +59,15 @@ export interface AgentView {
    */
   tabLabel?: string;
   /**
+   * What the pane's own process says it is doing — its OSC title, glyph-stripped and dropped when
+   * uninformative (see `meaningfulTerminalTitle`). Claude rewrites this per turn, so unlike
+   * `paneLabel` and `sessionName` — both set once, by hand — it tracks the work as it moves, which
+   * is what tells several agents in ONE project apart in the herd list.
+   *
+   * Absent when the title says nothing, and on Herdr servers too old to report it.
+   */
+  terminalTitle?: string;
+  /**
    * Epoch ms of this agent's last observed status transition (bridge/activity.ts). The only thing
    * that can make a pane read as unseen. Absent until the ledger has an entry, and on the very
    * first poll after a fresh install.

--- a/web/src/lib/pane-name.test.ts
+++ b/web/src/lib/pane-name.test.ts
@@ -56,8 +56,43 @@ describe("paneParts — the second line", () => {
     expect(paneParts(pane({ sessionName: "oauth-refactor" })).secondary).toBe("oauth-refactor");
   });
 
+  it("falls back to the terminal title — what the pane says it is doing", () => {
+    expect(paneParts(pane({ terminalTitle: "Reconcile the book lists" })).secondary).toBe(
+      "Reconcile the book lists",
+    );
+  });
+
+  it("lets a hand-set name outrank the terminal title", () => {
+    // A name you chose must not be overwritten by one the process rewrites every turn.
+    const over = { terminalTitle: "Reconcile the book lists" };
+    expect(paneParts(pane({ ...over, paneLabel: "hand-named" })).secondary).toBe("hand-named");
+    expect(paneParts(pane({ ...over, sessionName: "oauth-refactor" })).secondary).toBe(
+      "oauth-refactor",
+    );
+  });
+
   it("falls back to a shortened cwd", () => {
     expect(paneParts(pane()).secondary).toBe("~/dev/moonward");
+  });
+
+  it("prefers the terminal title over the cwd — a project's herd shares one cwd", () => {
+    expect(paneParts(pane({ terminalTitle: "Fixing the parser" })).secondary).toBe(
+      "Fixing the parser",
+    );
+  });
+
+  it("tells apart several agents sitting in ONE project and tab", () => {
+    // The herd this change exists for: same project, same cwd, no hand-set names. Before the title
+    // was read, all three rows rendered identically.
+    const rendered = [
+      "Custom UI for Collie",
+      "Read Notes From Underground",
+      "Reconcile book lists",
+    ].map((terminalTitle) => {
+      const p = paneParts(pane({ terminalTitle }));
+      return `${join(p)}|${p.secondary}`;
+    });
+    expect(new Set(rendered).size).toBe(3);
   });
 
   it("is null when there is nothing to say", () => {

--- a/web/src/lib/pane-name.ts
+++ b/web/src/lib/pane-name.ts
@@ -53,7 +53,11 @@ function informativeCwd(cwd: string, project: string): string | null {
 /** The parts of a herd-list row title, unjoined — see {@link PaneParts}. */
 export function paneParts(pane: AgentView): PaneParts {
   const project = pane.workspaceLabel || pane.workspaceId;
-  const own = pane.paneLabel || pane.sessionName;
+  // A hand-set name first, then what the pane says it is doing. The title sits ahead of the cwd
+  // because it is the only one of the three that tracks the work as it moves — and in the herd this
+  // exists to untangle (several agents in ONE project) the cwd is identical on every row, so it
+  // discriminates nothing.
+  const own = pane.paneLabel || pane.sessionName || pane.terminalTitle;
   return {
     project,
     tab: pane.tabLabel ?? null,

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -50,6 +50,13 @@ export interface AgentView {
    */
   tabLabel?: string;
   /**
+   * What the pane's process says it is doing — its OSC title, glyph-stripped and dropped when
+   * uninformative bridge-side (see `meaningfulTerminalTitle` in bridge/activity.ts). Unlike
+   * `paneLabel` and `sessionName`, which are set once by hand, this follows the work as it moves.
+   * Render as text only, never markup — same XSS boundary as `paneLabel`.
+   */
+  terminalTitle?: string;
+  /**
    * Epoch ms of this agent's last status transition, as the bridge observed it. Absent on an older
    * bridge — which is exactly why triage degrades cleanly; see `triage()`.
    */
@@ -65,13 +72,16 @@ export interface AgentView {
 
 /**
  * The name to show for a pane, in priority order: an explicit user label (herdr `pane.rename`) wins,
- * then Claude's own `/rename` session name, then the agent name (or "shell"). Both label and session
- * name are rendered only as React text nodes by callers — never markup — so they stay within the
- * pane-output XSS boundary.
+ * then Claude's own `/rename` session name, then the pane's terminal title, then the agent name (or
+ * "shell"). The two hand-set names outrank the title because a name you chose should not be
+ * overwritten by one the process is rewriting every turn; the title outranks the agent name because
+ * "claude" tells you nothing when four rows say it. All three are rendered only as React text nodes
+ * by callers — never markup — so they stay within the pane-output XSS boundary.
  */
 export function paneDisplayName(pane: AgentView): string {
   if (pane.paneLabel) return pane.paneLabel;
   if (pane.sessionName) return pane.sessionName;
+  if (pane.terminalTitle) return pane.terminalTitle;
   return pane.kind === "shell" ? "shell" : pane.agent;
 }
 


### PR DESCRIPTION
## The problem

Run several Claude agents in one space and the herd list gives you no way to tell them apart. The title line is `project · tab`, Herdr names an unlabelled tab positionally, and the second line falls back to a cwd that is identical on every row. Three agents in one project render as three copies of the same row.

The two names Collie already had — `pane.rename` and Claude's `/rename` — are both set once, by hand. Neither tracks what the agent is actually doing.

## What this does

Reads the pane's OSC title, which Herdr has been reporting all along.

It arrives **on the pane object**, not only on `session.snapshot`'s `agents[]`, so this needs no change to the "agents stay derived from `panes`, one code path" decision — `agents[]` stays unused exactly as before. `WirePane` simply never declared the field, so it was dropped at the type boundary on every poll.

Precedence becomes `paneLabel` → `sessionName` → `terminalTitle` → cwd. The hand-set names still win: a name you chose shouldn't be overwritten by one the process rewrites every turn.

## Why not just use `terminal_title_stripped`

Because it doesn't finish the job, and the half it misses is the animated half.

Herdr strips the settled `✳` but leaves Claude's rotating spinner frames. Measured over 450 polls of a live 3-agent herd on herdr 0.8.0: `✳ <title>` was stripped every time, `◐ <title>` and `◑ <title>` never were. Those frames advance on each poll, so binding a label straight to that field makes every working row's name flicker.

So the strip is Collie's own. It whitelists the symbol blocks a spinner is drawn from (Geometric Shapes, Misc Symbols, Dingbats, Misc Symbols and Arrows, emoji, plus bare `*`/`·`) and requires the trailing space that always follows a status glyph. Requiring that space is what lets it handle frames nobody has observed yet without eating a title that merely *opens* with punctuation — `(main) vim`, `— draft`. Herdr's stripped form is still used as a head start when it's the shorter of the two, so an older server that omits it takes the same path.

A title is dropped when it only repeats the row: the agent name (what Herdr falls back to when nothing sets a title), or the project already on line one. Same shape and same reasoning as `meaningfulTabLabel`, and it lives beside it.

## Verification

- `bun test ./bridge ./scripts` — 578 pass
- `web`: `vitest run` — 107 files, 2145 pass
- `bunx tsc --noEmit` clean in both trees
- Built and run against a live 3-agent herd: each row renders its own task name, no glyph, stable across polls

## Notes

- No version bump and no CHANGELOG entry, per `CLAUDE.md` § Versioning for fork PRs.
- Suggested CHANGELOG line, if you want one:
  > **A pane is named by what its process says it is doing** — Herdr's OSC title fills the second line where the cwd used to repeat the project, so several agents in one space stop rendering as identical rows. Herdr's own `terminal_title_stripped` leaves Claude's rotating spinner frames in place, so the glyph strip is Collie's.