### PR TITLE
fix(composer): a password prompt names itself and offers Type (#103)

### DIFF
--- a/.adr/0017-recognising-a-password-prompt-changes-what-collie-says.md
+++ b/.adr/0017-recognising-a-password-prompt-changes-what-collie-says.md
@@ -1,0 +1,96 @@
+# 0017 — Recognising a password prompt changes what Collie says, never what it sends
+
+Status: **Accepted** (2026-08-16)
+
+## Context
+
+The free-text reply path is guarded. It types the text **unsubmitted**, polls fresh pane reads until
+the harness adapter can see that text on the input line, and only then sends the submit key. That
+ordering is the fix for [#34](https://github.com/AltanS/collie/issues/34), where a blind Enter
+answered a focused permission dialog and approved the highlighted "Yes" while the bridge cheerfully
+reported `{ok: true}` — both Herdr RPCs really had succeeded.
+
+A password prompt breaks that guard in a way nothing else does. `sudo`, an SSH key passphrase and
+`gpg` all turn echo **off**: the characters reach the pane and the terminal deliberately renders
+nothing. The evidence the guard waits for is not slow, not flaky, and not missing by accident — it is
+being withheld on purpose, forever. So the submit key is never sent, and no retry, no longer poll
+window and no better adapter will change that.
+
+[#103](https://github.com/AltanS/collie/issues/103) is what that cost in practice. The reporter hit a
+`sudo` prompt from the phone, got "The agent's input box isn't on screen — a menu or dialog is
+probably up", went looking for a dialog that did not exist, and walked to a laptop. For three days.
+The remedy was one control away the whole time — **Type**, which sends keystrokes straight to the
+pane with no verification at all, Enter included, because typing into an unrecognised screen is its
+entire purpose — and nothing on screen connected the two.
+
+Once Collie can *recognise* the screen (a conservative, anchored match on the live tail:
+`[sudo] password for …:`, `user@host's password:`, `Enter passphrase …:`), three roads open, and two
+of them are the obvious ones:
+
+1. **Send it.** We know it's a password prompt, we know the guard's evidence can't arrive, so skip the
+   verification for this one case and press Enter after typing. One tap, no mode switch, no
+   explanation needed.
+2. **Build a secret channel.** A first-class "send a password" field that types and submits through a
+   dedicated path, bypassing the guard by design rather than by exception. Issue #103 sketches this
+   as its third suggestion.
+3. **Say what it is and point at the control that already works.**
+
+Road 1 is the dangerous one precisely because it looks safest. The premise "we know it's a password
+prompt" is a *heuristic over the mirror*, and the mirror is a rendered grid Collie does not emulate
+([ADR 0008](./0008-collie-does-not-run-a-terminal-emulator.md)). An agent that prints
+`Enter passphrase:` as the last line of its own output — narrating, quoting a runbook, echoing a log
+— produces a screen indistinguishable from the real thing at the tail. Send Enter there and the
+keystroke lands in whatever actually owns the keyboard, which on a stalled send is most likely the
+dialog #34 is about. The guard would then be defeated by the one input Collie chose to trust without
+evidence, and the failure would be silent: an approved permission dialog looks like a successful
+send.
+
+Road 2 inherits all of that and adds a surface to maintain. It also solves nothing Type does not
+already solve — Type has no verification to bypass, dies with the view it belongs to, and is armed by
+a named choice the operator reads before arming.
+
+There is a second, quieter problem that recognition *does* legitimately fix. The composer's
+write-through persists every keystroke to `localStorage` for 48 hours, so by the time any refusal is
+rendered the password is already stored — and it is stored on the path where the operator gives up
+and walks away, which is exactly what #103 describes doing.
+
+## Decision
+
+**Recognising a no-echo prompt changes what Collie says and what it stores. It never changes what it
+sends.**
+
+Concretely:
+
+- The refusal is unchanged in kind and in consequence — nothing is typed, no key is sent. Only the
+  wording changes: it names the mechanism ("it shows nothing as you type, so Send can never confirm
+  the text arrived") instead of guessing at a dialog.
+- **No automatic Enter, ever**, and no relaxation of the type-then-verify guard for a recognised
+  screen. Detection is not evidence; it is a guess about a grid.
+- The remedy offered is the existing **Type** mode, entered by the operator's own tap. Nothing new
+  types on their behalf.
+- The pre-existing "Type anyway?" override stays exactly where it was. A false positive must cost a
+  dismissable notice, never an action taken or an action withdrawn.
+- On the stall path, a screen the adapter still recognises as its own composer is **never** called a
+  password prompt — otherwise "press Enter" becomes advice for the #34 keystroke.
+- Recognition **drops the stored draft and stops persisting keystrokes** while it holds. This is the
+  one thing recognition is allowed to do on its own, because its worst case is a draft that fails to
+  survive the OS killing the PWA.
+
+## Consequences
+
+- A password prompt costs one extra deliberate tap (Use Type) rather than zero. That is the price of
+  never firing an unverified Enter, and it is the same price every other write path in Collie pays.
+- Recognition is conservative and English-only, so unrecognised prompts get the older, vaguer
+  refusal. That is a *fallback*, not a failure: a false negative lands the operator exactly where
+  0.29.0 left them, which is why the patterns are allowed to stay literal instead of clever.
+- Collie has no "send a secret" feature, and requests for one should be answered with Type unless
+  something changes below.
+- A password still ends up typed into a real terminal, and Collie still mirrors, polls and stores
+  history for that pane. Nothing here changes that; what it establishes is that Collie's own copy of
+  the secret ends at the keystroke — direct-typing state is component-local and cleared per batch, and
+  the draft store is closed for the duration.
+- **What would justify revisiting.** Not a nicer heuristic — a *source of truth*. If Herdr ever
+  reports the pane's echo state (a `termios ECHO` bit, or a prompt kind on the pane record), then
+  "this is a no-echo prompt" stops being a guess about rendered text and road 1 becomes a different
+  proposition, worth re-arguing on that evidence. Until then, the guard's contract holds: a key that
+  cannot be verified is not sent.

--- a/.adr/README.md
+++ b/.adr/README.md
@@ -72,3 +72,9 @@ A superseded ADR is never deleted or edited into agreement with the present. Mar
 | [0008](./0008-collie-does-not-run-a-terminal-emulator.md) | Collie does not run a terminal emulator | Accepted |
 | [0009](./0009-a-generic-menu-is-driven-by-the-keys-it-names.md) | A generic menu is driven by the keys it names, never by digits | Accepted |
 | [0010](./0010-long-sends-are-verified-via-the-paste-placeholder.md) | Long sends are verified via the paste placeholder, not by chunking them | Accepted |
+| [0017](./0017-recognising-a-password-prompt-changes-what-collie-says.md) | Recognising a password prompt changes what Collie says, never what it sends | Accepted |
+
+**0011–0016 are not missing** — they are the pack/federation decisions, accepted on the `v1`
+integration branch and arriving here when it merges. Numbers are claimed across *both* branches, so
+the next ADR written on `main` continues from the highest number in use anywhere, not from the highest
+one in this table.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ All notable changes to Collie are recorded here. The format follows
 `version` in `herdr-plugin.toml`, `package.json`, and `web/package.json` (enforced by
 `scripts/check-version.sh`). See [`CLAUDE.md`](./CLAUDE.md) → *Versioning* for the bump policy.
 
+## [0.30.0] - 2026-08-16
+
+### Added
+
+- **A password prompt says what it is and offers the control that works.** `sudo`, an SSH passphrase and `gpg` echo nothing, so Send's verification can never arrive — the refusal now names that and hands off to **Type** in one tap, instead of "a menu or dialog is probably up" (#103, 1334540)
+
+### Fixed
+
+- **A password typed into the composer is no longer kept for 48 hours** — recognising the prompt drops the stored draft and stops persisting keystrokes; the write-through had stored it before any send was attempted (#103, 1334540)
+
 ## [0.29.0] - 2026-08-16
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,6 +150,10 @@ the unit name; the Herdr action runs from anywhere.
   threshold collapses in the input box to `[Pasted text #N +M lines]`; the guard accepts that token as
   send evidence only when it is consistent with the message just typed. Don't try to dodge the
   threshold by chunking sends ([ADR 0010](./.adr/0010-long-sends-are-verified-via-the-paste-placeholder.md)).
+- **A password prompt is recognised so Collie can SAY what it is, never so it can send** — no
+  automatic Enter, no relaxed verification, no secret channel; the remedy offered is the operator's
+  own tap on "Type" ([ADR 0017](./.adr/0017-recognising-a-password-prompt-changes-what-collie-says.md)).
+  Recognition does one thing on its own: it drops the stored draft and stops persisting keystrokes.
 - Pane output is rendered as **React text nodes** (never `innerHTML`); the ANSI parser only derives
   colors/weights. Keep it that way — it's the XSS boundary. Strict CSP + same-origin gate stay.
 - **Collie runs no terminal emulator** — `pane.read` returns Herdr's already-rendered grid, so the

--- a/README.md
+++ b/README.md
@@ -968,6 +968,19 @@ through an origin the bridge doesn't expect — a custom domain, or a proxy that
 Allow the exact public origin with `COLLIE_ALLOWED_ORIGINS` (see [Configure](#configure)), or make
 the proxy forward `Host` unchanged (Variant B, rule 4).
 
+**A `sudo` (or SSH passphrase, or `gpg`) prompt won't take your reply.** Use **Type** in the
+Controls row, not Send. Send *verifies* what it typed before it presses Enter — it reads the text
+back off the screen, which is what stops a reply being swallowed by a dialog and its Enter answering
+that dialog ([#34](https://github.com/AltanS/collie/issues/34)). A password prompt turns echo off, so
+there is nothing to read back, and no amount of retrying will change that. **Type** sends your
+keystrokes straight to the pane with no verification at all — Enter included — which is exactly what
+this prompt needs. Collie now recognises the common prompts and offers the handoff on the spot — and
+the moment it recognises one it **drops the stored draft and stops storing what you type**, because a
+composer draft is otherwise kept on the phone for 48 hours and a password has no business sitting
+there. (Recognition is English-only and deliberately conservative; an unrecognised prompt just gets
+the older, vaguer refusal — use **Type** there too.) Nothing you
+type in **Type** is stored, echoed into a draft, or restored later. ([#103](https://github.com/AltanS/collie/issues/103))
+
 **Collie is gone after a reboot.** A `systemd --user` unit only runs while you have a session — on a
 headless host enable lingering once (`loginctl enable-linger $USER`) and the `collie` unit (already
 `enable`d) starts at boot with your user manager. The `tailscale serve` mapping persists on its own

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,6 +1,6 @@
 id = "herdr.collie"
 name = "Collie"
-version = "0.29.0"
+version = "0.30.0"
 min_herdr_version = "0.7.0"
 description = "Mobile web UI to monitor and reply to your agent herd, served over Tailscale"
 platforms = ["linux", "macos"]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "collie",
-  "version": "0.29.0",
+  "version": "0.30.0",
   "private": true,
   "license": "MIT",
   "description": "Collie — a mobile web UI to monitor and reply to your Herdr agent herd over Tailscale",

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "collie-web",
-  "version": "0.29.0",
+  "version": "0.30.0",
   "private": true,
   "license": "MIT",
   "type": "module",

--- a/web/src/components/composer.test.tsx
+++ b/web/src/components/composer.test.tsx
@@ -919,6 +919,98 @@ describe("Composer — blocked pre-flight override", () => {
   }, 15000);
 });
 
+// #103. A password prompt is the one refusal that never becomes a success: `sudo` turns echo off, so
+// the evidence Send needs is exactly what the screen is refusing to show, and the reporter tapped Send
+// at it for three days. These pin the two halves of the answer — say what it is, and get the operator
+// into the mode that works without leaving the secret behind.
+describe("Composer — password prompt", () => {
+  const SUDO = "$ sudo systemctl restart collie\n[sudo] password for altan:";
+
+  function serveSudo(calls: string[]) {
+    server.use(
+      http.get(/\/api\/pane\/[^/]+$/, () =>
+        HttpResponse.json({ paneId: "w1:p1", text: SUDO, truncated: false, revision: 1 }),
+      ),
+      http.post(/\/api\/pane\/[^/]+\/reply$/, async ({ request }) => {
+        const body = (await request.json()) as { text: string; submit?: boolean };
+        calls.push(body.submit ? "submit" : "type");
+        return HttpResponse.json({ ok: true });
+      }),
+    );
+  }
+
+  it("names the prompt and offers Type, without replacing the override", async () => {
+    const user = userEvent.setup();
+    const calls: string[] = [];
+    serveSudo(calls);
+    renderComposerWithStatus();
+    const box = screen.getByPlaceholderText(/type a reply/i);
+
+    await user.type(box, "hunter2hunter2");
+    await user.click(screen.getByRole("button", { name: "Send" }));
+
+    // The refusal names the mechanism, not "a menu or dialog is probably up".
+    await waitFor(() =>
+      expect(screen.getByTestId("status")).toHaveTextContent(/password prompt/i),
+    );
+    // The prompt is quoted off the mirror, so the claim is checkable against the screen.
+    expect(screen.getByText("[sudo] password for altan:")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /use type/i })).toBeInTheDocument();
+    // The pre-existing override is untouched — a false positive costs a dismissal, not an action.
+    expect(screen.getByRole("button", { name: /type anyway/i })).toBeInTheDocument();
+    expect(calls).toEqual([]);
+  });
+
+  it("the handoff clears the draft before arming Type", async () => {
+    const user = userEvent.setup();
+    const calls: string[] = [];
+    serveSudo(calls);
+    renderComposerWithStatus();
+    const box = screen.getByPlaceholderText(/type a reply/i);
+
+    await user.type(box, "hunter2hunter2");
+    // The write-through has already put the secret in the 48h store, before any send was attempted —
+    // the leak #103 asked about. Asserted here so the assertion below isn't vacuously true.
+    expect(localStorage.getItem("collie:draft:default:w1:p1")).toContain("hunter2hunter2");
+
+    await user.click(screen.getByRole("button", { name: "Send" }));
+    await user.click(await screen.findByRole("button", { name: /use type/i }));
+
+    // Armed, and the secret is gone from the field (and from its localStorage copy with it) — which
+    // is also what lets it arm at all: useDirectTyping refuses while any draft is present.
+    await waitFor(() =>
+      expect(screen.getByPlaceholderText(/type into the terminal/i)).toHaveValue(""),
+    );
+    expect(localStorage.getItem("collie:draft:default:w1:p1")).toBeNull();
+    expect(screen.queryByRole("button", { name: /use type/i })).not.toBeInTheDocument();
+    expect(calls).toEqual([]); // nothing was ever typed by the reply path
+  });
+
+  it("drops the stored draft the moment it recognises the prompt, button or no button", async () => {
+    // The reporter's actual behaviour: tap Send, give up, walk to a laptop. No button is ever pressed,
+    // so a handoff that clears on its way through would never have run — and the pane-leave save would
+    // have written the password back out. The store has to be empty from the refusal onwards.
+    const user = userEvent.setup();
+    const calls: string[] = [];
+    serveSudo(calls);
+    renderComposerWithStatus();
+    const box = screen.getByPlaceholderText(/type a reply/i);
+
+    await user.type(box, "hunter2hunter2");
+    expect(localStorage.getItem("collie:draft:default:w1:p1")).toContain("hunter2hunter2");
+
+    await user.click(screen.getByRole("button", { name: "Send" }));
+    await screen.findByRole("button", { name: /use type/i });
+    expect(localStorage.getItem("collie:draft:default:w1:p1")).toBeNull();
+
+    // Dismissing keeps the text on screen — the operator may still need to read it — but the typing
+    // that happened while the notice was up was never stored either.
+    await user.click(screen.getByRole("button", { name: /dismiss password-prompt notice/i }));
+    expect(box).toHaveValue("hunter2hunter2");
+    expect(localStorage.getItem("collie:draft:default:w1:p1")).toBeNull();
+  });
+});
+
 describe("Composer — destructive-input confirm", () => {
   it("holds a destructive command for a second tap, then sends", async () => {
     const user = userEvent.setup();

--- a/web/src/components/composer.tsx
+++ b/web/src/components/composer.tsx
@@ -18,13 +18,14 @@ import { SectionLabel } from "@/components/ui/section-label";
 import * as api from "@/lib/api";
 import { commandsFor } from "@/lib/agent-commands";
 import { isDestructiveInput } from "@/lib/destructive";
-import { loadDraft, saveDraft } from "@/lib/drafts";
+import { clearDraft, loadDraft, saveDraft } from "@/lib/drafts";
 import { useHoldReload } from "@/lib/reload-guard";
 import { isSelfEcho, normalizeDraft } from "@/hooks/use-terminal-draft";
 import { adapterFor } from "@/lib/harness";
 import { sendGuardedReply } from "@/lib/reply-action";
 import { TerminalDraftPreview } from "@/components/terminal-draft-preview";
 import { DirectTypingStrip } from "@/components/direct-typing-strip";
+import { NoEchoNotice } from "@/components/no-echo-notice";
 
 export interface ComposerHandle {
   /** Focus the input and put the caret at the end — used by the mirror-tap-to-focus in AgentChat. */
@@ -163,24 +164,40 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
   // text can never surface in pane B.
   const draftPaneRef = useRef({ session, paneId });
 
-  /** Set the draft AND persist it. Every write to `input` goes through here — an empty value removes
-   *  the stored key, so the deliberate-clear paths (verified send, user emptying the box) need no
-   *  special case. */
+  /**
+   * Set the draft AND persist it. Every write to `input` goes through here — an empty value removes
+   * the stored key, so the deliberate-clear paths (verified send, user emptying the box) need no
+   * special case.
+   *
+   * PERSISTENCE STOPS while a password prompt is on screen (#103). By the time the notice appears the
+   * secret is already in the 48h store — the write-through ran on every keystroke, before any send was
+   * attempted — so `noEchoRef` gates the save AND the pane-leave save below, and the outcome that sets
+   * it removes the stored copy outright. The button was never enough: the operator who taps Send,
+   * gives up and walks to a laptop (which is exactly what #103 reports doing, for three days) never
+   * presses anything, and the pane-leave path would have re-saved it on the way out.
+   *
+   * Gating on a REF, not the state, because the two must change in the same tick as the outcome that
+   * decides it — a render behind is a render in which the next keystroke is still being stored.
+   * The in-memory draft is untouched: a false positive costs one draft its ability to survive the OS
+   * killing the PWA, which is a cheap price for never storing a real one.
+   */
   function updateInput(next: string | ((prev: string) => string)) {
     const value = typeof next === "function" ? next(inputValueRef.current) : next;
     inputValueRef.current = value;
     setInput(value);
+    if (noEchoRef.current !== null) return;
     saveDraft(session, paneId, value);
   }
 
   useEffect(() => {
     const prev = draftPaneRef.current;
     if (prev.paneId === paneId && prev.session === session) return;
-    saveDraft(prev.session, prev.paneId, inputValueRef.current);
+    if (noEchoRef.current === null) saveDraft(prev.session, prev.paneId, inputValueRef.current);
     draftPaneRef.current = { session, paneId };
     const restored = loadDraft(session, paneId) ?? "";
     inputValueRef.current = restored;
     setInput(restored);
+    noticeNoEcho(null); // it described the pane we just left
   }, [session, paneId]);
   const [sending, setSending] = useState(false);
   const [uploading, setUploading] = useState(false);
@@ -242,12 +259,35 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
   // explaining WHY nothing was typed before deciding to overrule it.
   const forceConfirm = usePendingConfirm(10_000);
 
+  // The password prompt the last refused send was looking at, if it was one (#103). Set from the
+  // guard's own live read — never re-derived from `display`, which is a snapshot — and cleared by the
+  // ✕, by arming Type, by a send that goes through, and by leaving the pane. Not persisted: it is a
+  // statement about what is on screen right now.
+  //
+  // It is state AND a ref because it has two jobs on two clocks: the strip renders from the state,
+  // while the draft write-through (updateInput, above) has to stop storing keystrokes in the same tick
+  // the outcome lands, not on the render after. `noticeNoEcho` is the only writer of both — go through
+  // it, or the two disagree and the gap is measured in stored passwords.
+  const [noEcho, setNoEcho] = useState<{ prompt: string; typed: boolean } | null>(null);
+  const noEchoRef = useRef<{ prompt: string; typed: boolean } | null>(null);
+
+  /** Raise or clear the password-prompt notice. Raising it also DROPS the stored draft: at that moment
+   *  we know the field holds a secret the pane never accepted, and leaving it in a 48h store to be
+   *  restored on the next visit is the leak #103 asked about. The in-memory value stays — the operator
+   *  can still read it, hand it to Type, or dismiss the notice and carry on. */
+  function noticeNoEcho(next: { prompt: string; typed: boolean } | null) {
+    noEchoRef.current = next;
+    setNoEcho(next);
+    if (next !== null) clearDraft(session, paneId);
+  }
+
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const fileRef = useRef<HTMLInputElement>(null);
   const direct = useDirectTyping({
     paneKey: `${session ?? ""}\0${paneId}`,
     inputRef,
-    replyDraft: input,
+    // The ref, not `input`: the password-prompt handoff clears the draft and arms in one tick.
+    replyDraft: () => inputValueRef.current,
     canActivate: () => !(locked || sending || uploading),
     // `locked` covers a gone pane, a read-only device, and the idle pause. A LOST CONNECTION is
     // deliberately not added here: the mode already disarms on a failed batch, which is the same
@@ -258,6 +298,7 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
     onActivate: () => {
       sendConfirm.reset();
       forceConfirm.reset();
+      noticeNoEcho(null); // the notice's whole job was to get you here
     },
     focusInput: focusInputEnd,
   });
@@ -514,6 +555,7 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
         if (lastSentTimerRef.current) clearTimeout(lastSentTimerRef.current);
         lastSentTimerRef.current = setTimeout(() => setLastSent(null), 6000);
         forceConfirm.reset(); // a clean send disarms any leftover override
+        noticeNoEcho(null); // whatever prompt it described, the pane has moved past it
         onSent(); // you just acted — snap the mirror back to the live tail to see the result
         return true;
       } else if (res.status === "blocked") {
@@ -522,6 +564,9 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
         // the same two-tap shape as the destructive-send confirm. The second tap skips the pre-flight
         // ONLY; the type-then-verify guard still runs, so Enter is never fired blind either way.
         forceConfirm.confirm("force");
+        // A password prompt gets the notice AND keeps the override: the notice explains the screen and
+        // offers the control that works, the override stays for the case where the detection is wrong.
+        noticeNoEcho(res.noEcho !== undefined ? { prompt: res.noEcho, typed: false } : null);
         setStatus(`${res.error} Tap Send again to type anyway.`, "error");
         return false;
       } else {
@@ -530,6 +575,15 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
         // submit failed. Either way the draft stays put: the user checks the pane rather than
         // double-sending, and on a stall their message is still here to re-send once the dialog is
         // answered.
+        //
+        // Except at a password prompt, where the draft staying put is the wrong call and the notice
+        // says so: the text is already IN the pane (unsubmitted), so a re-send types a second copy of
+        // a secret rather than recovering a lost message. The notice's handoff is what clears it.
+        noticeNoEcho(
+          res.status === "stalled" && res.noEcho !== undefined
+            ? { prompt: res.noEcho, typed: true }
+            : null,
+        );
         setStatus(res.error, "error");
         return false;
       }
@@ -825,6 +879,31 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
             // `[Pasted text #N +M lines]`): pulling that into the composer would send the literal
             // string. The preview keeps showing it — the screen really does say that.
             onTakeOver={adapter?.draftIsOpaque?.(effectiveRaw) ? null : takeOverDraft}
+          />
+        )}
+        {/* The password-prompt notice (#103). Sits here, in the same in-flow slot as the other two
+            strips, because that is where the eye already is when a send is refused — and it is a
+            NOTICE beside the unchanged "Type anyway?" override, never a replacement for it. */}
+        {noEcho !== null && !direct.active && (
+          <NoEchoNotice
+            prompt={noEcho.prompt}
+            typed={noEcho.typed}
+            // Withdrawn, not disabled, when the mode can't be armed at all: a gone pane, a read-only
+            // device, the idle pause. Offering a control that would refuse is worse than offering none.
+            onUseType={
+              locked
+                ? null
+                : () => {
+                    // The draft is a password we know the pane never accepted, and it is already in
+                    // localStorage. Clear it BEFORE arming — both because leaving a secret in a 48h
+                    // store is the leak this issue asked about, and because `activate` refuses while
+                    // any draft is present, which would make the offered remedy fail on the spot.
+                    updateInput("");
+                    requestDrawer(null);
+                    direct.activate();
+                  }
+            }
+            onDismiss={() => noticeNoEcho(null)}
           />
         )}
         {/* Armed indicator for direct typing. In the same in-flow slot as the "You sent:" strip,

--- a/web/src/components/no-echo-notice.tsx
+++ b/web/src/components/no-echo-notice.tsx
@@ -1,0 +1,83 @@
+import { KeyRound, X } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+
+interface NoEchoNoticeProps {
+  /** The prompt the pane is sitting at, verbatim off the mirror ("[sudo] password for altan:"). Shown
+   *  so the claim is checkable against the screen the operator is already looking at — a false
+   *  positive is then self-evidently one, and the ✕ costs a tap. */
+  prompt: string;
+  /** Whether the refused send had already put the text into the pane (a `stalled` outcome) or not
+   *  (`blocked`, where the pre-flight refused before typing). It changes the operator's next move
+   *  completely — press Enter, versus type the secret — so it changes what this says. */
+  typed: boolean;
+  /** Hand off to direct typing: clears the draft (and its stored copy) and arms "Type". Absent while
+   *  the mode can't be armed at all — a gone pane, a read-only device, the idle pause. */
+  onUseType: (() => void) | null;
+  onDismiss: () => void;
+}
+
+// The one thing #103 was missing: a sentence, at the moment of the refusal, that names the screen and
+// points at the control that works.
+//
+// A password prompt is the single case where the reply guard's evidence can never arrive — `sudo`,
+// `ssh` and `gpg` turn echo off, so the characters land in the pane and the terminal deliberately
+// shows nothing to read back (lib/no-echo.ts). Send is right to withhold the submit key, and it will
+// be right on every retry, so an operator who does not know WHY is left tapping Send at a screen that
+// can never change. The reporter of #103 gave up and walked to a laptop for three days.
+//
+// It is a NOTICE, not a replacement for the override. The Send slot keeps offering "Type anyway?"
+// exactly as before, so a false positive costs a dismissable strip rather than an action; this sits
+// where the terminal-draft preview sits and says the part the status line has no room for.
+//
+// WHY THE HANDOFF CLEARS THE DRAFT. The composer write-through persists every keystroke to
+// localStorage (lib/drafts.ts, 48h), so by the time this appears the secret is already stored — and
+// `useDirectTyping` refuses to arm at all while a draft is present, which means the failed attempt
+// blocks the remedy. Clearing on the way through fixes both: it is the one path where the draft is
+// known to be a secret, and dropping it is what the operator wanted anyway.
+export function NoEchoNotice({ prompt, typed, onUseType, onDismiss }: NoEchoNoticeProps) {
+  return (
+    <div className="mb-2 flex items-start gap-1.5 rounded-md bg-muted/40 px-2.5 py-1.5 text-xs text-muted-foreground">
+      <KeyRound className="mt-0.5 size-3 shrink-0" />
+      <div className="min-w-0 flex-1">
+        <div className="font-medium">Password prompt — nothing echoes</div>
+        <div className="mt-0.5 truncate font-mono text-[11px] leading-snug text-muted-foreground/90">
+          {prompt}
+        </div>
+        {/* Four sentences, because the operator's next move differs on both axes. `typed` says whether
+            the secret is already in the pane (press Enter — and do NOT re-send, which would type a
+            second copy) or not (type it in the mode that works). `onUseType === null` means the mode
+            can't be armed at all right now, so naming it would be advice for a control that isn't
+            there; say what's in the way instead. */}
+        <div className="mt-1 leading-snug">
+          {onUseType === null
+            ? typed
+              ? "What you typed is already in the pane, unsubmitted — but this view isn't live, so nothing can be sent from here. Answer it at the terminal."
+              : "Nothing was typed. This view isn't live, so the keys that would work can't be sent from here."
+            : typed
+              ? "What you typed is already in the pane — it just can't be confirmed, so it wasn't submitted. Press Enter in Type, and don't send it again."
+              : "Send confirms what it typed, and this prompt shows nothing to confirm. Type sends your keys straight through, Enter included."}
+        </div>
+      </div>
+      {onUseType !== null && (
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-6 shrink-0 self-center px-2 text-xs font-medium"
+          onClick={onUseType}
+        >
+          Use Type
+        </Button>
+      )}
+      <Button
+        variant="ghost"
+        size="icon"
+        className="size-6 shrink-0 self-start text-muted-foreground"
+        aria-label="Dismiss password-prompt notice"
+        onClick={onDismiss}
+      >
+        <X className="size-3" />
+      </Button>
+    </div>
+  );
+}

--- a/web/src/hooks/use-direct-typing.ts
+++ b/web/src/hooks/use-direct-typing.ts
@@ -36,7 +36,11 @@ function keyForKeyDown(key: string): string | undefined {
 interface DirectTypingOptions {
   paneKey: string;
   inputRef: RefObject<HTMLTextAreaElement | null>;
-  replyDraft: string;
+  /** The durable reply draft, read at the moment of arming rather than captured at render. A getter,
+   *  because the password-prompt handoff (components/no-echo-notice.tsx) clears the draft and arms in
+   *  the SAME tick: a value captured at render would still be the secret the operator just typed, and
+   *  the refusal below would block the very remedy being offered. */
+  replyDraft: () => string;
   canActivate: () => boolean;
   /** True while the view the mode belongs to has stopped being live: a gone pane, a read-only
    *  device, or the idle pause. Arming survives none of them — see the disarm effect below. */
@@ -105,7 +109,7 @@ export function useDirectTyping({
     if (!canActivate()) return;
     // A buffered reply and live keystrokes cannot safely share one field. Keep the durable draft
     // exactly where it is and make the user send or clear it before arming direct terminal input.
-    if (replyDraft.length > 0) {
+    if (replyDraft().length > 0) {
       setStatus("Send or clear the draft before typing into the terminal.", "info");
       return;
     }

--- a/web/src/lib/no-echo.test.ts
+++ b/web/src/lib/no-echo.test.ts
@@ -1,0 +1,44 @@
+import { splitLines } from "./blocks";
+import { parseAnsi } from "./ansi";
+import { detectNoEchoPrompt } from "./no-echo";
+
+// #103: the screen where the reply guard's evidence can never arrive. The detector decides nothing —
+// the refusal is already made — so these pin the two things that matter: it recognises the prompts real
+// tools actually print, and it does not claim a screen that merely talks about passwords.
+
+const screen = (text: string) => splitLines(parseAnsi(text));
+
+describe("detectNoEchoPrompt", () => {
+  it("recognises the prompts sudo, ssh, ssh-add and gpg print", () => {
+    expect(detectNoEchoPrompt(screen("$ sudo systemctl restart collie\n[sudo] password for altan:")))
+      .toBe("[sudo] password for altan:");
+    expect(detectNoEchoPrompt(screen("altan@host's password:"))).toBe("altan@host's password:");
+    expect(detectNoEchoPrompt(screen("Enter passphrase for /home/altan/.ssh/id_ed25519:"))).toBe(
+      "Enter passphrase for /home/altan/.ssh/id_ed25519:",
+    );
+    expect(detectNoEchoPrompt(screen("Enter passphrase:"))).toBe("Enter passphrase:");
+    expect(detectNoEchoPrompt(screen("Password:"))).toBe("Password:");
+    expect(detectNoEchoPrompt(screen("Password (again):"))).toBe("Password (again):");
+  });
+
+  it("reads through the trailing whitespace a blocked terminal leaves", () => {
+    // The cursor sits after the prompt, so the row is padded and the rows under it are blank.
+    expect(detectNoEchoPrompt(screen("[sudo] password for altan: \n\n\n"))).toBe(
+      "[sudo] password for altan:",
+    );
+  });
+
+  it("ignores a prompt that has scrolled up out of the live tail", () => {
+    // Answered three commands ago: the terminal is not blocked on it, so offering the handoff would
+    // point at the wrong thing.
+    const old = "[sudo] password for altan:\nok\n$ ls\nREADME.md\n$ ";
+    expect(detectNoEchoPrompt(screen(old))).toBeNull();
+  });
+
+  it("does not claim a screen that merely mentions a password", () => {
+    expect(detectNoEchoPrompt(screen("I'll run sudo systemctl restart collie for you"))).toBeNull();
+    expect(detectNoEchoPrompt(screen("Reading the password from the environment instead."))).toBeNull();
+    // A command being composed, not a prompt: the colon is what marks the waiting cursor.
+    expect(detectNoEchoPrompt(screen("$ export PASSWORD"))).toBeNull();
+  });
+});

--- a/web/src/lib/no-echo.ts
+++ b/web/src/lib/no-echo.ts
@@ -15,7 +15,10 @@
 //
 // So this module exists to RECOGNISE the case, not to handle it. It never decides anything: the
 // refusal is already made by `composerReady`, and all a match does is let the UI name what it is
-// looking at and offer the control that works. That makes the cost of a false negative exactly zero —
+// looking at and offer the control that works. The road NOT taken — "we know it's a password prompt,
+// so skip the verification and press Enter ourselves" — is closed off in
+// .adr/0017-recognising-a-password-prompt-changes-what-collie-says.md: a match here is a guess about
+// a rendered grid, and an agent that merely PRINTS "Enter passphrase:" produces the same tail. That makes the cost of a false negative exactly zero —
 // the operator gets today's generic refusal and today's `force` override — and the cost of a false
 // positive one dismissable notice. Both are cheap enough that the patterns below stay conservative and
 // literal rather than clever.

--- a/web/src/lib/no-echo.ts
+++ b/web/src/lib/no-echo.ts
@@ -1,0 +1,78 @@
+// The one screen where the reply guard's evidence can never arrive.
+//
+// Everything the free-text reply path does is built on reading back what it typed: type unsubmitted →
+// poll fresh reads until the adapter sees the text on the input line → only then send the submit key
+// (lib/reply-action.ts). A password prompt breaks that by construction rather than by failing — `sudo`,
+// an SSH passphrase and `gpg` all turn echo OFF, so the characters are in the pane and the screen
+// deliberately shows nothing. The guard is right to withhold the submit key (it has no evidence), and
+// it will be right forever, so no amount of retrying or waiting gets the operator through.
+//
+// The remedy already exists and is one control away: "Type" sends keystrokes straight to the pane with
+// no verification at all, because typing into an unrecognised screen is its entire purpose
+// (hooks/use-direct-typing.ts). Issue #103 is that nothing on screen connected the two — the refusal
+// said "a menu or dialog is probably up", which is a true statement about a different situation, and
+// the reporter spent three days walking to a laptop to answer a `sudo`.
+//
+// So this module exists to RECOGNISE the case, not to handle it. It never decides anything: the
+// refusal is already made by `composerReady`, and all a match does is let the UI name what it is
+// looking at and offer the control that works. That makes the cost of a false negative exactly zero —
+// the operator gets today's generic refusal and today's `force` override — and the cost of a false
+// positive one dismissable notice. Both are cheap enough that the patterns below stay conservative and
+// literal rather than clever.
+//
+// It is deliberately HARNESS-NEUTRAL and lives outside harness/: a password prompt is not a property of
+// the agent occupying the pane, it is the operating system's own `readpass` painted over whatever was
+// there. The same three lines appear under Claude, under codex, and under a bare shell.
+
+import { isBlank, lineText, type StyledLine } from "./blocks";
+
+/**
+ * Prompts that read a secret with echo disabled. Anchored at the END of the line, because that is the
+ * one position a prompt can be in: the cursor sits right after it, waiting. Anchoring loosely would
+ * match a `sudo` command the operator is composing, or a log line about a password, neither of which is
+ * a prompt.
+ *
+ * Each pattern is the literal text a real tool prints:
+ *   sudo(8)          `[sudo] password for altan:`  and the plain `Password:` of the non-Linux prompt
+ *   ssh(1)           `altan@host's password:`
+ *   ssh-add / gpg    `Enter passphrase for /home/altan/.ssh/id_ed25519:`, `Enter passphrase:`
+ *   sudo -k / retry  `Password (again):`, `Verify password:`
+ * A trailing space is optional and a trailing `:` is not — some tools print `Password?` or nothing at
+ * all — but requiring the colon is what keeps this from claiming ordinary prose, and a tool that omits
+ * it simply falls through to the generic refusal, which is the pre-#103 behaviour.
+ *
+ * English only, and that door is deliberately left OPEN rather than argued shut: a `sudo` under
+ * `LANG=de_DE` prints `[sudo] Passwort für altan:` and gets today's generic refusal, which is the
+ * pre-#103 behaviour and costs nothing. Unlike everything else in this header, adding locales is
+ * simply unwritten work, not a decision.
+ */
+const NO_ECHO_PROMPTS: readonly RegExp[] = [
+  /(^|\s)\[sudo\]\s+password\s+for\s+\S+\s*:\s*$/i,
+  /(^|\s)password(\s*\([^)]*\))?\s*:\s*$/i,
+  /(^|\s)passphrase[^:]*:\s*$/i,
+  /(^|\s)enter\s+(the\s+)?(password|passphrase)[^:]*:\s*$/i,
+];
+
+/** How far back from the tail to look. A password prompt is the LAST thing on screen — it is what the
+ *  terminal is blocked on — but a tool may print a hint under it (`Sorry, try again.` sits above, not
+ *  below; ssh prints nothing). Two lines of slack absorbs a trailing blank or a lone cursor row without
+ *  letting a prompt scrolled well up the screen, which is no longer the live one, count. */
+const TAIL_LINES = 2;
+
+/**
+ * The no-echo prompt the pane is sitting at, verbatim, or `null`.
+ *
+ * The returned string is shown to the operator ("This looks like `[sudo] password for altan:`"), which
+ * is the point of returning the text rather than a boolean: the claim is checkable against the mirror
+ * they are already looking at, so a false positive is self-evidently one.
+ */
+export function detectNoEchoPrompt(lines: StyledLine[]): string | null {
+  const texts = lines.map(lineText);
+  let end = texts.length;
+  while (end > 0 && isBlank(texts[end - 1]!)) end--;
+  for (let i = end - 1; i >= 0 && i >= end - TAIL_LINES; i--) {
+    const text = texts[i]!.trimEnd();
+    if (NO_ECHO_PROMPTS.some((re) => re.test(text))) return text.trim();
+  }
+  return null;
+}

--- a/web/src/lib/reply-action.test.ts
+++ b/web/src/lib/reply-action.test.ts
@@ -221,6 +221,77 @@ describe("sendGuardedReply", () => {
     expect(calls).toEqual([]);
   });
 
+  // #103. The refusal is the same refusal — what changes is that the caller is told WHICH screen it
+  // refused at, because at a password prompt "a menu or dialog is probably up" sends the operator
+  // looking for a dialog to answer and waiting for an echo that is never coming.
+  it("#103: names the password prompt it refused at, and still types nothing", async () => {
+    const calls = harness(() => "$ sudo systemctl restart collie\n[sudo] password for altan:");
+
+    const out = await sendGuardedReply({
+      paneId: "w1:p1",
+      text: "hunter2hunter2",
+      agent: "claude",
+      ...instant,
+    });
+
+    expect(out).toMatchObject({
+      status: "blocked",
+      error: expect.stringMatching(/password prompt/i),
+      noEcho: "[sudo] password for altan:",
+    });
+    expect(calls).toEqual([]);
+  });
+
+  it("#103: a stall at a password prompt says the text is already in the pane", async () => {
+    // The path a `force` takes: the pre-flight was overridden, so the secret IS typed, and then the
+    // verification can never succeed because the prompt shows nothing. The caller must hear that a
+    // re-send types a SECOND copy rather than recovering a lost one.
+    const calls = harness(() => "[sudo] password for altan:");
+
+    const out = await sendGuardedReply({
+      paneId: "w1:p1",
+      text: "hunter2hunter2",
+      agent: "claude",
+      force: true,
+      ...instant,
+    });
+
+    expect(out).toMatchObject({
+      status: "stalled",
+      noEcho: "[sudo] password for altan:",
+      error: expect.stringMatching(/already in the pane/i),
+    });
+    // Still no submit key — the guard's own contract is untouched by any of this.
+    expect(calls).toEqual([{ text: "hunter2hunter2", submit: false }]);
+  });
+
+  it("#103: a stall on a screen the adapter still recognises is NOT called a password prompt", async () => {
+    // The dangerous false positive: an agent whose last printed line happens to read "Enter
+    // passphrase:" while its own input box is right there. The stall is then an ordinary one, and
+    // calling it no-echo would have the UI advise pressing Enter — the #34 keystroke.
+    harness(() => "[sudo] password for altan:");
+    const real = registry.adapterFor("claude")!;
+    // An adapter that says "my composer is right there" about the very screen the detector would
+    // otherwise claim. Its draft never carries the send, so the send still stalls — the question this
+    // pins is only whether the stall gets NAMED a password prompt. It must not be.
+    const spy = vi.spyOn(registry, "adapterFor").mockReturnValue({
+      ...real,
+      composerReady: () => true,
+      extractInputDraft: () => null,
+    });
+
+    const out = await sendGuardedReply({
+      paneId: "w1:p1",
+      text: "please do the thing",
+      agent: "claude",
+      ...instant,
+    });
+
+    expect(out.status).toBe("stalled");
+    expect(out).not.toHaveProperty("noEcho");
+    spy.mockRestore();
+  }, 15000);
+
   it("#34: force overrides the pre-flight's refusal but still never sends the submit key blind", async () => {
     const calls = harness(() => paneWithDialog);
 

--- a/web/src/lib/reply-action.ts
+++ b/web/src/lib/reply-action.ts
@@ -22,6 +22,7 @@ import { parseAnsi } from "./ansi";
 import { splitLines } from "./blocks";
 import { adapterFor, type HarnessAdapter } from "./harness";
 import { POLL_ATTEMPTS, POLL_DELAY_MS, defaultSleep, type Sleep } from "./harness/guard";
+import { detectNoEchoPrompt } from "./no-echo";
 
 export type ReplyOutcome =
   /** Text was verified in the input box and the submit key went through. */
@@ -33,10 +34,15 @@ export type ReplyOutcome =
    * (`force`). The caller's `onComposerSeen` work may have run before a re-confirming refusal — but
    * only ever on the path where a live read had just seen the composer, which is the invariant that
    * whole callback exists to enforce.
+   *
+   * `noEcho` carries the password prompt the refusing read was looking at, when it was one — see
+   * lib/no-echo.ts.
    */
-  | { status: "blocked"; error: string }
-  /** Text never reached the input box — NO submit key was sent. The caller MUST keep the draft. */
-  | { status: "stalled"; error: string }
+  | { status: "blocked"; error: string; noEcho?: string }
+  /** Text never reached the input box — NO submit key was sent. The caller MUST keep the draft.
+   *  `noEcho`: the prompt the last verification read saw, when the reason the text never appeared is
+   *  that the screen is deliberately not showing it — see lib/no-echo.ts. */
+  | { status: "stalled"; error: string; noEcho?: string }
   /** Transport/RPC failure. `textDelivered` = text is in the pane but unsubmitted; don't resend. */
   | { status: "error"; error: string; textDelivered?: boolean };
 
@@ -278,6 +284,11 @@ export async function sendGuardedReply(args: GuardedReplyArgs): Promise<ReplyOut
   if (!typed.ok) return { status: "error", error: typed.error };
 
   const sleep = args.sleep ?? defaultSleep;
+  // The last screen a verification read actually saw, kept only so the stall below can be named. The
+  // pre-flight catches almost every password prompt before a byte is typed, but not all of them: a
+  // harness with no `composerReady`, and a `force` the operator armed against a mis-detected screen,
+  // both arrive here having typed the secret into a prompt that will never echo it.
+  let lastSeen: string | null = null;
   for (let attempt = 0; attempt < POLL_ATTEMPTS; attempt++) {
     // Read BEFORE the first sleep: pane.read is an on-demand live read, not a cached poll, so the
     // text is often already on screen by the time the type call returns. That saves a whole
@@ -286,7 +297,17 @@ export async function sendGuardedReply(args: GuardedReplyArgs): Promise<ReplyOut
     let draft: string | null = null;
     try {
       const fresh = await fetchPane(args.paneId, args.requestedLines, args.session);
-      draft = adapter.extractInputDraft(splitLines(parseAnsi(fresh.text)));
+      const lines = splitLines(parseAnsi(fresh.text));
+      // Only a screen the adapter does NOT recognise as its composer can be a raw password prompt.
+      // Without that gate a match on the tail is dangerous rather than merely wrong: the notice this
+      // feeds tells the operator to press Enter in Type, so a stall that was really a dialog eating
+      // the text — with an agent that happened to PRINT "Enter passphrase:" as its last line — would
+      // have us advising the exact keystroke #34 exists to prevent. An adapter with no
+      // `composerReady` cannot rule anything out, so it doesn't (`?? false`): that path is the
+      // unguarded one either way, and it is where a bare shell's sudo prompt actually lives.
+      const composerVisible = adapter.composerReady?.(lines) ?? false;
+      lastSeen = composerVisible ? null : detectNoEchoPrompt(lines);
+      draft = adapter.extractInputDraft(lines);
     } catch {
       continue; // transient read failure — the bounded loop is the timeout
     }
@@ -308,6 +329,16 @@ export async function sendGuardedReply(args: GuardedReplyArgs): Promise<ReplyOut
   // If instead this is a false negative (the text IS in the box, the adapter just couldn't see it),
   // nothing is lost: the next send's pre-clear sweep removes it, and the stranded-draft preview
   // surfaces it in the meantime.
+  if (lastSeen !== null) {
+    // Typed into a prompt that will never show it. The text IS in the pane — unsubmitted, which for a
+    // password means the operator needs one Enter, not a retry, and a retry would type a second copy.
+    return {
+      status: "stalled",
+      error:
+        "That's a password prompt — it shows nothing as you type, so the text can't be confirmed and nothing was submitted. What you typed is already in the pane.",
+      noEcho: lastSeen,
+    };
+  }
   return {
     status: "stalled",
     error:
@@ -317,6 +348,11 @@ export async function sendGuardedReply(args: GuardedReplyArgs): Promise<ReplyOut
 
 const NO_BOX =
   "The agent's input box isn't on screen — a menu or dialog is probably up. Nothing was typed.";
+
+/** Said instead of {@link NO_BOX} when the screen is a password prompt. It names the mechanism rather
+ *  than the symptom, because the operator's next move depends on knowing that waiting won't help. */
+const NO_ECHO =
+  "That's a password prompt — it shows nothing as you type, so Send can never confirm the text arrived. Nothing was typed.";
 
 /**
  * What the pre-flight decided. Two fields, and the second is the safety invariant of this module made
@@ -368,7 +404,15 @@ async function preflight(adapter: HarnessAdapter, args: GuardedReplyArgs): Promi
   if (!composerReady(seen)) {
     // `force` is the user's deliberate "type anyway", so it overrides the refusal — but this is the
     // one screen we have POSITIVE evidence about, and what it says is "no composer". Keys stay home.
-    return blind(args.force ? null : { status: "blocked", error: NO_BOX });
+    if (args.force) return blind(null);
+    // The refusal is already made; naming the screen only changes what the operator is told. A
+    // password prompt is the one case where the generic "a menu or dialog is probably up" is not just
+    // unhelpful but actively misleading — there is no dialog to answer and no amount of retrying will
+    // ever work, because the evidence this guard needs is exactly what the prompt is refusing to show
+    // (#103). Hand the prompt itself back so the caller can say so and offer "Type".
+    const noEcho = detectNoEchoPrompt(seen);
+    if (noEcho !== null) return blind({ status: "blocked", error: NO_ECHO, noEcho });
+    return blind({ status: "blocked", error: NO_BOX });
   }
 
   // The region the read's `true` was true OF. Computed here, from the same parse `composerReady` just


### PR DESCRIPTION
Fixes #103.

Send verifies what it typed before it presses Enter — that's what keeps a swallowed reply from answering a dialog (#34). A password prompt turns echo off, so that evidence can never arrive, and the refusal said "a menu or dialog is probably up", which sends you looking for a dialog that isn't there. **Type** already solved it, one control away, and nothing pointed at it.

**What changes**

- `lib/no-echo.ts` recognises the prompt at the live tail (`[sudo] password for …:`, `user@host's password:`, `Enter passphrase …:`), harness-neutrally — it's the OS's `readpass`, not a property of the agent. It decides nothing: the refusal is already made, so a false negative costs zero and a false positive costs a dismissable notice.
- The guard names the case instead of guessing at a dialog, on the blocked path and on the stall (where `force` and adapterless harnesses land). The stall only counts as no-echo when the adapter does *not* see its own composer — otherwise a "press Enter" hint would be advice for the #34 keystroke.
- A notice beside the unchanged "Type anyway?" override quotes the prompt off the mirror and offers the handoff.
- **Recognising a prompt drops the stored draft and stops persisting keystrokes.** The composer write-through had already put the password in a 48h `localStorage` store before any send was attempted — and the reporter's actual behaviour (tap Send, give up, walk to a laptop) presses no button, so clearing on the handoff alone would never have run.

ADR 0017 records the road not taken: *skip the verification for a screen we recognised and press Enter ourselves.* A match is a guess about a rendered grid, and an agent that merely prints `Enter passphrase:` produces the same tail.

**Verification**

- `cd web && bun run test` — 2274 passing, 109 files
- `bunx tsc --noEmit` clean on both trees; `scripts/check-version.sh` ✓ at 0.30.0
- Negative control run on the new stall gate: removing it fails the test that pins it

🤖 Generated with [Claude Code](https://claude.com/claude-code)
