### PR TITLE
audit: optional COLLIE_AUDIT_CONTENT=none, keeping the event and dropping the body

### DIFF
--- a/bridge/audit-redaction.test.ts
+++ b/bridge/audit-redaction.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test";
+import { formatAuditLine } from "./audit";
+
+const entry = {
+  action: "reply",
+  paneId: "w1:p1",
+  session: "default",
+  detail: {
+    text: "deploy the thing and here is a secret nobody should keep on disk",
+    submit: true,
+    promptBinding: { checked: true, passed: true, expected: "user@host ~/work %" },
+  },
+};
+
+describe("audit content redaction", () => {
+  test("preview is unchanged — the default must not move", () => {
+    const line = JSON.parse(formatAuditLine(entry, 0));
+    expect(line.detail.text).toContain("deploy the thing");
+    expect(line.detail.promptBinding.expected).toContain("user@host");
+  });
+
+  test("none keeps the envelope and drops every string body", () => {
+    const line = JSON.parse(formatAuditLine(entry, 0, "none"));
+    expect(line.action).toBe("reply");
+    expect(line.paneId).toBe("w1:p1");
+    expect(line.session).toBe("default");
+    expect(line.detail.submit).toBe(true);
+    expect(line.detail.promptBinding.checked).toBe(true);
+    expect(line.detail.promptBinding.passed).toBe(true);
+  });
+
+  test("⛔ nothing of the message survives, at any nesting depth", () => {
+    const raw = formatAuditLine(entry, 0, "none");
+    expect(raw).not.toContain("deploy");
+    expect(raw).not.toContain("secret");
+    expect(raw).not.toContain("user@host");
+    expect(raw).toContain("chars⟩");
+  });
+
+  test("the length is kept, because 'was anything sent' is the question a reader asks", () => {
+    const line = JSON.parse(formatAuditLine(entry, 0, "none"));
+    expect(line.detail.text).toBe(`⟨${entry.detail.text.length} chars⟩`);
+  });
+});

--- a/bridge/audit.ts
+++ b/bridge/audit.ts
@@ -9,6 +9,20 @@ import { appendFile } from "node:fs/promises";
 /** Cap on any single string value written into a line — a 2 000-char reply becomes a 120-char preview. */
 const MAX_STR = 120;
 
