### PR TITLE
feat(palette): COLLIE_COMMANDS — the Agent-commands palette becomes yours

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,6 +44,34 @@ COLLIE_SUBMIT_KEYS=Enter
 # discovery, identical to the pre-multi-session behaviour.
 # COLLIE_MULTI_SESSION=on
 
+# --- Agent-commands palette ---
+# YOUR OWN slash commands for the palette. Set this and the palette becomes your shortcuts: a pane
+# your rows address shows them and nothing else, and a pane none of them address keeps the shipped
+# catalog. Unset, every pane is exactly as shipped. Nothing is lost by replacing the catalog —
+# typing "/" in Type-into-terminal mode still shows the agent's own completion list, live and
+# complete, which no list here could stay. This is also the only way to surface a command the
+# catalog cannot know about: one registered by a PLUGIN or by you, so it exists only on this
+# machine (omp's /fork-in-herdr, a Claude Code custom command, your own /deploy).
+# Comma-separated; each entry is:
+#   [<agent>:]/<command>[ <arg hint>][=<description>]
+# The agent prefix is herdr's detected agent name and scopes the row to those panes. It matches
+# exactly, plus one widening: a catalog name covers its variants, so "claude:" also reaches a
+# claude-code pane while "claude-local:" reaches only claude-local. Omit the prefix and the row
+# applies to EVERY pane — which also means every pane is now addressed, so one unscoped row
+# replaces every catalog. Scope your rows if you want the untouched agents left alone. An unscoped
+# row is also what makes the palette button appear on an agent Collie ships no catalog for.
+# The narrowest match wins for a given /command — exact, then family, then
+# unscoped — so "/deploy=Everywhere,omp:/deploy=On omp" is one button whose text depends on the
+# pane. An empty prefix (":/cmd") is rejected, not read as "every agent". Redefine the same
+# agent:/command and the LAST entry wins. An arg hint marks the row as arg-taking, so tapping it
+# puts "/cmd " in the composer to finish instead of sending it; without one, a tap SENDS the
+# command. Naming a shipped command takes over its description but keeps that command's confirm:
+# renaming a destructive row will not make it one-tap. A description cannot contain a comma, and
+# an arg hint cannot contain "=" (the first one starts the description). These strings are served
+# to every browser that can read this Collie — they are labels, not a place for secrets. Restart
+# the bridge AND reload the page to apply: the app reads them once per load.
+# COLLIE_COMMANDS=omp:/fork-in-herdr=Fork this conversation into a new herdr tab,omp:/fork-in-tmux=Fork into a new tmux window
+
 # --- Pane history (the agent's own session log) ---
 # On by default. This is the ONLY scrollback most agent panes can have: an agent TUI runs on the
 # terminal's alternate screen, which keeps no scrollback ring, so history is read from the log the

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ ships none of its own.
 - **A dashboard ranked by who needs you**, not by what changed last
 - **Push notifications** the moment an agent is waiting on you
 - **Special-keys pad** — `Esc`, `Ctrl+C`, arrows, combinable modifiers
-- **Slash-command palette** per agent — tap, don't type
+- **Slash-command palette** per agent — tap, don't type (or make it your own shortcuts, including
+  plugin/custom commands, with `COLLIE_COMMANDS` — see [`.env.example`](./.env.example))
 
 - **Send an image** from your camera roll
 - **Find in output** — search a pane, don't eyeball it

--- a/bridge/config.test.ts
+++ b/bridge/config.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
-import { defaultSocketPath, loadConfig } from "./config.ts";
+import { defaultSocketPath, loadConfig, parseOperatorCommands } from "./config.ts";
 
 // loadConfig is the deployment contract — env vars in, a resolved Config out. Pure (just reads
 // process.env + homedir), so we drive it by mutating the environment and restoring it after.
@@ -39,6 +39,7 @@ const KEYS = [
   "HERDR_SOCKET_PATH",
   "HERDR_PLUGIN_STATE_DIR",
   "COLLIE_HERDR_DIAL",
+  "COLLIE_COMMANDS",
 ];
 
 let saved: Record<string, string | undefined>;
@@ -300,5 +301,96 @@ describe("defaultSocketPath", () => {
     expect(defaultSocketPath("win32", {}, "C:\\Users\\u")).toBe(
       join("C:\\Users\\u", "AppData", "Roaming", "herdr", "herdr.sock"),
     );
+  });
+});
+
+// The palette's escape hatch: an operator-declared row for a command the shipped catalog cannot
+// vouch for (a plugin's, or their own). Pure, so it is driven directly rather than through env.
+describe("parseOperatorCommands", () => {
+  test("unset or blank yields nothing", () => {
+    expect(parseOperatorCommands(undefined)).toEqual([]);
+    expect(parseOperatorCommands("")).toEqual([]);
+    expect(parseOperatorCommands(" , ,")).toEqual([]);
+  });
+
+  test("scopes a row to one agent and keeps its description", () => {
+    expect(parseOperatorCommands("omp:/fork-in-herdr=Fork into a new herdr tab")).toEqual([
+      {
+        agent: "omp",
+        command: "/fork-in-herdr",
+        description: "Fork into a new herdr tab",
+        takesArg: false,
+        argHint: "",
+      },
+    ]);
+  });
+
+  test("an unscoped row carries no agent, so every pane gets it", () => {
+    const rows = parseOperatorCommands("/deploy");
+    expect(rows).toEqual([
+      { command: "/deploy", description: "Custom command", takesArg: false, argHint: "" },
+    ]);
+    expect("agent" in rows[0]!).toBe(false);
+  });
+
+  test("a hint after the command marks the row arg-taking", () => {
+    expect(parseOperatorCommands("claude:/model <name>=Switch model")).toEqual([
+      {
+        agent: "claude",
+        command: "/model",
+        description: "Switch model",
+        takesArg: true,
+        argHint: "<name>",
+      },
+    ]);
+  });
+
+  test("splits on commas, trims fields, and lowercases the agent", () => {
+    expect(parseOperatorCommands(" OMP:/a=One , codex:/b=Two ").map((c) => [c.agent, c.command, c.description])).toEqual([
+      ["omp", "/a", "One"],
+      ["codex", "/b", "Two"],
+    ]);
+  });
+
+  test("a colon AFTER the slash belongs to the command, not to a scope", () => {
+    const rows = parseOperatorCommands("/skill:review=Run the review skill");
+    expect(rows[0]!.agent).toBeUndefined();
+    expect(rows[0]!.command).toBe("/skill:review");
+  });
+
+  test("drops entries that are not slash commands", () => {
+    expect(parseOperatorCommands("fork-in-herdr,omp:,/,omp:/ok")).toEqual([
+      { agent: "omp", command: "/ok", description: "Custom command", takesArg: false, argHint: "" },
+    ]);
+  });
+
+  test("a redefinition wins, in place, without disturbing another scope", () => {
+    expect(
+      parseOperatorCommands("omp:/x=first,codex:/x=other,omp:/x=second").map((c) => [
+        c.agent,
+        c.description,
+      ]),
+    ).toEqual([
+      ["omp", "second"],
+      ["codex", "other"],
+    ]);
+  });
+
+  test("an empty scope is rejected, never widened to every agent", () => {
+    // ":/wipe" is someone reaching for a narrower rule than they typed. Dropping the empty prefix
+    // would hand them a row on every pane — the one outcome they were not asking for.
+    expect(parseOperatorCommands(":/wipe=Wipe")).toEqual([]);
+    expect(parseOperatorCommands("  :/wipe")).toEqual([]);
+  });
+
+  test("the FIRST = starts the description, so a hint cannot contain one", () => {
+    // A documented cost of the grammar, pinned so it cannot drift into a silent change of meaning:
+    // everything after that first `=` is description, `=` included.
+    expect(parseOperatorCommands("omp:/deploy <env>=Ship to a=b")).toMatchObject([
+      { command: "/deploy", argHint: "<env>", description: "Ship to a=b", takesArg: true },
+    ]);
+    expect(parseOperatorCommands("omp:/set [key=value]=Set a key")).toMatchObject([
+      { command: "/set", argHint: "[key", description: "value]=Set a key" },
+    ]);
   });
 });

