### PR TITLE
audit: COLLIE_AUDIT_CONTENT=none redacts by field role, fail closed

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -63,6 +63,10 @@ COLLIE_SUBMIT_KEYS=Enter
 # --- Security ---
 # If set, requests must carry a matching Tailscale-User-Login header (from `tailscale serve`).
 # COLLIE_TRUSTED_USER=you@example.com
+# How much of each action's parameters the audit trail keeps. `preview` (default) keeps a bounded
+# preview of every value; `none` redacts every string except the action parameters allowlisted in
+# bridge/audit.ts, which explains what each mode does and does not keep.
+# COLLIE_AUDIT_CONTENT=none
 #
 # Optional per-device authorisation (OFF by default). When Collie sits behind a reverse proxy that
 # authenticates the device and injects its identity as a request header, name that header here to

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -232,7 +232,8 @@ Also shipped, as defence in depth:
 
 - **Audit log** — every write-level action appends a JSONL line (timestamp, method, truncated params)
   to `<stateDir>/audit.log`, mode 0600 since it may echo reply text. An audit failure never fails the
-  user's action (`bridge/audit.ts`).
+  user's action. `COLLIE_AUDIT_CONTENT=none` keeps the trail and drops the bodies — what survives is
+  an allowlist of action parameters, documented at the list itself (`bridge/audit.ts`).
 - **Destructive-action confirm** — a browser-side prompt when input pattern-matches `rm`, `sudo`,
   `git push --force`, `dd`, etc. (`web/src/lib/destructive.ts`). Prevents catastrophic mistaps.
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,8 @@ Four sharp edges:
   shell. The idle-lock pauses an unattended screen and gates nothing — it is not auth, and never was
   ([ADR 0007](./.adr/0007-the-idle-lock-is-a-pause-not-a-gate.md)). Every write action (replies, keys, uploads, pane/tab
   create/close) is appended to `<state-dir>/audit.log`, so there is at least a trail — but a trail
-  is not a gate.
+  is not a gate. That trail keeps a preview of what you typed; `COLLIE_AUDIT_CONTENT=none` keeps the
+  events and drops the bodies (what survives is spelled out in `bridge/audit.ts`).
 - **One bridge fronts _every_ session.** With `COLLIE_MULTI_SESSION` on (the default), the bridge
   discovers and serves every named Herdr session under your config root — a private or sandbox
   session (e.g. `collie-demo`) is readable and drivable through the same URL as your primary, and the

--- a/bridge/audit-redaction.test.ts
+++ b/bridge/audit-redaction.test.ts
@@ -19,7 +19,7 @@ describe("audit content redaction", () => {
     expect(line.detail.promptBinding.expected).toContain("user@host");
   });
 