+/**
+ * How much of a value's CONTENT the trail keeps.
+ *
+ * - `preview` (default, unchanged behaviour): a bounded, single-line preview.
+ * - `none`: the length only. Every string inside `detail` becomes `⟨n chars⟩`.
+ *
+ * `none` exists for deployments where the audit trail is wanted but the message bodies are not:
+ * under `tailscale serve` the operator's replies and, via the prompt binding, a slice of whatever
+ * was on the terminal both land in this file. Keys, booleans, numbers and the whole envelope
+ * (ts, action, paneId, session, device) are untouched either way — the point is to keep answering
+ * "who typed into what, when" without also keeping "what they said".
+ */
+export type AuditContent = "preview" | "none";
+
 /** One write-level action worth recording. `ts` is stamped by {@link formatAuditLine}, not here. */
 export interface AuditEntry {
   /** The action performed, e.g. "reply" / "keys" / "upload" / "tab.create" / "pane.close". */
@@ -32,15 +46,18 @@ export type AppendFn = (line: string) => void | Promise<void>;
  * still fold embedded newlines to a space so a multi-line reply reads as one legible preview rather
  * than a wall of `\n`. Recurses into arrays/objects so `detail` can nest (e.g. a key-name array).
  */
-function sanitize(value: unknown): unknown {
+function sanitize(value: unknown, content: AuditContent = "preview"): unknown {
   if (typeof value === "string") {
+    // ⛔ The LENGTH, not a shorter preview. A truncated secret is still a secret, and the useful
+    // question a reader asks of a redacted trail is "was anything sent", which a count answers.
+    if (content === "none") return `⟨${value.length} chars⟩`;
     const oneLine = value.replace(/[\r\n]+/g, " ");
     return oneLine.length > MAX_STR ? `${oneLine.slice(0, MAX_STR)}…` : oneLine;
   }
-  if (Array.isArray(value)) return value.map(sanitize);
+  if (Array.isArray(value)) return value.map((v) => sanitize(v, content));
   if (value !== null && typeof value === "object") {
     const out: Record<string, unknown> = {};
-    for (const [k, v] of Object.entries(value)) out[k] = sanitize(v);
+    for (const [k, v] of Object.entries(value)) out[k] = sanitize(v, content);
     return out;
   }
   return value;
@@ -52,12 +69,16 @@ function sanitize(value: unknown): unknown {
  * attribution is omitted (not null) when absent. Pure — `now` (epoch ms) is injected so tests are
  * deterministic.
  */
-export function formatAuditLine(entry: AuditEntry, now: number): string {
+export function formatAuditLine(
+  entry: AuditEntry,
+  now: number,
+  content: AuditContent = "preview",
+): string {
   const line: Record<string, unknown> = { ts: new Date(now).toISOString(), action: entry.action };
   if (entry.paneId !== undefined) line.paneId = entry.paneId;
   if (entry.session !== undefined) line.session = entry.session;
   if (entry.device != null) line.device = entry.device;
-  line.detail = sanitize(entry.detail ?? {});
+  line.detail = sanitize(entry.detail ?? {}, content);
   return JSON.stringify(line);
 }
 
@@ -75,12 +96,13 @@ export class AuditLog {
   constructor(
     private readonly append: AppendFn,
     private readonly now: () => number = Date.now,
+    private readonly content: AuditContent = "preview",
   ) {}
 
   record(entry: AuditEntry): void {
     let line: string;
     try {
-      line = formatAuditLine(entry, this.now());
+      line = formatAuditLine(entry, this.now(), this.content);
     } catch (err) {
       console.warn(`[audit] could not format ${entry.action}: ${(err as Error).message}`);
       return;

--- a/bridge/config.ts
+++ b/bridge/config.ts
@@ -151,6 +151,8 @@ export interface Config {
    * `deviceAuth()` in server.ts for the full matrix. The header is trusted only because the bridge
    * binds loopback behind the proxy — a direct client can't set it (same trust basis as trustedUser).
    */
+  /** Whether the audit trail keeps a preview of each value's content, or only its length. */
+  auditContent: "preview" | "none";
   deviceHeader: string;
   /**
    * Device identifiers permitted to perform sensitive actions (typing into agent terminals,
@@ -253,6 +255,7 @@ export function loadConfig(): Config {
     },
     submitKeys: submitKeys.length ? submitKeys : ["Enter"],
     trustedUser: process.env.COLLIE_TRUSTED_USER ?? "",
+    auditContent: envEnum("COLLIE_AUDIT_CONTENT", ["preview", "none"] as const, "preview"),
     deviceHeader: (process.env.COLLIE_DEVICE_HEADER ?? "").trim(),
     deviceAllowlist: envList("COLLIE_DEVICE_ALLOWLIST"),
     allowedOrigins: envList("COLLIE_ALLOWED_ORIGINS"),

--- a/bridge/index.ts
+++ b/bridge/index.ts
@@ -59,7 +59,11 @@ await activity.load();
 
 // Append-only audit trail of write-level actions (see audit.ts). A write failure here is swallowed
 // inside record() so it can never break the user action it's auditing.
-const audit = new AuditLog(fileAuditAppender(join(cfg.stateDir, "audit.log")));
+const audit = new AuditLog(
+  fileAuditAppender(join(cfg.stateDir, "audit.log")),
+  Date.now,
+  cfg.auditContent,
+);
 
 // ── Update-availability monitor ───────────────────────────────────────────────
 // The running plugin version, captured NOW at module load — never re-read from disk later, or a


### PR DESCRIPTION
audit: optional COLLIE_AUDIT_CONTENT=none, keeping the event and dropping the body

The audit trail records every write-level action, which is right — sending
keystrokes to a pane is arbitrary code execution and who-did-what-when is worth
keeping. It also records up to 120 characters of the message itself, and up to
120 characters of the prompt binding, which is a slice of whatever happened to be
on the terminal at the time.

For a personal deployment that is fine. For one where the trail is wanted but the
bodies are not, there is currently no way to have one without the other.

This adds one config value:

  COLLIE_AUDIT_CONTENT=preview   (default, byte-for-byte today's behaviour)
  COLLIE_AUDIT_CONTENT=none      every string inside `detail` becomes the length

The envelope is untouched either way: ts, action, paneId, session, device, and
every boolean and number inside detail. So submitted, textDelivered and
promptBinding.checked/passed still answer the questions the log is for.

Two small decisions, in case they are worth arguing about:

- It keeps the LENGTH rather than a shorter preview. A truncated secret is still
  a secret, and the question a reader asks of a redacted trail is usually whether
  anything was sent at all, which a count answers.
- It recurses, so nesting is covered. The prompt binding is nested and holds the
  terminal fragment; a redaction reaching only the top level would have left the
  more sensitive half in place.

sanitize and formatAuditLine take the mode as a defaulted parameter, so every
existing caller and test is unaffected.

Tested: the existing suite passes unchanged (590 tests), plus four new cases
covering the default being untouched, the envelope surviving, nothing of the
message or the terminal surviving at any depth, and the length being preserved.

Happy to adjust the naming, or drop the env var and take a constructor argument
only, if you would rather not add configuration for this.