--- a/bridge/config.ts
+++ b/bridge/config.ts
@@ -3,6 +3,7 @@ import { join } from "node:path";
 
 import type { DialMode } from "./dial.ts";
 import type { JournalRoots } from "./journal/registry.ts";
+import type { OperatorCommand } from "./types.ts";
 
 // All bridge configuration, resolved once at startup. Env-driven so the systemd unit and the
 // plugin launcher can configure it without code changes. Defaults are safe for a single-user,
@@ -40,6 +41,90 @@ function envList(name: string): string[] {
     .split(",")
     .map((s) => s.trim())
     .filter(Boolean);
+}
+
+/**
+ * Parse `COLLIE_COMMANDS` — the operator's own Agent-commands palette.
+ *
+ * One entry per comma-separated field, in the same list style as every other Collie list var
+ * ({@link envList}):
+ *
+ * ```
+ * [<agent>:]/<command>[ <arg hint>][=<description>]
+ * ```
+ *
+ * `omp:/fork-in-herdr=Fork this conversation into a new herdr tab` scopes the row to omp panes;
+ * a bare `/deploy` applies to every agent (and makes the palette button appear on an agent that
+ * ships no catalog at all). An arg hint — anything after a space, before the FIRST `=` — marks the
+ * row as arg-taking, so tapping it INSERTS `/cmd ` into the composer instead of submitting it.
+ *
+ * A LATER entry for the same `agent:/command` pair replaces an earlier one, so appending to the
+ * variable (the usual way these grow) corrects a row instead of being silently ignored. An empty
+ * scope (`:/wipe`) is REJECTED rather than read as "every agent": the operator was reaching for a
+ * narrower rule than they got, and the failure has to be the narrow one.
+ *
+ * Two grammar costs, both of them separators the list style already spends: a description cannot
+ * contain a comma, and an arg hint cannot contain `=` (the first one starts the description, so
+ * `/set [key=value]=Set a key` hints `[key` and describes `value]=Set a key`). Everything after
+ * that first `=` is description, `=` included. Inventing a second separator that means one thing
+ * here and another everywhere else in this file costs more than either.
+ *
+ * Why this exists at all: the shipped catalog (`web/src/lib/agent-commands.ts`) is deliberately
+ * limited to commands its sources vouch for on EVERY user's machine, so a plugin- or user-registered
+ * command can never be added there. This is the supported way to get one into the palette — and a
+ * pane addressed by these rows shows them INSTEAD of the shipped ones, because the palette is a
+ * handful of one-thumb shortcuts and a list half-chosen by the operator is worse than either whole
+ * one. Exported and pure so the grammar is unit-testable without touching `process.env`.
+ */
+export function parseOperatorCommands(raw: string | undefined): OperatorCommand[] {
+  const out: OperatorCommand[] = [];
+  const at = new Map<string, number>();
+  for (const entry of (raw ?? "").split(",").map((s) => s.trim()).filter(Boolean)) {
+    const eq = entry.indexOf("=");
+    const spec = (eq === -1 ? entry : entry.slice(0, eq)).trim();
+    const description = (eq === -1 ? "" : entry.slice(eq + 1).trim()) || "Custom command";
+    // An `agent:` prefix only counts BEFORE the slash — a colon later belongs to the command or its
+    // hint and must not be mistaken for a scope.
+    const colon = spec.indexOf(":");
+    const slash = spec.indexOf("/");
+    const scoped = colon !== -1 && (slash === -1 || colon < slash);
+    const agent = scoped ? spec.slice(0, colon).trim().toLowerCase() : "";
+    const rest = (scoped ? spec.slice(colon + 1) : spec).trim();
+    const space = rest.search(/\s/);
+    const command = space === -1 ? rest : rest.slice(0, space);
+    const argHint = space === -1 ? "" : rest.slice(space + 1).trim();
+    if (!command.startsWith("/") || command.length < 2) {
+      console.warn(
+        `[config] COLLIE_COMMANDS: ignoring "${entry}" — expected [agent:]/command[ hint][=description]`,
+      );
+      continue;
+    }
+    if (scoped && agent === "") {
+      // Fail closed. Dropping the empty scope would widen the row to every pane — the opposite of
+      // what a scope was typed for.
+      console.warn(`[config] COLLIE_COMMANDS: ignoring "${entry}" — empty agent scope`);
+      continue;
+    }
+    const row: OperatorCommand = {
+      ...(agent ? { agent } : {}),
+      command,
+      description,
+      takesArg: argHint !== "",
+      argHint,
+    };
+    const key = `${agent}\u0000${command}`;
+    const prev = at.get(key);
+    if (prev !== undefined) {
+      // Later wins, in place: the row keeps its original position so fixing a description does not
+      // reshuffle the palette.
+      console.warn(`[config] COLLIE_COMMANDS: "${command}" redefined — later entry wins`);
+      out[prev] = row;
+      continue;
+    }
+    at.set(key, out.length);
+    out.push(row);
+  }
+  return out;
 }
 
 /**
@@ -136,6 +221,12 @@ export interface Config {
   journalRoots: JournalRoots;
   /** Key sequence sent to submit a reply after the text (agent-dependent; see HERDR_API.md). */
   submitKeys: string[];