-  test("none keeps the envelope and drops every string body", () => {
+  test("none keeps the envelope and every non-string parameter", () => {
     const line = JSON.parse(formatAuditLine(entry, 0, "none"));
     expect(line.action).toBe("reply");
     expect(line.paneId).toBe("w1:p1");
@@ -34,11 +34,73 @@ describe("audit content redaction", () => {
     expect(raw).not.toContain("deploy");
     expect(raw).not.toContain("secret");
     expect(raw).not.toContain("user@host");
-    expect(raw).toContain("chars⟩");
+    expect(raw).toContain("⟨redacted⟩");
   });
 
-  test("the length is kept, because 'was anything sent' is the question a reader asks", () => {
+  test("⛔ the redaction is a constant — an exact length is itself content", () => {
     const line = JSON.parse(formatAuditLine(entry, 0, "none"));
-    expect(line.detail.text).toBe(`⟨${entry.detail.text.length} chars⟩`);
+    expect(line.detail.text).toBe("⟨redacted⟩");
+    expect(line.detail.promptBinding.expected).toBe("⟨redacted⟩");
+    expect(String(line.detail.text)).not.toMatch(/\d/);
+  });
+
+  test("an allowlisted key survives, including through the array it names", () => {
+    const line = JSON.parse(
+      formatAuditLine(
+        { action: "keys", detail: { keys: ["ctrl+c", "Enter"], sent: false } },
+        0,
+        "none",
+      ),
+    );
+    expect(line.detail.keys).toEqual(["ctrl+c", "Enter"]);
+    expect(line.detail.sent).toBe(false);
+  });
+
+  test("⛔ an upload's client-declared filename redacts; the saved name identifies the entry", () => {
+    const line = JSON.parse(
+      formatAuditLine(
+        {
+          action: "upload",
+          detail: { filename: "my-passport-scan.png", size: 4096, saved: "w1_p1-abc-1234.png" },
+        },
+        0,
+        "none",
+      ),
+    );
+    expect(line.detail.filename).toBe("⟨redacted⟩");
+    expect(line.detail.size).toBe(4096);
+    expect(line.detail.saved).toBe("w1_p1-abc-1234.png");
+  });
+
+  test("⛔ a string under an unlisted key redacts — the allowlist fails closed", () => {
+    const line = JSON.parse(
+      formatAuditLine(
+        { action: "reply", detail: { somethingAddedLater: "a body nobody classified" } },
+        0,
+        "none",
+      ),
+    );
+    expect(line.detail.somethingAddedLater).toBe("⟨redacted⟩");
+  });
+
+  test("⛔ a toJSON smuggle cannot re-inject content at stringify time", () => {
+    const smuggle = {
+      action: "reply",
+      detail: { text: "x", evil: { toJSON: () => "smuggled-secret", keys: ["ctrl+c"] } },
+    };
+    const raw = formatAuditLine(smuggle, 0, "none");
+    expect(raw).not.toContain("smuggled-secret");
+    expect(JSON.parse(raw).detail.evil.keys).toEqual(["ctrl+c"]);
+  });
+
+  test("a function-valued property doesn't break preview mode either", () => {
+    const raw = formatAuditLine(
+      { action: "reply", detail: { text: "hello", cb: () => "nope" } },
+      0,
+    );
+    expect(raw).not.toContain("nope");
+    const line = JSON.parse(raw);
+    expect(line.detail.text).toBe("hello");
+    expect(line.detail.cb).toBeUndefined();
   });
 });

--- a/bridge/audit-redaction.test.ts
+++ b/bridge/audit-redaction.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test";
+import { formatAuditLine } from "./audit";
+
+const entry = {
+  action: "reply",
+  paneId: "w1:p1",
+  session: "default",
+  detail: {
+    text: "deploy the thing and here is a secret nobody should keep on disk",
+    submit: true,
+    promptBinding: { checked: true, passed: true, expected: "user@host ~/work %" },
+  },
+};
+
+describe("audit content redaction", () => {
+  test("preview is unchanged — the default must not move", () => {
+    const line = JSON.parse(formatAuditLine(entry, 0));
+    expect(line.detail.text).toContain("deploy the thing");
+    expect(line.detail.promptBinding.expected).toContain("user@host");
+  });
+
+  test("none keeps the envelope and drops every string body", () => {
+    const line = JSON.parse(formatAuditLine(entry, 0, "none"));
+    expect(line.action).toBe("reply");
+    expect(line.paneId).toBe("w1:p1");
+    expect(line.session).toBe("default");
+    expect(line.detail.submit).toBe(true);
+    expect(line.detail.promptBinding.checked).toBe(true);
+    expect(line.detail.promptBinding.passed).toBe(true);
+  });
+
+  test("⛔ nothing of the message survives, at any nesting depth", () => {
+    const raw = formatAuditLine(entry, 0, "none");
+    expect(raw).not.toContain("deploy");
+    expect(raw).not.toContain("secret");
+    expect(raw).not.toContain("user@host");
+    expect(raw).toContain("chars⟩");
+  });
+
+  test("the length is kept, because 'was anything sent' is the question a reader asks", () => {
+    const line = JSON.parse(formatAuditLine(entry, 0, "none"));
+    expect(line.detail.text).toBe(`⟨${entry.detail.text.length} chars⟩`);
+  });
+});

--- a/bridge/audit.test.ts
+++ b/bridge/audit.test.ts
@@ -55,7 +55,7 @@ describe("AuditLog", () => {
   test("records a formatted, newline-terminated line to the injected append", async () => {
     const lines: string[] = [];
     const append: AppendFn = (l) => void lines.push(l);
-    const log = new AuditLog(append, () => 0);
+    const log = new AuditLog(append, { now: () => 0 });
 
     log.record({ action: "keys", paneId: "p1", detail: { keys: ["Enter"] } });
     // record() is fire-and-forget; let the swallowed promise settle.
@@ -73,7 +73,7 @@ describe("AuditLog", () => {
 
   test("a rejecting append never throws out of record() (audit must not break the action)", async () => {
     const append: AppendFn = () => Promise.reject(new Error("disk full"));
-    const log = new AuditLog(append, () => 0);
+    const log = new AuditLog(append, { now: () => 0 });
     const warnings: string[] = [];
     const origWarn = console.warn;
     console.warn = ((...args: unknown[]) => void warnings.push(args.map(String).join(" "))) as typeof console.warn;
@@ -91,7 +91,7 @@ describe("AuditLog", () => {
     const append: AppendFn = () => {
       throw new Error("boom");
     };
-    const log = new AuditLog(append, () => 0);
+    const log = new AuditLog(append, { now: () => 0 });
     const origWarn = console.warn;
     console.warn = (() => {}) as typeof console.warn;
     try {

--- a/bridge/audit.ts
+++ b/bridge/audit.ts
@@ -9,6 +9,20 @@ import { appendFile } from "node:fs/promises";
 /** Cap on any single string value written into a line — a 2 000-char reply becomes a 120-char preview. */
 const MAX_STR = 120;
 
+/**
+ * How much of a value's CONTENT the trail keeps.
+ *
+ * - `preview` (default, unchanged behaviour): a bounded, single-line preview.
+ * - `none`: the length only. Every string inside `detail` becomes `⟨n chars⟩`.
+ *
+ * `none` exists for deployments where the audit trail is wanted but the message bodies are not:
+ * under `tailscale serve` the operator's replies and, via the prompt binding, a slice of whatever
+ * was on the terminal both land in this file. Keys, booleans, numbers and the whole envelope
+ * (ts, action, paneId, session, device) are untouched either way — the point is to keep answering
+ * "who typed into what, when" without also keeping "what they said".
+ */
+export type AuditContent = "preview" | "none";
+
 /** One write-level action worth recording. `ts` is stamped by {@link formatAuditLine}, not here. */
 export interface AuditEntry {
   /** The action performed, e.g. "reply" / "keys" / "upload" / "tab.create" / "pane.close". */
@@ -32,15 +46,18 @@ export type AppendFn = (line: string) => void | Promise<void>;
  * still fold embedded newlines to a space so a multi-line reply reads as one legible preview rather
  * than a wall of `\n`. Recurses into arrays/objects so `detail` can nest (e.g. a key-name array).
  */
-function sanitize(value: unknown): unknown {
+function sanitize(value: unknown, content: AuditContent = "preview"): unknown {
   if (typeof value === "string") {
+    // ⛔ The LENGTH, not a shorter preview. A truncated secret is still a secret, and the useful
+    // question a reader asks of a redacted trail is "was anything sent", which a count answers.
+    if (content === "none") return `⟨${value.length} chars⟩`;
     const oneLine = value.replace(/[\r\n]+/g, " ");
     return oneLine.length > MAX_STR ? `${oneLine.slice(0, MAX_STR)}…` : oneLine;
   }
-  if (Array.isArray(value)) return value.map(sanitize);
+  if (Array.isArray(value)) return value.map((v) => sanitize(v, content));
   if (value !== null && typeof value === "object") {
     const out: Record<string, unknown> = {};
-    for (const [k, v] of Object.entries(value)) out[k] = sanitize(v);
+    for (const [k, v] of Object.entries(value)) out[k] = sanitize(v, content);
     return out;
   }
   return value;
@@ -52,12 +69,16 @@ function sanitize(value: unknown): unknown {
  * attribution is omitted (not null) when absent. Pure — `now` (epoch ms) is injected so tests are
  * deterministic.
  */
-export function formatAuditLine(entry: AuditEntry, now: number): string {
+export function formatAuditLine(
+  entry: AuditEntry,
+  now: number,
+  content: AuditContent = "preview",
+): string {
   const line: Record<string, unknown> = { ts: new Date(now).toISOString(), action: entry.action };
   if (entry.paneId !== undefined) line.paneId = entry.paneId;
   if (entry.session !== undefined) line.session = entry.session;
   if (entry.device != null) line.device = entry.device;
-  line.detail = sanitize(entry.detail ?? {});
+  line.detail = sanitize(entry.detail ?? {}, content);
   return JSON.stringify(line);
 }
 
@@ -75,12 +96,13 @@ export class AuditLog {
   constructor(
     private readonly append: AppendFn,
     private readonly now: () => number = Date.now,
+    private readonly content: AuditContent = "preview",
   ) {}
 
   record(entry: AuditEntry): void {
     let line: string;
     try {
-      line = formatAuditLine(entry, this.now());
+      line = formatAuditLine(entry, this.now(), this.content);
     } catch (err) {
       console.warn(`[audit] could not format ${entry.action}: ${(err as Error).message}`);
       return;

--- a/bridge/audit.ts
+++ b/bridge/audit.ts
@@ -13,15 +13,43 @@ const MAX_STR = 120;
  * How much of a value's CONTENT the trail keeps.
  *
  * - `preview` (default, unchanged behaviour): a bounded, single-line preview.
- * - `none`: the length only. Every string inside `detail` becomes `⟨n chars⟩`.
+ * - `none`: nothing. Every string inside `detail` becomes `⟨redacted⟩` unless its key names an
+ *   action parameter ({@link METADATA_KEYS}).
  *
  * `none` exists for deployments where the audit trail is wanted but the message bodies are not:
  * under `tailscale serve` the operator's replies and, via the prompt binding, a slice of whatever
- * was on the terminal both land in this file. Keys, booleans, numbers and the whole envelope
+ * was on the terminal both land in this file. Booleans, numbers and the whole envelope
  * (ts, action, paneId, session, device) are untouched either way — the point is to keep answering
  * "who typed into what, when" without also keeping "what they said".
  */
 export type AuditContent = "preview" | "none";
+
+/**
+ * The metadata allowlist for `none` mode, matched by key name at ANY depth inside `detail`.
+ *
+ * A string survives only if its key names an action PARAMETER — a key name, an id, an enum-ish
+ * outcome, a server-generated filename. Anything screen- or operator-originated must not be listed:
+ * `text` is what the operator typed and `promptBinding.expected` is a slice of the pane screen.
+ *
+ * ⛔ The direction of the default is the whole feature. A detail field added later under a new name
+ * redacts until someone deliberately adds it here, so a content-bearing field can never leak into a
+ * redacted trail by being forgotten. Members of an array inherit the array's own key ("keys" carries
+ * "ctrl+c", not a body).
+ */
+const METADATA_KEYS: ReadonlySet<string> = new Set([
+  "checked",
+  "keys",
+  "passed",
+  "reason",
+  "saved",
+  "sent",
+  "size",
+  "submit",
+  "submitted",
+  "tabId",
+  "textDelivered",
+  "workspaceId",
+]);
 
 /** One write-level action worth recording. `ts` is stamped by {@link formatAuditLine}, not here. */
 export interface AuditEntry {
@@ -45,19 +73,32 @@ export type AppendFn = (line: string) => void | Promise<void>;
  * JSON.stringify already escapes a literal newline to `\n` (keeping the output single-line), but we
  * still fold embedded newlines to a space so a multi-line reply reads as one legible preview rather
  * than a wall of `\n`. Recurses into arrays/objects so `detail` can nest (e.g. a key-name array).
+ *
+ * `allowed` carries the enclosing key's verdict against {@link METADATA_KEYS}: an object re-decides
+ * per key, an array hands its own verdict to every member. It is false at the root, so a `detail`
+ * that is somehow a bare string redacts rather than passing through unnamed.
+ *
+ * ⛔ Function-valued properties are DROPPED, in both modes. Copying them through means
+ * `JSON.stringify` later CALLS a copied own `toJSON`, which re-injects its return value into the
+ * line — past the preview cap, and past every redaction decision made here.
  */
-function sanitize(value: unknown, content: AuditContent = "preview"): unknown {
+function sanitize(value: unknown, content: AuditContent = "preview", allowed = false): unknown {
+  if (typeof value === "function") return null;
   if (typeof value === "string") {
-    // ⛔ The LENGTH, not a shorter preview. A truncated secret is still a secret, and the useful
-    // question a reader asks of a redacted trail is "was anything sent", which a count answers.
-    if (content === "none") return `⟨${value.length} chars⟩`;
+    // ⛔ A constant, never `⟨n chars⟩`. An exact length is itself content — a 9-character redaction
+    // next to a password prompt narrows the secret — and "was anything sent" is already answered by
+    // the entry existing at all.
+    if (content === "none" && !allowed) return "⟨redacted⟩";
     const oneLine = value.replace(/[\r\n]+/g, " ");
     return oneLine.length > MAX_STR ? `${oneLine.slice(0, MAX_STR)}…` : oneLine;
   }
-  if (Array.isArray(value)) return value.map((v) => sanitize(v, content));
+  if (Array.isArray(value)) return value.map((v) => sanitize(v, content, allowed));
   if (value !== null && typeof value === "object") {
     const out: Record<string, unknown> = {};
-    for (const [k, v] of Object.entries(value)) out[k] = sanitize(v, content);
+    for (const [k, v] of Object.entries(value)) {
+      if (typeof v === "function") continue;
+      out[k] = sanitize(v, content, METADATA_KEYS.has(k));
+    }
     return out;
   }
   return value;
@@ -93,11 +134,19 @@ export function fileAuditAppender(path: string): AppendFn {
  * never break the user action it was auditing.
  */
 export class AuditLog {
+  private readonly now: () => number;
+  private readonly content: AuditContent;
+
+  // Everything past `append` arrives in an options object, not a positional slot: the same slot is
+  // claimed by different arguments on different branches, and a silently-transposed `now`/`content`
+  // is a redaction quietly turning itself off.
   constructor(
     private readonly append: AppendFn,
-    private readonly now: () => number = Date.now,
-    private readonly content: AuditContent = "preview",
-  ) {}
+    opts: { now?: () => number; content?: AuditContent } = {},
+  ) {
+    this.now = opts.now ?? Date.now;
+    this.content = opts.content ?? "preview";
+  }
 
   record(entry: AuditEntry): void {
     let line: string;

--- a/bridge/config.ts
+++ b/bridge/config.ts
@@ -1,6 +1,7 @@
 import { homedir } from "node:os";
 import { join } from "node:path";
 
+import type { AuditContent } from "./audit.ts";
 import type { DialMode } from "./dial.ts";
 import type { JournalRoots } from "./journal/registry.ts";
 
@@ -145,14 +146,17 @@ export interface Config {
    */
   trustedUser: string;
   /**
+   * How much of each value's content the audit trail keeps — see {@link AuditContent} in audit.ts
+   * for what `none` does and does not redact.
+   */
+  auditContent: AuditContent;
+  /**
    * Per-device authorisation. Name of a request header carrying an opaque device identifier,
    * injected by a trusted upstream reverse proxy. Empty = the feature is off (no behaviour change).
    * When set, devices whose header value isn't in {@link deviceAllowlist} are read-only. See
    * `deviceAuth()` in server.ts for the full matrix. The header is trusted only because the bridge
    * binds loopback behind the proxy — a direct client can't set it (same trust basis as trustedUser).
    */
-  /** Whether the audit trail keeps a preview of each value's content, or only its length. */
-  auditContent: "preview" | "none";
   deviceHeader: string;
   /**
    * Device identifiers permitted to perform sensitive actions (typing into agent terminals,

--- a/bridge/config.ts
+++ b/bridge/config.ts
@@ -151,6 +151,8 @@ export interface Config {
    * `deviceAuth()` in server.ts for the full matrix. The header is trusted only because the bridge
    * binds loopback behind the proxy — a direct client can't set it (same trust basis as trustedUser).
    */
+  /** Whether the audit trail keeps a preview of each value's content, or only its length. */
+  auditContent: "preview" | "none";
   deviceHeader: string;
   /**
    * Device identifiers permitted to perform sensitive actions (typing into agent terminals,
@@ -253,6 +255,7 @@ export function loadConfig(): Config {
     },
     submitKeys: submitKeys.length ? submitKeys : ["Enter"],
     trustedUser: process.env.COLLIE_TRUSTED_USER ?? "",
+    auditContent: envEnum("COLLIE_AUDIT_CONTENT", ["preview", "none"] as const, "preview"),
     deviceHeader: (process.env.COLLIE_DEVICE_HEADER ?? "").trim(),
     deviceAllowlist: envList("COLLIE_DEVICE_ALLOWLIST"),
     allowedOrigins: envList("COLLIE_ALLOWED_ORIGINS"),

--- a/bridge/index.ts
+++ b/bridge/index.ts
@@ -59,11 +59,9 @@ await activity.load();
 
 // Append-only audit trail of write-level actions (see audit.ts). A write failure here is swallowed
 // inside record() so it can never break the user action it's auditing.
-const audit = new AuditLog(
-  fileAuditAppender(join(cfg.stateDir, "audit.log")),
-  Date.now,
-  cfg.auditContent,
-);
+const audit = new AuditLog(fileAuditAppender(join(cfg.stateDir, "audit.log")), {
+  content: cfg.auditContent,
+});
 
 // ── Update-availability monitor ───────────────────────────────────────────────
 // The running plugin version, captured NOW at module load — never re-read from disk later, or a

--- a/bridge/index.ts
+++ b/bridge/index.ts
@@ -59,7 +59,11 @@ await activity.load();
 
 // Append-only audit trail of write-level actions (see audit.ts). A write failure here is swallowed
 // inside record() so it can never break the user action it's auditing.
-const audit = new AuditLog(fileAuditAppender(join(cfg.stateDir, "audit.log")));
+const audit = new AuditLog(
+  fileAuditAppender(join(cfg.stateDir, "audit.log")),
+  Date.now,
+  cfg.auditContent,
+);
 
 // ── Update-availability monitor ───────────────────────────────────────────────
 // The running plugin version, captured NOW at module load — never re-read from disk later, or a

--- a/bridge/server.test.ts
+++ b/bridge/server.test.ts
@@ -54,6 +54,7 @@ function cfg(overrides: Partial<Config> = {}): Config {
     },
     submitKeys: ["Enter"],
     trustedUser: "",
+    auditContent: "preview",
     deviceHeader: "",
     deviceAllowlist: [],
     allowedOrigins: [],


### PR DESCRIPTION
Supersedes #107 — the feature and its name are @shuangwangnyc's (their commit is cherry-picked here with authorship preserved); the reshape on top changes *how* the redaction decides.

**What changed relative to #107:**

- **Field-role redaction, fail closed.** `none` no longer redacts every string by type — a string survives only if its key is on a metadata allowlist (`METADATA_KEYS` in `bridge/audit.ts`); everything else redacts, so a detail field added later under a new name can never leak by being forgotten. Key names like `keys: ["ctrl+c"]` stay legible; `text`, `promptBinding.expected`, labels, cwds, and the client-declared upload `filename` redact.
- **Flat `⟨redacted⟩`, never `⟨n chars⟩`** — an exact length is itself content (a 9-character redaction next to a password prompt narrows the secret).
- **The `toJSON` hole is closed in both modes** — `sanitize` drops function-valued properties, so a copied own `toJSON` can no longer re-inject unredacted content (or escape the 120-char preview cap) at stringify time.
- **`AuditLog` takes an options object** instead of a third positional slot (the slot after `append` is claimed differently across branches).
- Config JSDoc ordering, `server.test.ts` cfg factory, `.env.example`/README/ARCHITECTURE pointers.

No version bump — release deferred; the bump rides the next `chore(release):` commit.

Tests: 617 pass (root suite + collie-ctl lifecycle), `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)