+  /**
+   * Operator-declared additions to the Agent-commands palette, served on `/api/config`. Empty
+   * unless `COLLIE_COMMANDS` is set — see {@link parseOperatorCommands} for the grammar and for
+   * why the shipped catalog cannot carry these.
+   */
+  operatorCommands: OperatorCommand[];
   /**
    * Tailscale identity gate. If set, any request carrying a `Tailscale-User-Login` header
    * (injected by `tailscale serve`) must match this login — a mismatching tailnet user is
@@ -252,6 +343,7 @@ export function loadConfig(): Config {
       ),
     },
     submitKeys: submitKeys.length ? submitKeys : ["Enter"],
+    operatorCommands: parseOperatorCommands(process.env.COLLIE_COMMANDS),
     trustedUser: process.env.COLLIE_TRUSTED_USER ?? "",
     deviceHeader: (process.env.COLLIE_DEVICE_HEADER ?? "").trim(),
     deviceAllowlist: envList("COLLIE_DEVICE_ALLOWLIST"),

--- a/bridge/server.test.ts
+++ b/bridge/server.test.ts
@@ -53,6 +53,7 @@ function cfg(overrides: Partial<Config> = {}): Config {
       opencode: ["/nope/opencode"],
     },
     submitKeys: ["Enter"],
+    operatorCommands: [],
     trustedUser: "",
     deviceHeader: "",
     deviceAllowlist: [],

--- a/bridge/server.ts
+++ b/bridge/server.ts
@@ -286,18 +286,23 @@ export function startServer(opts: {
 
       // ── Misc API ─────────────────────────────────────────────────────────
       if (pathname === "/api/config") {
-        // Read-level, like the other non-terminal endpoints. Nothing here is secret — the VAPID
-        // public key is handed to every browser by design — but this was the one route that skipped
-        // checkAccess entirely, so COLLIE_PUBLIC_HOSTS didn't cover it and a rebound DNS name could
-        // still read the build id. The client only ever calls this same-origin, and a refusal can't
-        // be mistaken for an outage: ConnectionBanner short-circuits to AuthErrorBanner before its
-        // red-state probe runs. Noted in #32.
+        // Read-level, like the other non-terminal endpoints. Nothing Collie puts here is a
+        // credential — the VAPID public key is handed to every browser by design — but the payload
+        // is no longer entirely Collie's: operatorCommands is operator-authored text, and any read
+        // client sees it verbatim (`.env.example` says so where it is set).
+        // It was also the one route that skipped checkAccess entirely, so COLLIE_PUBLIC_HOSTS
+        // didn't cover it and a rebound DNS name could read it. The client only ever calls this
+        // same-origin, and a refusal can't be mistaken for an outage: ConnectionBanner
+        // short-circuits to AuthErrorBanner before its red-state probe runs. Noted in #32.
         const denied = guard(req, cfg, "read");
         if (denied) return denied;
         return json({
           push: push.enabled,
           vapidPublicKey: push.publicKey,
           build: await buildId(),
+          // Omitted entirely when unset, so an operator who never touched COLLIE_COMMANDS
+          // ships the same payload as before.
+          ...(cfg.operatorCommands.length > 0 ? { operatorCommands: cfg.operatorCommands } : {}),
         } satisfies BridgeConfig, req.headers.get("accept-encoding"));
       }
       if (pathname === "/api/subscribe" && req.method === "POST") {

--- a/bridge/types.ts
+++ b/bridge/types.ts
@@ -268,12 +268,34 @@ export interface CreatedPane {
  */
 export type CreateResponse = { ok: true; pane: CreatedPane } | { ok: false; error: string };
 
+/**
+ * One operator-declared slash command (`COLLIE_COMMANDS`). A pane any of these rows address shows
+ * them INSTEAD of the shipped Agent-commands catalog; a pane none of them address keeps it. This is
+ * the escape hatch for commands the shipped catalog cannot know about — plugin- or user-registered
+ * ones like omp's `/fork-in-herdr` — which exist only on THIS operator's machine and so must never
+ * be hard-coded into `web/src/lib/agent-commands.ts`.
+ */
+export interface OperatorCommand {
+  /** Herdr agent name this applies to, lowercased. Omitted = every agent. */
+  agent?: string;
+  /** Includes the leading slash. */
+  command: string;
+  /** One-line description shown in the palette (also searched). */
+  description: string;
+  /** True when tapping should insert `/cmd ` into the composer instead of submitting it. */
+  takesArg: boolean;
+  /** Placeholder shown after insert, e.g. `<name>`. Empty when {@link takesArg} is false. */
+  argHint: string;
+}
+
 /** GET /api/config — bridge capabilities and the build id (push setup + stale-cache detection). */
 export interface BridgeConfig {
   push: boolean;
   vapidPublicKey: string;
   /** Build id of the bundle the bridge is currently serving (for stale-cache detection). */
   build?: string;
+  /** The operator's own palette rows. Absent/empty when `COLLIE_COMMANDS` is unset. */
+  operatorCommands?: OperatorCommand[];
 }
 
 /** Rank for triage ordering — lower sorts first ("NEEDS YOU" at the top). */

--- a/web/src/components/command-palette.test.tsx
+++ b/web/src/components/command-palette.test.tsx
@@ -2,8 +2,9 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import { CommandPalette } from "./command-palette";
+import type { OperatorCommand } from "@/lib/types";
 
-function setup(overrides?: { agent?: string | null }) {
+function setup(overrides?: { agent?: string | null; mine?: OperatorCommand[] }) {
   const props = {
     open: true,
     onClose: vi.fn(),
@@ -78,5 +79,73 @@ describe("CommandPalette", () => {
     setup({ agent: "gemini" });
     expect(screen.queryByText("/status")).toBeNull();
     expect(screen.queryByText("/compact")).toBeNull();
+  });
+
+  it("shows one of the operator's own commands on the first screen and submits it", async () => {
+    const user = userEvent.setup();
+    const props = setup({
+      agent: "omp",
+      mine: [
+        {
+          agent: "omp",
+          command: "/fork-in-herdr",
+          description: "Fork into a new herdr tab",
+          takesArg: false,
+          argHint: "",
+        },
+      ],
+    });
+    // No search needed — an operator-declared row is common by construction.
+    await user.click(screen.getByText("/fork-in-herdr"));
+    expect(props.onSubmit).toHaveBeenCalledExactlyOnceWith("/fork-in-herdr");
+    expect(props.onClose).toHaveBeenCalledOnce();
+  });
+
+  it("gives an agent with no catalog a palette when an unscoped row applies", () => {
+    setup({
+      agent: "gemini",
+      mine: [{ command: "/deploy", description: "Ship it", takesArg: false, argHint: "" }],
+    });
+    expect(screen.getByText("/deploy")).toBeInTheDocument();
+  });
+
+  it("renders one button when a scoped and an unscoped row name the same command", () => {
+    setup({
+      agent: "omp",
+      mine: [
+        { command: "/deploy", description: "Everywhere", takesArg: false, argHint: "" },
+        { agent: "omp", command: "/deploy", description: "On omp", takesArg: false, argHint: "" },
+      ],
+    });
+    // getAllByText, not getByText: two rows would also mean two children under one React key.
+    expect(screen.getAllByText("/deploy")).toHaveLength(1);
+    expect(screen.getByText("On omp")).toBeInTheDocument();
+  });
+
+  it("shows the operator's rows INSTEAD of the shipped catalog", () => {
+    setup({
+      agent: "omp",
+      mine: [
+        { agent: "omp", command: "/fork-in-herdr", description: "Fork", takesArg: false, argHint: "" },
+      ],
+    });
+    expect(screen.getByText("/fork-in-herdr")).toBeInTheDocument();
+    // The sheet is the operator's shortcuts now — no searching past ten rows nobody picked.
+    expect(screen.queryByText("/compact")).toBeNull();
+  });
+
+  it("still asks twice before a renamed destructive command", async () => {
+    const user = userEvent.setup();
+    const props = setup({
+      agent: "omp",
+      mine: [
+        { agent: "omp", command: "/new", description: "Fresh start", takesArg: false, argHint: "" },
+      ],
+    });
+    await user.click(screen.getByText("Fresh start"));
+    expect(props.onSubmit).not.toHaveBeenCalled();
+    expect(screen.getByText("Confirm?")).toBeInTheDocument();
+    await user.click(screen.getByText("Fresh start"));
+    expect(props.onSubmit).toHaveBeenCalledExactlyOnceWith("/new");
   });
 });

--- a/web/src/components/command-palette.tsx
+++ b/web/src/components/command-palette.tsx
@@ -6,19 +6,29 @@ import { BottomSheet } from "@/components/ui/sheet";
 import { AgentIcon } from "@/components/agent-icon";
 import { usePendingConfirm } from "@/hooks/use-pending-confirm";
 import { commandsFor, type AgentCommand } from "@/lib/agent-commands";
+import type { OperatorCommand } from "@/lib/types";
 
 interface CommandPaletteProps {
   open: boolean;
   onClose: () => void;
   agent: string | undefined | null;
+  /** The operator's own rows (`COLLIE_COMMANDS`); they replace the catalog on panes they address. */
+  mine?: readonly OperatorCommand[];
   /** Insert "/cmd " into the composer for the user to complete (arg-taking commands). */
   onInsert: (text: string) => void;
   /** Send "/cmd" immediately and submit (no-arg commands). */
   onSubmit: (text: string) => void;
 }
 
-export function CommandPalette({ open, onClose, agent, onInsert, onSubmit }: CommandPaletteProps) {
-  const all = commandsFor(agent);
+export function CommandPalette({
+  open,
+  onClose,
+  agent,
+  mine,
+  onInsert,
+  onSubmit,
+}: CommandPaletteProps) {
+  const all = commandsFor(agent, mine);
   const [query, setQuery] = useState("");
   const { pending, confirm, reset } = usePendingConfirm();
 

--- a/web/src/components/composer.tsx
+++ b/web/src/components/composer.tsx
@@ -17,6 +17,7 @@ import { DisplayPrefsContent } from "@/components/display-prefs";
 import { SectionLabel } from "@/components/ui/section-label";
 import * as api from "@/lib/api";
 import { commandsFor } from "@/lib/agent-commands";
+import { useOperatorCommands } from "@/lib/operator-commands";
 import { isDestructiveInput } from "@/lib/destructive";
 import { loadDraft, saveDraft } from "@/lib/drafts";
 import { useHoldReload } from "@/lib/reload-guard";
@@ -380,7 +381,10 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
     focusInputEnd();
   }
 
-  const commands = commandsFor(agent);
+  // The operator's own palette rows, resolved against the shipped catalog for both the button's
+  // visibility test here and the palette's own list below (same call, same arguments).
+  const operatorCommands = useOperatorCommands();
+  const commands = commandsFor(agent, operatorCommands);
 
   function focusInputImmediately() {
     const el = inputRef.current;
@@ -953,6 +957,7 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
         open={drawer === "cmd"}
         onClose={closeDrawer}
         agent={agent}
+        mine={operatorCommands}
         onInsert={insertCommand}
         onSubmit={(t) => send(t, false)}
       />

--- a/web/src/lib/agent-commands.test.ts
+++ b/web/src/lib/agent-commands.test.ts
@@ -126,3 +126,151 @@ describe("commandsFor", () => {
     },
   );
 });
+
+// The operator's own rows (COLLIE_COMMANDS → /api/config). The shipped catalogs cannot carry a
+// plugin- or user-registered command, and a list half-chosen by you and half-guessed for you is
+// worse than either — so a pane your rows address shows your rows and nothing else.
+describe("commandsFor with the operator's own rows", () => {
+  const forkIn = {
+    agent: "omp",
+    command: "/fork-in-herdr",
+    description: "Fork into a new herdr tab",
+    takesArg: false,
+    argHint: "",
+  };
+
+  it("replaces the catalog on the panes it addresses", () => {
+    const omp = commandsFor("omp", [forkIn]);
+    expect(omp.map((c) => c.command)).toEqual(["/fork-in-herdr"]);
+    // The shipped rows are gone, not merged: this surface is the operator's shortcuts now.
+    expect(omp.some((c) => c.command === "/compact")).toBe(false);
+  });
+
+  it("leaves a pane none of your rows address exactly as shipped", () => {
+    // Scoping rows to omp says nothing about your claude panes, so they are not part of the choice.
+    expect(commandsFor("claude", [forkIn])).toEqual(commandsFor("claude"));
+    expect(commandsFor("claude", [forkIn]).some((c) => c.command === "/fork-in-herdr")).toBe(false);
+  });
+
+  it("matches the scope through the same variant tolerance as the catalog lookup", () => {
+    expect(commandsFor(" OMP ", [forkIn]).some((c) => c.command === "/fork-in-herdr")).toBe(true);
+  });
+
+  it("surfaces extras on the first screen, never as a two-tap confirm", () => {
+    const row = commandsFor("omp", [forkIn]).find((c) => c.command === "/fork-in-herdr");
+    expect(row?.common).toBe(true);
+    expect(row?.dangerous).toBe(false);
+    expect(row?.description).toBe("Fork into a new herdr tab");
+  });
+
+  it("gives an agent with no catalog a palette when an unscoped extra applies", () => {
+    const unscoped = { command: "/deploy", description: "Ship it", takesArg: false, argHint: "" };
+    expect(commandsFor("gemini")).toEqual([]);
+    expect(commandsFor("gemini", [unscoped]).map((c) => c.command)).toEqual(["/deploy"]);
+    // Including a pane with no detected agent at all, where the button would otherwise never show.
+    expect(commandsFor(null, [unscoped]).map((c) => c.command)).toEqual(["/deploy"]);
+  });
+
+  it("renders one button, not two, when a row names a shipped command", () => {
+    const override = {
+      agent: "omp",
+      command: "/compact",
+      description: "My own wording",
+      takesArg: false,
+      argHint: "",
+    };
+    const rows = commandsFor("omp", [override]);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].description).toBe("My own wording");
+  });
+
+  it("carries an arg-taking extra through with its hint", () => {
+    const withArg = {
+      agent: "omp",
+      command: "/label",
+      description: "Rename the pane",
+      takesArg: true,
+      argHint: "<name>",
+    };
+    const row = commandsFor("omp", [withArg]).find((c) => c.command === "/label");
+    expect(row?.takesArg).toBe(true);
+    expect(row?.argHint).toBe("<name>");
+  });
+
+  it("is unchanged by an empty extras list", () => {
+    expect(commandsFor("omp", [])).toEqual(commandsFor("omp"));
+  });
+
+  it("keeps a shipped row's confirm when an extra renames it", () => {
+    // The two-tap confirm belongs to the command, not to the text describing it. Re-wording a
+    // session wipe must not be a way — least of all an unwitting one — to make it one tap.
+    const shipped = commandsFor("omp").find((c) => c.command === "/new");
+    expect(shipped?.dangerous).toBe(true);
+    const override = {
+      agent: "omp",
+      command: "/new",
+      description: "Fresh start",
+      takesArg: false,
+      argHint: "",
+    };
+    const row = commandsFor("omp", [override]).find((c) => c.command === "/new");
+    expect(row?.description).toBe("Fresh start");
+    expect(row?.dangerous).toBe(true);
+  });
+
+  it("resolves a scoped and an unscoped row for one command to a single scoped button", () => {
+    // "everywhere, except here" is the obvious use of a scope. Two rows with one /name would also
+    // collide on the palette's React key.
+    const extras = [
+      { command: "/deploy", description: "Everywhere", takesArg: false, argHint: "" },
+      { agent: "omp", command: "/deploy", description: "On omp", takesArg: false, argHint: "" },
+    ];
+    const omp = commandsFor("omp", extras).filter((c) => c.command === "/deploy");
+    expect(omp.map((c) => c.description)).toEqual(["On omp"]);
+    // Declaration order must not decide it.
+    const flipped = commandsFor("omp", [extras[1], extras[0]]).filter((c) => c.command === "/deploy");
+    expect(flipped.map((c) => c.description)).toEqual(["On omp"]);
+    // Every other pane still gets the global row.
+    expect(
+      commandsFor("claude", extras).filter((c) => c.command === "/deploy").map((c) => c.description),
+    ).toEqual(["Everywhere"]);
+  });
+
+  it("reaches an agent variant the same way its catalog does", () => {
+    const mine = { agent: "claude", command: "/mine", description: "Mine", takesArg: false, argHint: "" };
+    // The scope resolves the variant, and having done so it owns that pane's palette.
+    expect(commandsFor("claude-code", [mine]).map((c) => c.command)).toEqual(["/mine"]);
+  });
+
+  it("does not let the catalog's prefix tolerance widen a narrow scope", () => {
+    // "claude-local:" folds onto CLAUDE for the CATALOG lookup, but the operator typed a name for
+    // one pane. Reading it as the whole family is the same failure as treating ":/cmd" as global.
+    const local = { agent: "claude-local", command: "/deploy", description: "Local", takesArg: false, argHint: "" };
+    expect(commandsFor("claude", [local]).some((c) => c.command === "/deploy")).toBe(false);
+    expect(commandsFor("claude-code", [local]).some((c) => c.command === "/deploy")).toBe(false);
+    expect(commandsFor("claude-local", [local]).some((c) => c.command === "/deploy")).toBe(true);
+    // Same for every other family with a bare-prefix rule.
+    const omp = { agent: "omp-experimental", command: "/deploy", description: "X", takesArg: false, argHint: "" };
+    expect(commandsFor("omp", [omp]).some((c) => c.command === "/deploy")).toBe(false);
+  });
+
+  it("prefers the exact scope over the family one, whichever was declared first", () => {
+    const family = { agent: "claude", command: "/deploy", description: "Family", takesArg: false, argHint: "" };
+    const exact = { agent: "claude-code", command: "/deploy", description: "Exact", takesArg: false, argHint: "" };
+    const pick = (extras: typeof family[]) =>
+      commandsFor("claude-code", extras).filter((c) => c.command === "/deploy").map((c) => c.description);
+    expect(pick([family, exact])).toEqual(["Exact"]);
+    expect(pick([exact, family])).toEqual(["Exact"]);
+    // …and the family row still reaches a variant pane when it is the only one aimed there.
+    expect(pick([family])).toEqual(["Family"]);
+    expect(
+      commandsFor("claude", [family, exact]).filter((c) => c.command === "/deploy").map((c) => c.description),
+    ).toEqual(["Family"]);
+  });
+
+  it("scopes to an agent Collie ships no catalog for", () => {
+    const mine = { agent: "aider", command: "/mine", description: "Mine", takesArg: false, argHint: "" };
+    expect(commandsFor("aider", [mine]).map((c) => c.command)).toEqual(["/mine"]);
+    expect(commandsFor("omp", [mine]).some((c) => c.command === "/mine")).toBe(false);
+  });
+});

--- a/web/src/lib/agent-commands.ts
+++ b/web/src/lib/agent-commands.ts
@@ -11,6 +11,8 @@
 //
 // To regenerate: re-run the per-agent doc-fetch agents (see CHANGELOG) and replace the arrays.
 
+import type { OperatorCommand } from "@/lib/types";
+
 export interface AgentCommand {
   /** Includes the leading slash, e.g. "/compact". */
   command: string;
@@ -228,26 +230,112 @@ const CATALOG: Record<string, readonly AgentCommand[]> = {
 };
 
 /**
- * Commands for a Herdr-detected agent (`pane.agent`, e.g. "claude" / "codex"). Returns [] for
- * unknown/absent agents — the UI then hides the command button.
+ * Commands for a Herdr-detected agent (`pane.agent`, e.g. "claude" / "codex") — the operator's own
+ * `COLLIE_COMMANDS` rows if any of them address this pane, otherwise the shipped catalog. Returns
+ * [] when neither has anything, and the UI hides the command button.
  *
  * `Object.hasOwn`, not a truthy index: `CATALOG` is a plain object, so an agent string that spells
  * an inherited `Object.prototype` member ("constructor", "toString", "valueOf", …) indexes to that
  * member — a FUNCTION — which is truthy and would be handed back as if it were a command array.
  * command-palette.tsx then calls `.filter` on it and throws, taking the palette down. Same hardening
  * quick-replies.ts applies to its twin lookup, and adapterFor() to the registry.
+ *
+ * Four rules:
+ *
+ * 1. YOUR LIST IS THE PALETTE. A pane addressed by even one of your rows shows your rows for that
+ *    pane and nothing else. This surface is a handful of one-thumb shortcuts, and the value of the
+ *    shipped catalog is that someone chose those ten; a list half-chosen by you and half-guessed
+ *    for you is worse than either. Discovery is not lost by this — the agent's own `/` completion
+ *    renders in the mirrored pane, complete and live, which no copy here could stay.
+ * 2. A PANE YOU DID NOT ADDRESS KEEPS ITS CATALOG. Scoping rows to `omp:` says nothing about your
+ *    claude panes, so they are left alone. Declaring nothing at all leaves every pane as shipped.
+ * 3. DANGER IS INHERITED, NOT RESET. A row naming a shipped command keeps that row's `dangerous`
+ *    classification, so re-describing a session wipe cannot turn a two-tap command into a one-tap
+ *    one. A row that names nothing shipped is not dangerous — nothing out here knows otherwise.
+ * 4. THE MORE SPECIFIC SCOPE WINS, and one `/name` is one row. Exact (`claude-code:` on a
+ *    claude-code pane) beats family (`claude:` on the same pane) beats unscoped;
+ *    `/deploy=Global,omp:/deploy=On omp` is the obvious way to write "this everywhere, except
+ *    here" and must not render as two identically named buttons (which also collide on the
+ *    palette's `key={c.command}`). Declaration order decides only between rows of equal
+ *    specificity, where the later one wins — the same rule the parser uses for exact duplicates.
+ *    A family scope is only ever the catalog's own name for the family: `claude:` reaches a
+ *    "claude-code" pane because CLAUDE's shipped rows do; `claude-local:` does NOT, even though
+ *    the catalog lookup would fold it onto CLAUDE. Folding an arbitrary operator string through
+ *    that ladder turns a scope written to be narrow into a family-wide one.
  */
-export function commandsFor(agent: string | undefined | null): readonly AgentCommand[] {
-  if (!agent) return [];
-  const key = agent.toLowerCase().trim();
-  if (Object.hasOwn(CATALOG, key)) return CATALOG[key];
-  // Tolerate variants like "claude-code" / "opencode-dev".
-  if (key.startsWith("claude")) return CLAUDE;
-  if (key.startsWith("codex")) return CODEX;
-  if (key.startsWith("opencode")) return OPENCODE;
-  if (key === "pi" || key.startsWith("pi-") || key.startsWith("pi.")) return PI;
+export function commandsFor(
+  agent: string | undefined | null,
+  mine: readonly OperatorCommand[] = [],
+): readonly AgentCommand[] {
+  const shipped = catalogFor(agent);
+  if (mine.length === 0) return shipped;
+  const paneKey = agent?.toLowerCase().trim() ?? "";
+  const paneFamily = canonicalAgent(paneKey);
+  // One entry per `/name`, keyed by how specifically it was aimed. Insertion order is declaration
+  // order and Map.set on an existing key keeps that position, so a scoped row correcting a global
+  // one lands where the global one was.
+  const aimed = new Map<string, { row: OperatorCommand; aim: number }>();
+  for (const row of mine) {
+    const aim = specificity(row, paneKey, paneFamily);
+    if (aim === MISSES) continue;
+    const prev = aimed.get(row.command);
+    if (prev !== undefined && prev.aim > aim) continue;
+    aimed.set(row.command, { row, aim });
+  }
+  // Rule 2: nothing of yours points here, so this pane was never part of what you were choosing.
+  if (aimed.size === 0) return shipped;
+  const byName = new Map(shipped.map((c) => [c.command, c] as const));
+  return [...aimed.values()].map(({ row }) => ({
+    command: row.command,
+    description: row.description,
+    takesArg: row.takesArg,
+    argHint: row.argHint,
+    // A row you typed into your own config is by definition one you want on the first screen.
+    common: true,
+    dangerous: byName.get(row.command)?.dangerous ?? false,
+  }));
+}
+
+const MISSES = 0;
+const UNSCOPED = 1;
+const FAMILY = 2;
+const EXACT = 3;
+
+/** How narrowly one of your rows was aimed at this pane — see rule 4 on {@link commandsFor}. */
+function specificity(row: OperatorCommand, paneKey: string, paneFamily: string): number {
+  // An unscoped row applies everywhere, including to an agent with no catalog at all (and to a
+  // pane with no agent, where the palette button would otherwise never appear).
+  if (row.agent === undefined) return UNSCOPED;
+  if (paneKey === "") return MISSES;
+  const scope = row.agent.toLowerCase().trim();
+  if (scope === paneKey) return EXACT;
+  // `Object.hasOwn`, not `canonicalAgent(scope) === paneFamily`: only the catalog's own name for a
+  // family addresses the whole family. Anything else stays exact, so a narrow operator scope can
+  // never be widened by the lookup's prefix tolerance.
+  return Object.hasOwn(CATALOG, scope) && scope === paneFamily ? FAMILY : MISSES;
+}
+
+/**
+ * Fold a PANE's agent name onto the name its catalog is filed under ("claude-code" -> "claude"),
+ * or onto itself when nothing ships for it. This is the lookup's variant tolerance, and it is
+ * deliberately applied to what Herdr reports, never to what the operator typed as a scope: it is
+ * a widening rule, and widening a scope is the one thing rule 4 on {@link commandsFor} forbids.
+ */
+function canonicalAgent(key: string): string {
+  if (key === "") return "";
+  if (Object.hasOwn(CATALOG, key)) return key;
+  if (key.startsWith("claude")) return "claude";
+  if (key.startsWith("codex")) return "codex";
+  if (key.startsWith("opencode")) return "opencode";
+  if (key === "pi" || key.startsWith("pi-") || key.startsWith("pi.")) return "pi";
   // `omp` is its own prefix — no other agent string in this file starts with it, and it must NOT be
   // reached by the `pi` rules above: oh-my-pi ships a different command set from pi.dev's.
-  if (key.startsWith("omp")) return OMP;
-  return [];
+  if (key.startsWith("omp")) return "omp";
+  return key;
+}
+
+function catalogFor(agent: string | undefined | null): readonly AgentCommand[] {
+  if (!agent) return [];
+  const key = canonicalAgent(agent.toLowerCase().trim());
+  return Object.hasOwn(CATALOG, key) ? CATALOG[key] : [];
 }

--- a/web/src/lib/operator-commands.test.ts
+++ b/web/src/lib/operator-commands.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+
+// Spied at the api seam, not over the network: the invariant under test is how MANY times the
+// store asks, and a mock records that synchronously — no waiting on a request that may never come.
+vi.mock("@/lib/api", () => ({ fetchConfig: vi.fn() }));
+
+import { fetchConfig } from "@/lib/api";
+import type { BridgeConfig } from "@/lib/types";
+import {
+  __resetOperatorCommands,
+  getOperatorCommands,
+  loadOperatorCommands,
+  useOperatorCommands,
+} from "./operator-commands";
+
+const asked = vi.mocked(fetchConfig);
+
+const forkIn = {
+  agent: "omp",
+  command: "/fork-in-herdr",
+  description: "Fork into a new herdr tab",
+  takesArg: false,
+  argHint: "",
+};
+
+const config = (operatorCommands?: BridgeConfig["operatorCommands"]): BridgeConfig => ({
+  push: false,
+  vapidPublicKey: "",
+  ...(operatorCommands ? { operatorCommands } : {}),
+});
+
+beforeEach(() => asked.mockReset());
+afterEach(() => __resetOperatorCommands());
+
+describe("the operator's palette rows are read once, not polled", () => {
+  it("fetches on the first mount and serves later mounts from module state", async () => {
+    asked.mockResolvedValue(config([forkIn]));
+    const first = renderHook(() => useOperatorCommands());
+    await waitFor(() => expect(first.result.current).toEqual([forkIn]));
+    first.unmount();
+    const second = renderHook(() => useOperatorCommands());
+    expect(second.result.current).toEqual([forkIn]); // no second round trip, no flash of empty
+    expect(asked).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not re-request when the composer re-renders around it", async () => {
+    asked.mockResolvedValue(config([forkIn]));
+    const { result, rerender } = renderHook(() => useOperatorCommands());
+    await waitFor(() => expect(result.current).toEqual([forkIn]));
+    for (let i = 0; i < 20; i++) rerender();
+    expect(asked).toHaveBeenCalledTimes(1);
+  });
+
+  it("survives a refusal as an empty list, retried on a later mount, not on every render", async () => {
+    // Extras are additive: with none, the palette is exactly what a user without the var sees. So a
+    // read-only device or an auth lapse costs an empty list and nothing else — and, critically, the
+    // composer re-renders on every 1.5s snapshot, so a kick in the render body would turn one
+    // refusal into a request per tick, forever.
+    asked.mockRejectedValue(new Error("403"));
+    const { result, rerender } = renderHook(() => useOperatorCommands());
+    await waitFor(() => expect(asked).toHaveBeenCalledTimes(1));
+    for (let i = 0; i < 20; i++) rerender();
+    expect(result.current).toEqual([]);
+    expect(asked).toHaveBeenCalledTimes(1); // the failure did not arm a request loop
+    expect(getOperatorCommands()).toEqual([]);
+
+    asked.mockResolvedValue(config([forkIn]));
+    const retry = renderHook(() => useOperatorCommands()); // a later mount is the retry
+    await waitFor(() => expect(retry.result.current).toEqual([forkIn]));
+  });
+
+  it("shares one in-flight request between concurrent callers", async () => {
+    // All three land before the first response resolves, so the second and third must join the
+    // promise already in flight rather than opening their own.
+    asked.mockResolvedValue(config([forkIn]));
+    const all = Promise.all([loadOperatorCommands(), loadOperatorCommands(), loadOperatorCommands()]);
+    expect(asked).toHaveBeenCalledTimes(1);
+    await all;
+    expect(getOperatorCommands()).toEqual([forkIn]);
+  });
+
+  it("treats a bridge that sends no operatorCommands as no extras", async () => {
+    asked.mockResolvedValue(config());
+    await loadOperatorCommands();
+    expect(getOperatorCommands()).toEqual([]);
+  });
+});

--- a/web/src/lib/operator-commands.ts
+++ b/web/src/lib/operator-commands.ts
@@ -1,0 +1,79 @@
+import { useEffect, useSyncExternalStore } from "react";
+
+import { fetchConfig } from "@/lib/api";
+import type { OperatorCommand } from "@/lib/types";
+
+// The operator's own palette rows (`COLLIE_COMMANDS`), read from /api/config and held in
+// module state. Modelled on the lib/server-build.ts store idiom: plain module state + subscribe +
+// a useSyncExternalStore hook, so the composer participates without prop-drilling through the route
+// tree.
+//
+// THE CONTRACT: one SUCCESSFUL read is cached for the life of the page; a failed attempt is not
+// cached, so a later mount tries again. Never polled, and deliberately not folded into the 1.5s
+// snapshot: this is startup config on the bridge side (loadConfig() runs once, bridge/index.ts), so
+// re-reading it every tick would spend bytes on a value that cannot change without a bridge
+// restart. Which is also why changing it takes a bridge restart AND a page load, not just the
+// restart — the same contract every other COLLIE_* var has, and what `.env.example` promises.
+//
+// A FAILED FETCH IS NOT AN ERROR STATE. With no rows, every pane falls back to its shipped catalog,
+// which is exactly what a user without this var already sees. So a refusal (read-only
+// device, auth lapse) or an offline start leaves an empty list and no status noise, and the single
+// in-flight promise is cleared so a later MOUNT retries. Retry granularity is the reason the kick
+// below lives in an effect and not in the render body: the composer re-renders on every 1.5s
+// snapshot, so a render-phase kick would turn one refusal into a request per tick, forever.
+
+let current: readonly OperatorCommand[] = [];
+let inflight: Promise<void> | null = null;
+let loaded = false;
+const listeners = new Set<() => void>();
+
+function emit(): void {
+  for (const fn of listeners) fn();
+}
+
+/** Read the list once per page load. Concurrent callers share the one in-flight request. */
+export function loadOperatorCommands(): Promise<void> {
+  if (loaded) return Promise.resolve();
+  if (inflight) return inflight;
+  inflight = fetchConfig()
+    .then((cfg) => {
+      current = cfg.operatorCommands ?? [];
+      loaded = true;
+      emit();
+    })
+    .catch(() => {
+      // Additive feature — see the header. Leave the list empty and allow a later retry.
+    })
+    .finally(() => {
+      inflight = null;
+    });
+  return inflight;
+}
+
+export function getOperatorCommands(): readonly OperatorCommand[] {
+  return current;
+}
+
+export function subscribeOperatorCommands(cb: () => void): () => void {
+  listeners.add(cb);
+  return () => listeners.delete(cb);
+}
+
+/**
+ * Reactive read. Kicks the one-shot fetch on mount, so the only thing a call site has to do is read
+ * the value — there is no "load this somewhere at startup" step to forget.
+ */
+export function useOperatorCommands(): readonly OperatorCommand[] {
+  useEffect(() => {
+    void loadOperatorCommands();
+  }, []);
+  return useSyncExternalStore(subscribeOperatorCommands, getOperatorCommands, getOperatorCommands);
+}
+
+/** Test helper — reset module state between cases. */
+export function __resetOperatorCommands(): void {
+  current = [];
+  inflight = null;
+  loaded = false;
+  listeners.clear();
+}

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -254,11 +254,28 @@ export interface CreatedPane {
 /** Result of creating a new tab/space — on success `pane` is the fresh shell to navigate into. */
 export type CreateResponse = { ok: true; pane: CreatedPane } | { ok: false; error: string };
 
+/**
+ * One operator-declared palette row (`COLLIE_COMMANDS`). Mirrors OperatorCommand in
+ * bridge/types.ts. Resolved against the shipped catalog by `commandsFor()`, which hands a pane
+ * these rows instead of the catalog when any of them address it — see agent-commands.ts for why a
+ * plugin- or user-registered command can only arrive this way.
+ */
+export interface OperatorCommand {
+  /** Herdr agent name this applies to, lowercased. Omitted = every agent. */
+  agent?: string;
+  command: string;
+  description: string;
+  takesArg: boolean;
+  argHint: string;
+}
+
 export interface BridgeConfig {
   push: boolean;
   vapidPublicKey: string;
   /** Build id of the bundle the bridge is currently serving (for stale-cache detection). */
   build?: string;
+  /** The operator's own palette rows. Absent when `COLLIE_COMMANDS` is unset. */
+  operatorCommands?: OperatorCommand[];
 }
 
 /**


### PR DESCRIPTION
## The gap

The shipped catalogs in `web/src/lib/agent-commands.ts` are limited, by their own sourcing rules, to commands *every* user of that harness has. A command registered by a **plugin** or by the user exists on one machine only, so it can never be vouched for there — and it's exactly the command worth one tap: omp's `/fork-in-herdr`, a Claude Code custom command, your own `/deploy`.

Today the only way to send one from Collie is to type it, or fight terminal pass-through.

## The change

```
COLLIE_COMMANDS=omp:/fork-in-herdr=Fork this conversation into a new herdr tab
```

**A pane your rows address shows your rows and nothing else. A pane none of them address keeps the shipped catalog. Declare nothing and every pane is exactly as shipped.**

Replacing rather than merging is the point. This surface is a handful of one-thumb shortcuts, and the value of the shipped ten is that *someone chose them* — a list half-chosen by the operator and half-guessed for them is worse than either whole one.

**Nothing is lost by replacing it.** The agent's own `/` completion already renders in the mirrored pane, live and complete. I checked what the alternative would even be: the set is registered at runtime *inside* the agent process (omp has no `commands --json`, no on-disk list; `fork-in` gets its two by calling `registerCommand` at load), so there is nothing to enumerate from out here. Scraping the popup back through `pane.read` yields four wrapped visible rows and a scrollbar, per-agent grammar, in the user's live session. Discovery belongs to the harness. This pane is for the handful you reach for without looking.

## Rules

Four, all chosen so adding a row narrows or clarifies, never widens:

1. **Your list is the palette**, on the panes it addresses.
2. **A pane you did not address keeps its catalog.** Scoping to `omp:` says nothing about your claude panes. (One *unscoped* row addresses everything, and `.env.example` says so.)
3. **Danger is inherited, not reset.** Naming a shipped command takes over its description but keeps its confirm — re-wording a session wipe can't make it one-tap.
4. **Narrowest scope wins; one `/name` is one row.** Exact beats family beats unscoped, so `/deploy=Everywhere,omp:/deploy=On omp` is one button whose text depends on the pane (two would also collide on the palette's `key={c.command}`). A family scope is only ever the catalog's own name for the family: `claude:` reaches a `claude-code` pane because CLAUDE's shipped rows do, but `claude-local:` addresses `claude-local` only — folding an arbitrary operator string through the lookup ladder would widen a scope written to be narrow.

Grammar reuses the existing comma-separated list style (`envList`), so a description can't contain a comma and an arg hint can't contain `=`. Both documented in `.env.example` and pinned by tests. An empty scope (`:/wipe`) is rejected rather than read as "every agent" — the operator was reaching for something narrower than that, so the failure should be the narrow one.

## Shape

- `bridge/config.ts` — `parseOperatorCommands()`, pure and unit-tested without `process.env`
- `bridge/server.ts` — served on `/api/config`; the key is omitted entirely when unset, so an operator who never touched this ships the same payload as before
- `web/src/lib/operator-commands.ts` — module-state store + `useSyncExternalStore`, the `lib/server-build.ts` idiom. One successful read cached per page load; a failed read isn't cached, and the kick lives in an effect rather than the render body so a refusal can't become a request per 1.5s tick
- `web/src/lib/agent-commands.ts` — `commandsFor(agent, mine)` resolves the four rules

## Tests

24 new, all green. Parser grammar (scope, arg hints, duplicates, empty scope, the `=` and comma costs), the store's caching/retry/concurrency contract, the four resolution rules, and the rendered palette (replacement, one-button dedupe, inherited confirm).

`bunx tsc --noEmit` clean both packages. Bridge suite 569/569. Web suite: 2117 pass / 48 fail — the same 48 fail on `main` (localStorage-less environment: theme, dash/display prefs, draft persistence), none in touched files.

Verified end-to-end on a live bridge: `/api/config` carries the rows, and the screenshot above is the real sheet on an omp pane — "Search 2 commands…", shipped catalog gone.

## Versioning

Per `CLAUDE.md`, fork PRs leave the version files and CHANGELOG alone. Suggested entry:

> - **`COLLIE_COMMANDS` makes the Agent-commands palette yours** — your own slash commands, including plugin- and user-registered ones the shipped catalogs can't carry; a pane your rows address shows them instead of the catalog (#NN, `3021479`)

## Note

Built on top of #108 conceptually but textually independent — no overlapping files, either order merges clean.
