### PR TITLE
feat(composer): add speech input through Codex-owned auth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,6 +28,9 @@ COLLIE_HOST=127.0.0.1
 # Usually injected by the systemd unit; override only if your socket is elsewhere.
 # Defaults to ~/.config/herdr/herdr.sock, or %APPDATA%\herdr\herdr.sock on Windows.
 # HERDR_SOCKET_PATH=/home/you/.config/herdr/herdr.sock
+
+# Optional absolute path when Codex is installed outside the service's PATH (common with nvm/launchd).
+# COLLIE_CODEX_BIN=/home/you/.local/bin/codex
 # Which dialer opens that socket: auto (default) | net | bun. "auto" is right everywhere — node:net
 # on Windows, where herdr's socket is a named pipe, and Bun's native transport elsewhere. Forcing
 # "net" on Linux/macOS runs the Windows dial path against your real socket; that's how it gets

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 A phone web UI for your [Herdr](https://herdr.dev) agent herd, served over Tailscale. Open a URL, see
 which agent is waiting on you, and answer it with your phone's keyboard.
 
-The reply box is an ordinary text field, so your phone's own voice dictation works in it; Collie
-ships none of its own.
+The reply box is an ordinary text field, and can optionally record a voice reply through an existing
+Codex ChatGPT sign-in.
 
 It assumes a [Tailscale](https://tailscale.com) tailnet — your phone and the host on the same one —
 and it is **single-user**: one operator, one tailnet, no multi-tenant auth. If you need shared or
@@ -24,9 +24,10 @@ public access, Collie isn't built for it. Read the
 - **Special-keys pad** — `Esc`, `Ctrl+C`, arrows, combinable modifiers
 - **Find in output**, and **conversation history** the terminal can't scroll back to
 - **Send an image** from your camera roll
+- **Speech to text through Codex** — record a reply without copying OAuth credentials into Collie
 - **Switch between Herdr sessions** without touching the host
 - **Installs to your home screen** (PWA) and runs entirely on your own machine — loopback bind, no
-  cloud, no account
+  Collie account (the optional Codex transcription sends audio to ChatGPT)
 
 ## Contents
 
@@ -37,6 +38,7 @@ public access, Collie isn't built for it. Read the
 - [First run — what you'll see](#first-run--what-youll-see)
 - [Configure](#configure) · [Your own slash commands](#your-own-slash-commands) ·
   [Multi-session](#multi-session)
+- [Speech to text (experimental)](#speech-to-text-experimental)
 - [Dark mode / light mode](#dark-mode--light-mode)
 - [Commands](#commands)
 - [Manage & update](#manage--update)
@@ -113,6 +115,7 @@ On the **host** (the tailnet node your agents run on). Need Herdr 0.7.0+ — che
 | Tool | Why |
 | --- | --- |
 | [**Bun**](https://bun.sh) | Runs the bridge and builds the web UI — the only hard dependency. |
+| [**Codex CLI**](https://developers.openai.com/codex/cli) | Optional — supplies an existing ChatGPT sign-in for speech to text. |
 | [**Herdr**](https://herdr.dev) ≥ 0.7.0 | The herd Collie mirrors; its CLI registers the plugin. |
 | [**Tailscale**](https://tailscale.com) | Front door for the default variant (`tailscale serve`); optional if you run [Variant C](./DEPLOYMENT.md#variant-c--reverse-proxy-as-the-only-front-door-no-tailscale) behind your own reverse proxy. Without any front door, the bridge is `127.0.0.1`-only. |
 | **git** | Clone, and the `update` command. |
@@ -309,6 +312,24 @@ first screen. Syntax error? `journalctl --user -u collie -n 20` names the line.
 config root, switchable from the header; `COLLIE_MULTI_SESSION=off` serves only the primary one. Every
 session it finds is drivable through the same URL — including a private or sandbox one, which is why
 [Security](#%EF%B8%8F-security--read-before-you-run-it) lists this as a sharp edge.
+
+## Speech to text (experimental)
+
+When the host's Codex CLI is signed in with ChatGPT, Collie automatically enables a microphone next
+to Send. Tap once to record and again to transcribe. **Hands free** sends the resulting text through
+the same guarded reply path as the other programmatic actions; turn it off in Settings to place the
+text at the input caret without sending. Both preferences are stored on that browser and default on.
+
+Collie asks a long-running `codex app-server` process for a short-lived access token, so it never
+reads or writes Codex's OAuth file, keyring entry, or refresh token. If Codex is missing, too old, or
+not signed in with ChatGPT, the Settings control stays visible but disabled. An API-key login is not
+sufficient for this provider. If a service manager cannot see a Codex installed by a shell version
+manager, set `COLLIE_CODEX_BIN` to its absolute path in Collie's `.env` and restart.
+
+This provider calls ChatGPT's private, undocumented transcription endpoint. Audio (up to 25 MB and
+two minutes) leaves the host and the integration may break when that endpoint or Codex's experimental
+app-server protocol changes. The recorder and UI depend only on Collie's internal STT provider
+interface so another provider can be added without rewriting them, but only Codex ships today.
 
 ## Dark mode / light mode
 

--- a/bridge/index.ts
+++ b/bridge/index.ts
@@ -19,6 +19,8 @@ import {
 } from "./sessions.ts";
 import { Snooze } from "./snooze.ts";
 import { StateEngine } from "./state-engine.ts";
+import { CodexAppServerAuthBroker } from "./stt/codex-auth.ts";
+import { CodexSttProvider } from "./stt/codex.ts";
 import {
   bridgeStampSync,
   githubTagsFetcher,
@@ -62,6 +64,10 @@ await activity.load();
 const audit = new AuditLog(fileAuditAppender(join(cfg.stateDir, "audit.log")), {
   content: cfg.auditContent,
 });
+
+// Codex owns its OAuth lifecycle through app-server. Collie never reads auth.json/keyrings and
+// never sees the refresh token; the short-lived access token exists only inside this provider.
+const stt = new CodexSttProvider({ broker: new CodexAppServerAuthBroker() });
 
 // ── Update-availability monitor ───────────────────────────────────────────────
 // The running plugin version, captured NOW at module load — never re-read from disk later, or a
@@ -205,7 +211,7 @@ const sweepTimer = setInterval(() => {
 }, SWEEP_INTERVAL_MS);
 sweepTimer.unref();
 
-const server = startServer({ cfg, registry, push, snooze, notifyPrefs, updateMonitor, audit, activity });
+const server = startServer({ cfg, registry, push, snooze, notifyPrefs, updateMonitor, audit, activity, stt });
 
 const shutdown = async () => {
   console.log("\n[bridge] shutting down");
@@ -221,6 +227,7 @@ const shutdown = async () => {
   clearInterval(sweepTimer);
   clearTimeout(updateFirstCheck);
   clearInterval(updateTimer);
+  stt.close();
   process.exit(0);
 };
 process.on("SIGINT", shutdown);

--- a/bridge/server.ts
+++ b/bridge/server.ts
@@ -18,6 +18,8 @@ import { herdTagFor, type SessionRegistry } from "./sessions.ts";
 import type { Snooze } from "./snooze.ts";
 import type { UpdateMonitor } from "./update.ts";
 import type { StateEngine } from "./state-engine.ts";
+import { sttStatusResponse, transcribeAudio } from "./stt/http.ts";
+import type { SttProvider } from "./stt/provider.ts";
 import { adapterFor, buildJournalRegistry } from "./journal/registry.ts";
 import { TranscriptStore } from "./journal/store.ts";
 import type { JournalAdapter } from "./journal/types.ts";
@@ -44,7 +46,7 @@ const MAX_UPLOAD_OVERHEAD = 64 * 1024; // 64 KB
 // Hard cap the runtime enforces on ANY request body (Bun.serve maxRequestBodySize). Bigger than the
 // upload cap + overhead so the handler's own 413 fires first for honest clients; this cuts off a
 // chunked or lying client that never sends an accurate Content-Length.
-const MAX_REQUEST_BODY_BYTES = 12 * 1024 * 1024; // 12 MB
+const MAX_REQUEST_BODY_BYTES = 26 * 1024 * 1024; // 25 MB audio + request framing headroom
 // Upper bound on the pane-read `lines` param — don't trust the client (or Herdr) to cap it.
 const MAX_READ_LINES = 10_000;
 const MAX_EXPECTED_PROMPT_CHARS = 8192;
@@ -142,8 +144,9 @@ export function startServer(opts: {
   updateMonitor: UpdateMonitor;
   audit: AuditLog;
   activity: ActivityLedger;
+  stt: SttProvider;
 }) {
-  const { cfg, registry, push, snooze, notifyPrefs, updateMonitor, audit, activity } = opts;
+  const { cfg, registry, push, snooze, notifyPrefs, updateMonitor, audit, activity, stt } = opts;
   // One journal registry + store for the process. The store's cache is keyed by absolute path, so
   // sharing it across herdr sessions AND across harnesses is correct — two sessions can front panes
   // whose agents write into the same root. Which harnesses have journals at all is decided in
@@ -310,6 +313,19 @@ export function startServer(opts: {
           // ships the same payload as before.
           ...(mine.length > 0 ? { operatorCommands: mine } : {}),
         } satisfies BridgeConfig, req.headers.get("accept-encoding"));
+      }
+      if (pathname === "/api/stt/status" && req.method === "GET") {
+        const denied = guard(req, cfg, "read");
+        if (denied) return denied;
+        return secure(await sttStatusResponse(stt));
+      }
+      if (pathname === "/api/stt/transcribe" && req.method === "POST") {
+        // Transcription does not drive a terminal. The browser receives only text; Codex auth stays
+        // inside the bridge. It does consume an external account's quota, however, so only devices
+        // authorised for writes may trigger it; status remains safe for read-only clients above.
+        const denied = guard(req, cfg, "write");
+        if (denied) return denied;
+        return secure(await transcribeAudio(stt, req));
       }
       if (pathname === "/api/subscribe" && req.method === "POST") {
         // Read-level: registering for push isn't terminal-driving, so a read-only device may still

--- a/bridge/stt/codex-auth.test.ts
+++ b/bridge/stt/codex-auth.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, test } from "bun:test";
+import { EventEmitter } from "node:events";
+
+import {
+  CodexAppServerAuthBroker,
+  type CodexAppServerProcess,
+} from "./codex-auth.ts";
+
+class FakeStream extends EventEmitter {
+  write = (_chunk: string): boolean => true;
+}
+
+class FakeProcess extends EventEmitter implements CodexAppServerProcess {
+  readonly stdin = new FakeStream();
+  readonly stdout = new FakeStream();
+  readonly stderr = new FakeStream();
+  readonly requests: Array<Record<string, unknown>> = [];
+  killed = false;
+
+  constructor(replyToInitialize = true) {
+    super();
+    this.stdin.write = (chunk) => {
+      const message = JSON.parse(chunk) as Record<string, unknown>;
+      this.requests.push(message);
+      const id = message.id;
+      if (message.method === "initialize" && replyToInitialize) {
+        this.reply({ id, result: { codexHome: "/tmp/codex" } });
+      } else if (message.method === "getAuthStatus") {
+        const params = message.params as { includeToken?: boolean };
+        this.reply({
+          id,
+          result: {
+            authMethod: "chatgpt",
+            authToken: params.includeToken ? "access-token" : null,
+            requiresOpenaiAuth: true,
+          },
+        });
+      }
+      return true;
+    };
+  }
+
+  kill(): boolean {
+    this.killed = true;
+    return true;
+  }
+
+  private reply(message: unknown) {
+    queueMicrotask(() => this.stdout.emit("data", `${JSON.stringify(message)}\n`));
+  }
+}
+
+describe("CodexAppServerAuthBroker", () => {
+  test("reuses one initialized process and only returns a token when requested", async () => {
+    const child = new FakeProcess();
+    let spawnCount = 0;
+    const broker = new CodexAppServerAuthBroker({
+      spawn: () => {
+        spawnCount += 1;
+        return child;
+      },
+      requestTimeoutMs: 1_000,
+    });
+
+    expect(await broker.status()).toEqual({ available: true });
+    expect(await broker.accessToken()).toEqual({
+      accessToken: "access-token",
+      authMethod: "chatgpt",
+    });
+    expect(spawnCount).toBe(1);
+    expect(child.requests.map((request) => request.method)).toEqual([
+      "initialize",
+      "initialized",
+      "getAuthStatus",
+      "getAuthStatus",
+    ]);
+    expect(child.requests.at(-2)?.params).toEqual({
+      includeToken: false,
+      refreshToken: false,
+    });
+    expect(child.requests.at(-1)?.params).toEqual({
+      includeToken: true,
+      refreshToken: false,
+    });
+
+    broker.close();
+    expect(child.killed).toBe(true);
+  });
+
+  test("waits for initialization before serving concurrent auth requests", async () => {
+    const child = new FakeProcess();
+    const broker = new CodexAppServerAuthBroker({ spawn: () => child, requestTimeoutMs: 1_000 });
+
+    await Promise.all([broker.status(), broker.accessToken()]);
+
+    expect(child.requests.map((request) => request.method)).toEqual([
+      "initialize",
+      "initialized",
+      "getAuthStatus",
+      "getAuthStatus",
+    ]);
+    broker.close();
+  });
+
+  test("retires a child whose initialization times out and starts cleanly next time", async () => {
+    const first = new FakeProcess(false);
+    const second = new FakeProcess();
+    const children = [first, second];
+    const broker = new CodexAppServerAuthBroker({
+      spawn: () => {
+        const child = children.shift()!;
+        if (child === second) first.stdout.emit("data", '{"id":999');
+        return child;
+      },
+      requestTimeoutMs: 10,
+    });
+
+    expect((await broker.status()).available).toBe(false);
+    expect(first.killed).toBe(true);
+    expect(await broker.accessToken()).toEqual({
+      accessToken: "access-token",
+      authMethod: "chatgpt",
+    });
+    expect(second.requests.map((request) => request.method)).toEqual([
+      "initialize",
+      "initialized",
+      "getAuthStatus",
+    ]);
+    broker.close();
+  });
+});

--- a/bridge/stt/codex-auth.ts
+++ b/bridge/stt/codex-auth.ts
@@ -1,0 +1,232 @@
+import { spawn as spawnChild } from "node:child_process";
+import type { EventEmitter } from "node:events";
+
+type EventStream = Pick<EventEmitter, "on">;
+
+export interface CodexAppServerProcess extends EventEmitter {
+  stdin: EventStream & { write(chunk: string): boolean };
+  stdout: EventStream;
+  stderr: EventStream;
+  kill(): boolean;
+}
+
+interface AuthStatusResponse {
+  authMethod: string | null;
+  authToken: string | null;
+  requiresOpenaiAuth: boolean | null;
+}
+
+export interface CodexAccessToken {
+  accessToken: string;
+  authMethod: "chatgpt";
+}
+
+export interface CodexAuthBroker {
+  status(): Promise<{ available: boolean; reason?: string }>;
+  accessToken(refresh?: boolean): Promise<CodexAccessToken>;
+  close(): void;
+}
+
+interface PendingRequest {
+  resolve(value: unknown): void;
+  reject(error: Error): void;
+  timer: ReturnType<typeof setTimeout>;
+}
+
+interface BrokerOptions {
+  spawn?: () => CodexAppServerProcess;
+  requestTimeoutMs?: number;
+}
+
+const DEFAULT_REQUEST_TIMEOUT_MS = 10_000;
+
+/**
+ * Keeps Codex in charge of its own OAuth storage and refresh token. Collie receives only the
+ * short-lived access token returned by app-server's compatibility auth RPC, and never reads
+ * auth.json or an OS keyring directly.
+ */
+export class CodexAppServerAuthBroker implements CodexAuthBroker {
+  private readonly spawnProcess: () => CodexAppServerProcess;
+  private readonly requestTimeoutMs: number;
+  private process: CodexAppServerProcess | null = null;
+  private starting: Promise<void> | null = null;
+  private nextId = 1;
+  private stdoutBuffer = "";
+  private readonly pending = new Map<number, PendingRequest>();
+
+  constructor(options: BrokerOptions = {}) {
+    this.spawnProcess =
+      options.spawn ??
+      (() =>
+        spawnChild(process.env.COLLIE_CODEX_BIN?.trim() || "codex", ["app-server", "--listen", "stdio://"], {
+          stdio: ["pipe", "pipe", "pipe"],
+        }) as unknown as CodexAppServerProcess);
+    this.requestTimeoutMs = options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS;
+  }
+
+  async status(): Promise<{ available: boolean; reason?: string }> {
+    try {
+      const auth = await this.authStatus(false, false);
+      if (auth.authMethod !== "chatgpt") {
+        return {
+          available: false,
+          reason: auth.authMethod
+            ? "Codex must be signed in with ChatGPT"
+            : "Codex is not signed in with ChatGPT",
+        };
+      }
+      return { available: true };
+    } catch (error) {
+      return { available: false, reason: safeMessage(error, "Codex app-server is unavailable") };
+    }
+  }
+
+  async accessToken(refresh = false): Promise<CodexAccessToken> {
+    const auth = await this.authStatus(true, refresh);
+    if (auth.authMethod !== "chatgpt") {
+      throw new Error("Codex must be signed in with ChatGPT");
+    }
+    if (!auth.authToken) throw new Error("Codex did not provide an access token");
+    return { accessToken: auth.authToken, authMethod: "chatgpt" };
+  }
+
+  close(): void {
+    const process = this.process;
+    this.process = null;
+    this.starting = null;
+    if (process) process.kill();
+    this.failPending(new Error("Codex app-server closed"));
+  }
+
+  private async authStatus(includeToken: boolean, refreshToken: boolean): Promise<AuthStatusResponse> {
+    return (await this.request("getAuthStatus", { includeToken, refreshToken })) as AuthStatusResponse;
+  }
+
+  private async ensureStarted(): Promise<void> {
+    if (this.starting) return this.starting;
+    if (this.process) return;
+    const starting = this.startProcess();
+    this.starting = starting;
+    try {
+      await starting;
+    } finally {
+      if (this.starting === starting) this.starting = null;
+    }
+  }
+
+  private async startProcess(): Promise<void> {
+    let child: CodexAppServerProcess;
+    try {
+      child = this.spawnProcess();
+    } catch (error) {
+      throw new Error(safeMessage(error, "Could not start Codex app-server"));
+    }
+    this.process = child;
+    child.stdout.on("data", (chunk: unknown) => this.onStdout(child, String(chunk)));
+    // Drain stderr without logging it. Auth material must never reach Collie's logs.
+    child.stderr.on("data", () => {});
+    child.on("error", (error: Error) => this.onProcessFailure(child, error));
+    child.on("exit", () => this.onProcessFailure(child, new Error("Codex app-server exited")));
+
+    try {
+      await this.sendRequest("initialize", {
+        clientInfo: { name: "collie", title: "Collie", version: "0.0.0" },
+      });
+      this.write({ method: "initialized", params: {} });
+    } catch (error) {
+      // A timed-out initialize leaves a live but unusable process. Retire this exact child so the
+      // next request retries from a clean handshake; its late exit must not tear down a replacement.
+      if (this.process === child) this.process = null;
+      child.kill();
+      this.stdoutBuffer = "";
+      throw error;
+    }
+  }
+
+  private async request(method: string, params: unknown): Promise<unknown> {
+    await this.ensureStarted();
+    return this.sendRequest(method, params);
+  }
+
+  private sendRequest(method: string, params: unknown): Promise<unknown> {
+    const id = this.nextId++;
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject(new Error(`Codex app-server timed out during ${method}`));
+      }, this.requestTimeoutMs);
+      timer.unref?.();
+      this.pending.set(id, { resolve, reject, timer });
+      try {
+        this.write({ id, method, params });
+      } catch (error) {
+        clearTimeout(timer);
+        this.pending.delete(id);
+        reject(error instanceof Error ? error : new Error(String(error)));
+      }
+    });
+  }
+
+  private write(message: unknown): void {
+    if (!this.process) throw new Error("Codex app-server is not running");
+    this.process.stdin.write(`${JSON.stringify(message)}\n`);
+  }
+
+  private onStdout(child: CodexAppServerProcess, chunk: string): void {
+    // A timed-out child can still flush stdout after its replacement starts. Never let stale bytes
+    // enter the replacement's JSONL buffer or resolve one of its request ids.
+    if (this.process !== child) return;
+    this.stdoutBuffer += chunk;
+    for (;;) {
+      const newline = this.stdoutBuffer.indexOf("\n");
+      if (newline < 0) return;
+      const line = this.stdoutBuffer.slice(0, newline);
+      this.stdoutBuffer = this.stdoutBuffer.slice(newline + 1);
+      if (!line.trim()) continue;
+      let message: { id?: unknown; result?: unknown; error?: { message?: unknown } };
+      try {
+        message = JSON.parse(line) as typeof message;
+      } catch {
+        continue;
+      }
+      if (typeof message.id !== "number") continue;
+      const pending = this.pending.get(message.id);
+      if (!pending) continue;
+      clearTimeout(pending.timer);
+      this.pending.delete(message.id);
+      if (message.error) {
+        pending.reject(
+          new Error(
+            typeof message.error.message === "string"
+              ? message.error.message
+              : "Codex app-server request failed",
+          ),
+        );
+      } else {
+        pending.resolve(message.result);
+      }
+    }
+  }
+
+  private onProcessFailure(child: CodexAppServerProcess, error: Error): void {
+    if (this.process !== child) return;
+    this.process = null;
+    this.starting = null;
+    this.stdoutBuffer = "";
+    this.failPending(new Error(safeMessage(error, "Codex app-server failed")));
+  }
+
+  private failPending(error: Error): void {
+    for (const request of this.pending.values()) {
+      clearTimeout(request.timer);
+      request.reject(error);
+    }
+    this.pending.clear();
+  }
+}
+
+function safeMessage(error: unknown, fallback: string): string {
+  if (!(error instanceof Error)) return fallback;
+  if (error.message.includes("ENOENT")) return "Codex CLI was not found";
+  return error.message || fallback;
+}

--- a/bridge/stt/codex.test.ts
+++ b/bridge/stt/codex.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "bun:test";
+
+import type { CodexAuthBroker } from "./codex-auth.ts";
+import { CodexSttProvider } from "./codex.ts";
+
+function jwt(accountId: string): string {
+  const payload = Buffer.from(
+    JSON.stringify({ "https://api.openai.com/auth.chatgpt_account_id": accountId }),
+  ).toString("base64url");
+  return `header.${payload}.signature`;
+}
+
+describe("CodexSttProvider", () => {
+  test("uploads audio with Codex auth and refreshes once after a 401", async () => {
+    const token = jwt("acct-123");
+    const refreshes: boolean[] = [];
+    const broker: CodexAuthBroker = {
+      status: async () => ({ available: true }),
+      accessToken: async (refresh = false) => {
+        refreshes.push(refresh);
+        return { accessToken: token, authMethod: "chatgpt" };
+      },
+      close() {},
+    };
+    const requests: Array<{ input: string; init: RequestInit }> = [];
+    const provider = new CodexSttProvider({
+      broker,
+      fetch: async (input, init) => {
+        requests.push({ input: String(input), init: init ?? {} });
+        return requests.length === 1
+          ? new Response("expired", { status: 401 })
+          : Response.json({ text: "Merhaba Collie" });
+      },
+    });
+
+    expect(
+      await provider.transcribe({
+        audio: new Uint8Array([1, 2, 3]),
+        mimeType: "audio/webm;codecs=opus",
+        filename: "recording.webm",
+      }),
+    ).toEqual({ text: "Merhaba Collie" });
+    expect(refreshes).toEqual([false, true]);
+    expect(requests).toHaveLength(2);
+    expect(requests[0]?.input).toBe("https://chatgpt.com/backend-api/transcribe");
+    expect(requests[0]?.init.redirect).toBe("manual");
+
+    const headers = new Headers(requests[0]?.init.headers);
+    expect(headers.get("authorization")).toBe(`Bearer ${token}`);
+    expect(headers.get("chatgpt-account-id")).toBe("acct-123");
+    expect(headers.get("originator")).toBe("codex_cli_rs");
+    const body = requests[0]?.init.body;
+    expect(body).toBeInstanceOf(FormData);
+    const file = (body as FormData).get("file");
+    expect(file).toBeInstanceOf(Blob);
+    expect((file as File).name).toBe("recording.webm");
+    expect((file as Blob).type).toBe("audio/webm;codecs=opus");
+  });
+});

--- a/bridge/stt/codex.test.ts
+++ b/bridge/stt/codex.test.ts
@@ -10,6 +10,15 @@ function jwt(accountId: string): string {
   return `header.${payload}.signature`;
 }
 
+function currentJwt(accountId: string): string {
+  const payload = Buffer.from(
+    JSON.stringify({
+      "https://api.openai.com/auth": { chatgpt_account_id: accountId },
+    }),
+  ).toString("base64url");
+  return `header.${payload}.signature`;
+}
+
 describe("CodexSttProvider", () => {
   test("uploads audio with Codex auth and refreshes once after a 401", async () => {
     const token = jwt("acct-123");
@@ -55,5 +64,30 @@ describe("CodexSttProvider", () => {
     expect(file).toBeInstanceOf(Blob);
     expect((file as File).name).toBe("recording.webm");
     expect((file as Blob).type).toBe("audio/webm;codecs=opus");
+  });
+
+  test("reads the ChatGPT account id from the current namespaced auth claim", async () => {
+    const token = currentJwt("acct-current");
+    const broker: CodexAuthBroker = {
+      status: async () => ({ available: true }),
+      accessToken: async () => ({ accessToken: token, authMethod: "chatgpt" }),
+      close() {},
+    };
+    const accountHeaders: Array<string | null> = [];
+    const provider = new CodexSttProvider({
+      broker,
+      fetch: async (_input, init) => {
+        accountHeaders.push(new Headers(init?.headers).get("chatgpt-account-id"));
+        return Response.json({ text: "Merhaba" });
+      },
+    });
+
+    await provider.transcribe({
+      audio: new Uint8Array([1]),
+      mimeType: "audio/ogg",
+      filename: "recording.ogg",
+    });
+
+    expect(accountHeaders).toEqual(["acct-current"]);
   });
 });

--- a/bridge/stt/codex.ts
+++ b/bridge/stt/codex.ts
@@ -3,6 +3,7 @@ import type { SttAudio, SttProvider, SttStatus } from "./provider.ts";
 
 const TRANSCRIBE_URL = "https://chatgpt.com/backend-api/transcribe";
 const ACCOUNT_ID_CLAIM = "https://api.openai.com/auth.chatgpt_account_id";
+const AUTH_NAMESPACE_CLAIM = "https://api.openai.com/auth";
 const REQUEST_TIMEOUT_MS = 120_000;
 
 interface CodexProviderOptions {
@@ -99,7 +100,12 @@ function accountIdFromJwt(token: string): string {
       string,
       unknown
     >;
-    const accountId = claims[ACCOUNT_ID_CLAIM];
+    const namespacedAuth = claims[AUTH_NAMESPACE_CLAIM];
+    const accountId =
+      claims[ACCOUNT_ID_CLAIM] ??
+      (typeof namespacedAuth === "object" && namespacedAuth !== null
+        ? (namespacedAuth as Record<string, unknown>).chatgpt_account_id
+        : undefined);
     if (typeof accountId !== "string" || !accountId) {
       throw new Error("missing account id");
     }

--- a/bridge/stt/codex.ts
+++ b/bridge/stt/codex.ts
@@ -1,0 +1,117 @@
+import type { CodexAuthBroker } from "./codex-auth.ts";
+import type { SttAudio, SttProvider, SttStatus } from "./provider.ts";
+
+const TRANSCRIBE_URL = "https://chatgpt.com/backend-api/transcribe";
+const ACCOUNT_ID_CLAIM = "https://api.openai.com/auth.chatgpt_account_id";
+const REQUEST_TIMEOUT_MS = 120_000;
+
+interface CodexProviderOptions {
+  broker: CodexAuthBroker;
+  fetch?: Fetcher;
+}
+
+type Fetcher = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+
+export class CodexSttProvider implements SttProvider {
+  readonly id = "codex";
+  private readonly broker: CodexAuthBroker;
+  private readonly fetcher: Fetcher;
+  private tail: Promise<void> = Promise.resolve();
+
+  constructor(options: CodexProviderOptions) {
+    this.broker = options.broker;
+    this.fetcher = options.fetch ?? ((input, init) => globalThis.fetch(input, init));
+  }
+
+  status(): Promise<SttStatus> {
+    return this.broker.status();
+  }
+
+  transcribe(input: SttAudio): Promise<{ text: string }> {
+    // A 401 asks Codex to refresh its OAuth session. Keep that refresh and its retry ordered even
+    // when two Collie clients record at once, so this process never starts competing refreshes.
+    const result = this.tail.then(() => this.transcribeOnce(input));
+    this.tail = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    return result;
+  }
+
+  private async transcribeOnce(input: SttAudio): Promise<{ text: string }> {
+    let response = await this.request(input, false);
+    if (response.status === 401) response = await this.request(input, true);
+    if (!response.ok) throw new Error(responseError(response.status));
+
+    let payload: unknown;
+    try {
+      payload = await response.json();
+    } catch {
+      throw new Error("Codex returned an invalid transcription response");
+    }
+    const text = (payload as { text?: unknown } | null)?.text;
+    if (typeof text !== "string" || !text.trim()) {
+      throw new Error("Codex returned an empty transcription");
+    }
+    return { text: text.trim() };
+  }
+
+  close(): void {
+    this.broker.close();
+  }
+
+  private async request(input: SttAudio, refresh: boolean): Promise<Response> {
+    const { accessToken } = await this.broker.accessToken(refresh);
+    const accountId = accountIdFromJwt(accessToken);
+    const body = new FormData();
+    const bytes = new Uint8Array(input.audio.byteLength);
+    bytes.set(input.audio);
+    body.append("file", new File([bytes.buffer], input.filename, { type: input.mimeType }));
+
+    try {
+      return await this.fetcher(TRANSCRIBE_URL, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          Accept: "application/json",
+          "ChatGPT-Account-ID": accountId,
+          "User-Agent": "codex_cli_rs/0.0.0 (Collie)",
+          originator: "codex_cli_rs",
+        },
+        body,
+        redirect: "manual",
+        signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+      });
+    } catch (error) {
+      if (error instanceof DOMException && error.name === "TimeoutError") {
+        throw new Error("Codex transcription timed out");
+      }
+      throw new Error("Could not reach Codex transcription");
+    }
+  }
+}
+
+function accountIdFromJwt(token: string): string {
+  const payload = token.split(".")[1];
+  if (!payload) throw new Error("Codex access token is invalid");
+  try {
+    const claims = JSON.parse(Buffer.from(payload, "base64url").toString("utf8")) as Record<
+      string,
+      unknown
+    >;
+    const accountId = claims[ACCOUNT_ID_CLAIM];
+    if (typeof accountId !== "string" || !accountId) {
+      throw new Error("missing account id");
+    }
+    return accountId;
+  } catch {
+    throw new Error("Codex access token has no ChatGPT account id");
+  }
+}
+
+function responseError(status: number): string {
+  if (status === 401) return "Codex sign-in expired — run codex login";
+  if (status === 403) return "Codex transcription was refused";
+  if (status === 429) return "Codex transcription is rate limited — try again shortly";
+  return `Codex transcription failed (${status})`;
+}

--- a/bridge/stt/http.test.ts
+++ b/bridge/stt/http.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from "bun:test";
+
+import { MAX_STT_AUDIO_BYTES, sttStatusResponse, transcribeAudio } from "./http.ts";
+import type { SttAudio, SttProvider, SttStatus } from "./provider.ts";
+
+class FakeProvider implements SttProvider {
+  readonly id = "codex";
+  received: SttAudio | null = null;
+
+  constructor(private readonly currentStatus: SttStatus = { available: true }) {}
+
+  async status() {
+    return this.currentStatus;
+  }
+
+  async transcribe(input: SttAudio) {
+    this.received = input;
+    return { text: "spoken text" };
+  }
+
+  close() {}
+}
+
+describe("STT HTTP contract", () => {
+  test("reports provider availability without credentials", async () => {
+    const response = await sttStatusResponse(
+      new FakeProvider({ available: false, reason: "Codex is not signed in with ChatGPT" }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      provider: "codex",
+      available: false,
+      reason: "Codex is not signed in with ChatGPT",
+    });
+  });
+
+  test("accepts supported audio as a bounded binary body", async () => {
+    const provider = new FakeProvider();
+    const request = new Request("http://localhost/api/stt/transcribe", {
+      method: "POST",
+      headers: { "content-type": "audio/webm;codecs=opus" },
+      body: new Uint8Array([1, 2, 3]),
+    });
+
+    const response = await transcribeAudio(provider, request);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ text: "spoken text" });
+    expect(provider.received).toEqual({
+      audio: new Uint8Array([1, 2, 3]),
+      mimeType: "audio/webm;codecs=opus",
+      filename: "recording.webm",
+    });
+  });
+
+  test("rejects oversized and unsupported audio before calling the provider", async () => {
+    const provider = new FakeProvider();
+    const oversized = new Request("http://localhost/api/stt/transcribe", {
+      method: "POST",
+      headers: {
+        "content-type": "audio/webm",
+        "content-length": String(MAX_STT_AUDIO_BYTES + 1),
+      },
+      body: new Uint8Array([1]),
+    });
+    const unsupported = new Request("http://localhost/api/stt/transcribe", {
+      method: "POST",
+      headers: { "content-type": "audio/aac" },
+      body: new Uint8Array([1]),
+    });
+
+    expect((await transcribeAudio(provider, oversized)).status).toBe(413);
+    expect((await transcribeAudio(provider, unsupported)).status).toBe(415);
+    expect(provider.received).toBeNull();
+  });
+});

--- a/bridge/stt/http.ts
+++ b/bridge/stt/http.ts
@@ -1,0 +1,60 @@
+import type { SttProvider } from "./provider.ts";
+
+export const MAX_STT_AUDIO_BYTES = 25 * 1024 * 1024;
+
+const AUDIO_EXTENSIONS: Record<string, string> = {
+  "audio/webm": "webm",
+  "audio/ogg": "ogg",
+  "application/ogg": "ogg",
+  "audio/mp4": "m4a",
+  "audio/m4a": "m4a",
+  "audio/x-m4a": "m4a",
+};
+
+export async function sttStatusResponse(provider: SttProvider): Promise<Response> {
+  const status = await provider.status();
+  return Response.json({ provider: provider.id, ...status });
+}
+
+export async function transcribeAudio(provider: SttProvider, request: Request): Promise<Response> {
+  const contentLength = numberHeader(request.headers.get("content-length"));
+  if (contentLength !== null && contentLength > MAX_STT_AUDIO_BYTES) {
+    return error("Audio is larger than 25 MB", 413);
+  }
+
+  const mimeType = request.headers.get("content-type")?.trim() ?? "";
+  const baseMime = mimeType.split(";", 1)[0]!.toLowerCase();
+  const extension = AUDIO_EXTENSIONS[baseMime];
+  if (!extension) return error("Unsupported audio format", 415);
+
+  let audio: Uint8Array;
+  try {
+    audio = new Uint8Array(await request.arrayBuffer());
+  } catch {
+    return error("Could not read audio", 400);
+  }
+  if (audio.byteLength === 0) return error("Audio is empty", 400);
+  if (audio.byteLength > MAX_STT_AUDIO_BYTES) return error("Audio is larger than 25 MB", 413);
+
+  try {
+    const result = await provider.transcribe({
+      audio,
+      mimeType,
+      filename: `recording.${extension}`,
+    });
+    return Response.json(result);
+  } catch (cause) {
+    const message = cause instanceof Error ? cause.message : "Transcription failed";
+    return error(message, 502);
+  }
+}
+
+function numberHeader(raw: string | null): number | null {
+  if (raw === null || !/^\d+$/.test(raw)) return null;
+  const value = Number(raw);
+  return Number.isSafeInteger(value) ? value : null;
+}
+
+function error(message: string, status: number): Response {
+  return Response.json({ error: message }, { status });
+}

--- a/bridge/stt/provider.ts
+++ b/bridge/stt/provider.ts
@@ -1,0 +1,17 @@
+export interface SttAudio {
+  audio: Uint8Array;
+  mimeType: string;
+  filename: string;
+}
+
+export interface SttStatus {
+  available: boolean;
+  reason?: string;
+}
+
+export interface SttProvider {
+  readonly id: string;
+  status(): Promise<SttStatus>;
+  transcribe(input: SttAudio): Promise<{ text: string }>;
+  close(): void;
+}

--- a/web/src/components/composer.test.tsx
+++ b/web/src/components/composer.test.tsx
@@ -8,6 +8,7 @@ import { createMemoryRouter, RouterProvider } from "react-router";
 import { clearStatus, useStatus } from "@/lib/status";
 import { isReloadHeld, __resetReloadGuard } from "@/lib/reload-guard";
 import { loadDraft } from "@/lib/drafts";
+import { setHandsFree } from "@/lib/stt-prefs";
 import { server } from "@/test/setup";
 import { recordReply } from "@/test/handlers";
 import { Composer } from "./composer";
@@ -57,6 +58,142 @@ function renderComposer(overrides: Partial<ComponentProps<typeof Composer>> = {}
   render(<RouterProvider router={router} />);
   return props;
 }
+
+class ComposerMediaRecorder {
+  static isTypeSupported = () => true;
+  ondataavailable: ((event: BlobEvent) => void) | null = null;
+  onstop: (() => void) | null = null;
+  state: RecordingState = "inactive";
+  readonly mimeType: string;
+
+  constructor(_stream: MediaStream, options?: MediaRecorderOptions) {
+    this.mimeType = options?.mimeType ?? "audio/webm";
+  }
+
+  start() {
+    this.state = "recording";
+  }
+
+  stop() {
+    if (this.state === "inactive") return;
+    this.state = "inactive";
+    this.ondataavailable?.({ data: new Blob(["voice"], { type: this.mimeType }) } as BlobEvent);
+    this.onstop?.();
+  }
+}
+
+function enableFakeRecording() {
+  const stopTrack = vi.fn();
+  let transcriptionRequests = 0;
+  vi.stubGlobal("MediaRecorder", ComposerMediaRecorder);
+  Object.defineProperty(navigator, "mediaDevices", {
+    configurable: true,
+    value: {
+      getUserMedia: vi.fn().mockResolvedValue({ getTracks: () => [{ stop: stopTrack }] }),
+    },
+  });
+  server.use(
+    http.get("/api/stt/status", () =>
+      HttpResponse.json({ provider: "codex", available: true }),
+    ),
+    http.post("/api/stt/transcribe", () => {
+      transcriptionRequests += 1;
+      return HttpResponse.json({ text: "spoken reply" });
+    }),
+  );
+  return { stopTrack, transcriptionRequests: () => transcriptionRequests };
+}
+
+describe("Composer — speech to text", () => {
+  it("places a transcript in the input without sending when Hands free is off", async () => {
+    enableFakeRecording();
+    setHandsFree(false);
+    const user = userEvent.setup();
+    const replies: string[] = [];
+    server.use(replyHandler((text) => replies.push(text)));
+    renderComposer();
+
+    const mic = await screen.findByRole("button", { name: "Start recording" });
+    await user.click(mic);
+    await user.click(await screen.findByRole("button", { name: "Stop recording" }));
+
+    await waitFor(() =>
+      expect(screen.getByPlaceholderText(/type a reply/i)).toHaveValue("spoken reply"),
+    );
+    expect(replies).toEqual([]);
+  });
+
+  it("sends a transcript through the existing programmatic send flow by default", async () => {
+    enableFakeRecording();
+    const user = userEvent.setup();
+    const replies: string[] = [];
+    server.use(replyHandler((text) => replies.push(text)));
+    const props = renderComposer();
+
+    const mic = await screen.findByRole("button", { name: "Start recording" });
+    await user.click(mic);
+    await user.click(await screen.findByRole("button", { name: "Stop recording" }));
+
+    await waitFor(() => expect(replies).toContain("spoken reply"));
+    await waitFor(() => expect(props.onSent).toHaveBeenCalled());
+    expect(screen.getByPlaceholderText(/type a reply/i)).toHaveValue("");
+  });
+
+  it("cancels an active recording before entering direct terminal typing", async () => {
+    const recording = enableFakeRecording();
+    const user = userEvent.setup();
+    renderComposer();
+
+    await user.click(await screen.findByRole("button", { name: "Start recording" }));
+    await user.click(screen.getByRole("button", { name: "Type into terminal" }));
+
+    await waitFor(() => expect(recording.stopTrack).toHaveBeenCalled());
+    expect(recording.transcriptionRequests()).toBe(0);
+    expect(screen.getByRole("button", { name: "Stop typing into terminal" })).toBeInTheDocument();
+  });
+
+  it("does not send a transcription that resolves while direct typing is activated", async () => {
+    enableFakeRecording();
+    const user = userEvent.setup();
+    const replies: string[] = [];
+    let resolveTranscription!: () => void;
+    const transcriptionStarted = vi.fn();
+    server.use(
+      replyHandler((text) => replies.push(text)),
+      http.post("/api/stt/transcribe", async () => {
+        transcriptionStarted();
+        await new Promise<void>((resolve) => (resolveTranscription = resolve));
+        return HttpResponse.json({ text: "must not send" });
+      }),
+    );
+    renderComposer();
+
+    await user.click(await screen.findByRole("button", { name: "Start recording" }));
+    await user.click(screen.getByRole("button", { name: "Stop recording" }));
+    await waitFor(() => expect(transcriptionStarted).toHaveBeenCalled());
+    await user.click(screen.getByRole("button", { name: "Type into terminal" }));
+    resolveTranscription();
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Stop typing into terminal" })).toBeInTheDocument(),
+    );
+    expect(replies).toEqual([]);
+  });
+
+  it("keeps recording when direct typing activation is refused by an existing draft", async () => {
+    const recording = enableFakeRecording();
+    const user = userEvent.setup();
+    renderComposer();
+
+    await user.type(screen.getByPlaceholderText(/type a reply/i), "keep this draft");
+    await user.click(await screen.findByRole("button", { name: "Start recording" }));
+    await user.click(screen.getByRole("button", { name: "Type into terminal" }));
+
+    expect(recording.stopTrack).not.toHaveBeenCalled();
+    expect(screen.getByRole("button", { name: "Stop recording" })).toBeInTheDocument();
+    expect(screen.getByPlaceholderText(/type a reply/i)).toHaveValue("keep this draft");
+  });
+});
 
 /**
  * Wait for a send that can never verify to reach its terminal `stalled` outcome.

--- a/web/src/components/composer.tsx
+++ b/web/src/components/composer.tsx
@@ -1,7 +1,7 @@
 import { forwardRef, useEffect, useImperativeHandle, useRef, useState } from "react";
 import type { ChangeEvent, ClipboardEvent, ReactNode } from "react";
 import { useRevalidator } from "react-router";
-import { Check, ImagePlus, Keyboard, Loader2, Send, Settings2, Slash, Terminal, X, Zap } from "lucide-react";
+import { Check, ImagePlus, Keyboard, Loader2, Mic, Send, Settings2, Slash, Square, Terminal, X, Zap } from "lucide-react";
 
 import type { DisplayPrefs } from "@/hooks/use-display-prefs";
 import { usePendingConfirm } from "@/hooks/use-pending-confirm";
@@ -27,6 +27,9 @@ import { sendGuardedReply } from "@/lib/reply-action";
 import { TerminalDraftPreview } from "@/components/terminal-draft-preview";
 import { DirectTypingStrip } from "@/components/direct-typing-strip";
 import { NoEchoNotice } from "@/components/no-echo-notice";
+import { useAudioRecorder } from "@/hooks/use-audio-recorder";
+import { useSttAvailability } from "@/hooks/use-stt-availability";
+import { useSttPrefs } from "@/lib/stt-prefs";
 
 export interface ComposerHandle {
   /** Focus the input and put the caret at the end — used by the mirror-tap-to-focus in AgentChat. */
@@ -285,6 +288,14 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const fileRef = useRef<HTMLInputElement>(null);
+  const sttStatus = useSttAvailability();
+  const sttPrefs = useSttPrefs();
+  const recorder = useAudioRecorder({
+    scopeKey: `${session ?? ""}\0${paneId}`,
+    onTranscript: handleTranscript,
+    onError: (message) => setStatus(message, "error"),
+  });
+  const sttAvailable = Boolean(sttStatus?.available && sttPrefs.enabled && recorder.supported);
   const direct = useDirectTyping({
     paneKey: `${session ?? ""}\0${paneId}`,
     inputRef,
@@ -298,12 +309,21 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
     suspended: locked,
     sendKeys: pressKeys,
     onActivate: () => {
+      // This callback runs only after the mode's draft/capability guards accept activation. Cancel
+      // synchronously here so a resolving hands-free transcript cannot cross into direct mode, but
+      // a refused activation does not discard an otherwise-valid recording.
+      recorder.cancel();
       sendConfirm.reset();
       forceConfirm.reset();
       noticeNoEcho(null); // the notice's whole job was to get you here
     },
     focusInput: focusInputEnd,
   });
+  useEffect(() => {
+    // Direct typing changes the input into a raw terminal keyboard. A recording started in reply
+    // mode must never finish into that different interaction mode.
+    if (direct.active) recorder.cancel();
+  }, [direct.active]);
   const sentTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const lastSentTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   // What we last sent, and when — so we can recognise our OWN reply momentarily echoing on the "❯"
@@ -369,7 +389,12 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
   // the hold clears (see lib/self-update.ts). Keyed by pane so panes don't clobber each other's hold.
   useHoldReload(
     `composer:${paneId}`,
-    input.trim() !== "" || direct.active || direct.value !== "" || direct.busy || uploading,
+    input.trim() !== "" ||
+      direct.active ||
+      direct.value !== "" ||
+      direct.busy ||
+      uploading ||
+      recorder.state !== "idle",
   );
 
   // Preview appearance latch. A STABLE, non-echo, not-already-handled draft flips the preview on —
@@ -437,6 +462,39 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
 
   function focusInputEnd() {
     setTimeout(focusInputImmediately, 0);
+  }
+
+  function insertTranscript(transcript: string) {
+    const text = transcript.trim();
+    if (!text) return;
+    const current = inputValueRef.current;
+    const textarea = inputRef.current;
+    const start = textarea?.selectionStart ?? current.length;
+    const end = textarea?.selectionEnd ?? start;
+    const before = current.slice(0, start);
+    const after = current.slice(end);
+    const prefix = before.length > 0 && !/\s$/.test(before) ? " " : "";
+    const suffix = after.length > 0 && !/^\s/.test(after) ? " " : "";
+    const inserted = `${prefix}${text}${suffix}`;
+    updateInput(`${before}${inserted}${after}`);
+    setTimeout(() => {
+      const next = inputRef.current;
+      if (!next) return;
+      const caret = start + inserted.length;
+      next.focus();
+      next.setSelectionRange(caret, caret);
+    }, 0);
+  }
+
+  async function handleTranscript(transcript: string) {
+    if (!sttPrefs.handsFree) {
+      insertTranscript(transcript);
+      return;
+    }
+    // Voice replies use the same guarded programmatic-send seam as quick actions. If the live pane
+    // refuses or stalls the send, keep the transcript as a local draft so recorded speech is never
+    // silently lost.
+    if (!(await send(transcript, false))) insertTranscript(transcript);
   }
 
   // Resolves true only on a VERIFIED send (the text was seen in the pane's input box before the
@@ -998,6 +1056,43 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
               )}
             </Button>
           </div>
+          {sttAvailable && !direct.active && (
+            <div className="flex shrink-0 items-center gap-1">
+              <Button
+                type="button"
+                variant={recorder.state === "recording" ? "destructive" : "outline"}
+                size="icon"
+                className={cn(
+                  "size-11 rounded-full",
+                  recorder.state === "recording" && "animate-pulse",
+                )}
+                disabled={locked || sending || recorder.state === "requesting" || recorder.state === "transcribing"}
+                onClick={recorder.state === "idle" ? recorder.start : recorder.stop}
+                aria-label={recorder.state === "recording" ? "Stop recording" : "Start recording"}
+                aria-pressed={recorder.state === "recording"}
+              >
+                {recorder.state === "requesting" || recorder.state === "transcribing" ? (
+                  <Loader2 className="size-4 animate-spin" />
+                ) : recorder.state === "recording" ? (
+                  <Square className="size-4 fill-current" />
+                ) : (
+                  <Mic className="size-4" />
+                )}
+              </Button>
+              {recorder.state !== "idle" && (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  className="size-8 rounded-full text-muted-foreground"
+                  onClick={recorder.cancel}
+                  aria-label="Cancel recording"
+                >
+                  <X className="size-4" />
+                </Button>
+              )}
+            </div>
+          )}
           {!direct.active && forcingSend ? (
             // The pre-flight refused and the user is being offered the override. Labelled for what it
             // actually does — TYPE the text into whatever is on screen — not "send", because the

--- a/web/src/components/stt-control.test.tsx
+++ b/web/src/components/stt-control.test.tsx
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { http, HttpResponse } from "msw";
+
+import { server } from "@/test/setup";
+import { SttControl } from "@/components/stt-control";
+import { __resetSttPrefs } from "@/lib/stt-prefs";
+
+beforeEach(() => {
+  vi.stubGlobal("MediaRecorder", class {});
+  Object.defineProperty(navigator, "mediaDevices", {
+    configurable: true,
+    value: { getUserMedia: vi.fn() },
+  });
+  __resetSttPrefs();
+});
+
+describe("SttControl", () => {
+  test("shows speech-to-text disabled when Codex auth is unavailable", async () => {
+    server.use(
+      http.get("/api/stt/status", () =>
+        HttpResponse.json({
+          provider: "codex",
+          available: false,
+          reason: "Codex is not signed in with ChatGPT",
+        }),
+      ),
+    );
+
+    render(<SttControl />);
+
+    const enabled = await screen.findByRole("switch", { name: "Speech to text" });
+    expect(enabled).toBeDisabled();
+    expect(enabled).not.toBeChecked();
+    expect(screen.getByText("Codex is not signed in with ChatGPT")).toBeInTheDocument();
+  });
+
+  test("defaults both choices on and persists turning STT off", async () => {
+    const user = userEvent.setup();
+    server.use(
+      http.get("/api/stt/status", () =>
+        HttpResponse.json({ provider: "codex", available: true }),
+      ),
+    );
+
+    render(<SttControl />);
+
+    const enabled = await screen.findByRole("switch", { name: "Speech to text" });
+    const handsFree = screen.getByRole("switch", { name: "Hands free" });
+    expect(enabled).toBeChecked();
+    expect(handsFree).toBeChecked();
+
+    await user.click(enabled);
+
+    expect(enabled).not.toBeChecked();
+    expect(handsFree).toBeDisabled();
+    expect(localStorage.getItem("collie:stt-prefs:v1")).toContain('"enabled":false');
+  });
+});

--- a/web/src/components/stt-control.tsx
+++ b/web/src/components/stt-control.tsx
@@ -1,0 +1,67 @@
+import { Loader2, Mic } from "lucide-react";
+
+import { Card } from "@/components/ui/card";
+import { Switch } from "@/components/ui/switch";
+import { audioRecordingSupported } from "@/hooks/use-audio-recorder";
+import { useSttAvailability } from "@/hooks/use-stt-availability";
+import { setHandsFree, setSttEnabled, useSttPrefs } from "@/lib/stt-prefs";
+
+export function SttControl() {
+  const serverStatus = useSttAvailability();
+  const prefs = useSttPrefs();
+  const browserSupported = audioRecordingSupported();
+  const available = Boolean(serverStatus?.available && browserSupported);
+  const reason = !browserSupported
+    ? "This browser does not support audio recording"
+    : serverStatus?.reason;
+  const effectiveEnabled = available && prefs.enabled;
+
+  return (
+    <Card className="gap-0 py-0">
+      <div className="flex items-center justify-between gap-4 p-4">
+        <div className="flex min-w-0 items-start gap-3">
+          <Mic className="mt-0.5 size-5 shrink-0 text-muted-foreground" />
+          <div className="min-w-0">
+            <div className="font-medium">Speech to text</div>
+            <p className="text-sm text-muted-foreground">
+              Record a reply with experimental Codex transcription.
+            </p>
+          </div>
+        </div>
+        <div className="flex h-6 w-11 shrink-0 items-center justify-center">
+          {serverStatus ? (
+            <Switch
+              checked={effectiveEnabled}
+              disabled={!available}
+              onCheckedChange={setSttEnabled}
+              aria-label="Speech to text"
+            />
+          ) : (
+            <Loader2 className="size-4 animate-spin text-muted-foreground" />
+          )}
+        </div>
+      </div>
+
+      <div className="flex items-center justify-between gap-4 border-t border-border/60 p-4">
+        <div className="min-w-0 pl-8">
+          <div className="font-medium">Hands free</div>
+          <p className="text-sm text-muted-foreground">
+            Send the transcript immediately instead of placing it in the input box.
+          </p>
+        </div>
+        <Switch
+          checked={prefs.handsFree}
+          disabled={!effectiveEnabled}
+          onCheckedChange={setHandsFree}
+          aria-label="Hands free"
+        />
+      </div>
+
+      {serverStatus && !available && reason && (
+        <p className="border-t border-border/60 px-4 py-2.5 text-xs text-muted-foreground">
+          {reason}
+        </p>
+      )}
+    </Card>
+  );
+}

--- a/web/src/hooks/use-audio-recorder.test.ts
+++ b/web/src/hooks/use-audio-recorder.test.ts
@@ -1,0 +1,131 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+import { preferredRecordingMimeType, useAudioRecorder } from "./use-audio-recorder";
+
+class FakeMediaRecorder {
+  static isTypeSupported = vi.fn((type: string) => type === "audio/webm;codecs=opus");
+  ondataavailable: ((event: BlobEvent) => void) | null = null;
+  onstop: (() => void) | null = null;
+  onerror: ((event: Event) => void) | null = null;
+  state: RecordingState = "inactive";
+  readonly stream: MediaStream;
+  readonly mimeType: string;
+
+  constructor(stream: MediaStream, options?: MediaRecorderOptions) {
+    this.stream = stream;
+    this.mimeType = options?.mimeType ?? "";
+  }
+
+  start() {
+    this.state = "recording";
+  }
+
+  stop() {
+    if (this.state === "inactive") return;
+    this.state = "inactive";
+    this.ondataavailable?.({ data: new Blob(["voice"], { type: this.mimeType }) } as BlobEvent);
+    this.onstop?.();
+  }
+}
+
+describe("useAudioRecorder", () => {
+  const stopTrack = vi.fn();
+  const stream = {
+    getTracks: () => [{ stop: stopTrack }],
+  } as unknown as MediaStream;
+
+  beforeEach(() => {
+    stopTrack.mockClear();
+    FakeMediaRecorder.isTypeSupported.mockReset();
+    FakeMediaRecorder.isTypeSupported.mockImplementation(
+      (type) => type === "audio/webm;codecs=opus",
+    );
+    vi.stubGlobal("MediaRecorder", FakeMediaRecorder);
+    Object.defineProperty(navigator, "mediaDevices", {
+      configurable: true,
+      value: { getUserMedia: vi.fn().mockResolvedValue(stream) },
+    });
+  });
+
+  test("prefers opus webm and falls back to mp4", () => {
+    expect(preferredRecordingMimeType()).toBe("audio/webm;codecs=opus");
+    FakeMediaRecorder.isTypeSupported.mockImplementation((type) => type === "audio/mp4");
+    expect(preferredRecordingMimeType()).toBe("audio/mp4");
+  });
+
+  test("transcribes once after stop and releases the microphone", async () => {
+    const onTranscript = vi.fn();
+    const onError = vi.fn();
+    const transcribe = vi.fn(async (_audio: Blob, _signal?: AbortSignal) => ({
+      text: "hello from speech",
+    }));
+    const { result } = renderHook(() =>
+      useAudioRecorder({ onTranscript, onError, transcribe }),
+    );
+
+    await act(() => result.current.start());
+    expect(result.current.state).toBe("recording");
+    act(() => result.current.stop());
+
+    await waitFor(() => expect(onTranscript).toHaveBeenCalledWith("hello from speech"));
+    expect(transcribe).toHaveBeenCalledTimes(1);
+    expect(transcribe.mock.calls[0]?.[0].type).toBe("audio/webm;codecs=opus");
+    expect(onError).not.toHaveBeenCalled();
+    expect(stopTrack).toHaveBeenCalled();
+    expect(result.current.state).toBe("idle");
+  });
+
+  test("cancels recording on unmount without transcribing", async () => {
+    const transcribe = vi.fn(async () => ({ text: "should not land" }));
+    const { result, unmount } = renderHook(() =>
+      useAudioRecorder({ onTranscript: vi.fn(), transcribe }),
+    );
+
+    await act(() => result.current.start());
+    unmount();
+
+    expect(stopTrack).toHaveBeenCalled();
+    expect(transcribe).not.toHaveBeenCalled();
+  });
+
+  test("drops an in-flight result when the owning pane changes", async () => {
+    let resolveTranscription!: (result: { text: string }) => void;
+    const transcribe = vi.fn(
+      () => new Promise<{ text: string }>((resolve) => (resolveTranscription = resolve)),
+    );
+    const onTranscript = vi.fn();
+    const { result, rerender } = renderHook(
+      ({ scopeKey }) => useAudioRecorder({ scopeKey, onTranscript, transcribe }),
+      { initialProps: { scopeKey: "pane-a" } },
+    );
+
+    await act(() => result.current.start());
+    act(() => result.current.stop());
+    await waitFor(() => expect(result.current.state).toBe("transcribing"));
+    rerender({ scopeKey: "pane-b" });
+    resolveTranscription({ text: "belongs to pane A" });
+
+    await waitFor(() => expect(result.current.state).toBe("idle"));
+    expect(onTranscript).not.toHaveBeenCalled();
+  });
+
+  test("releases the microphone when MediaRecorder startup throws", async () => {
+    class ThrowingMediaRecorder extends FakeMediaRecorder {
+      start() {
+        throw new Error("codec failed");
+      }
+    }
+    vi.stubGlobal("MediaRecorder", ThrowingMediaRecorder);
+    const onError = vi.fn();
+    const { result } = renderHook(() =>
+      useAudioRecorder({ onTranscript: vi.fn(), onError }),
+    );
+
+    await act(() => result.current.start());
+
+    expect(result.current.state).toBe("idle");
+    expect(stopTrack).toHaveBeenCalled();
+    expect(onError).toHaveBeenCalledWith("Could not start audio recording");
+  });
+});

--- a/web/src/hooks/use-audio-recorder.ts
+++ b/web/src/hooks/use-audio-recorder.ts
@@ -1,0 +1,200 @@
+import { useEffect, useRef, useState } from "react";
+
+import { transcribeAudio } from "@/lib/api";
+
+export type AudioRecorderState = "idle" | "requesting" | "recording" | "transcribing";
+
+interface AudioRecorderOptions {
+  onTranscript(text: string): void | Promise<void>;
+  onError?(message: string): void;
+  transcribe?: (audio: Blob, signal?: AbortSignal) => Promise<{ text: string }>;
+  maxDurationMs?: number;
+  /** Cancels the current job when its owning pane/session identity changes. */
+  scopeKey?: string;
+}
+
+const DEFAULT_MAX_DURATION_MS = 120_000;
+const MAX_AUDIO_BYTES = 25 * 1024 * 1024;
+const MIME_CANDIDATES = [
+  "audio/webm;codecs=opus",
+  "audio/mp4",
+  "audio/webm",
+  "audio/ogg;codecs=opus",
+] as const;
+
+export function preferredRecordingMimeType(): string {
+  if (typeof MediaRecorder === "undefined") return "";
+  if (typeof MediaRecorder.isTypeSupported !== "function") return "";
+  return MIME_CANDIDATES.find((type) => MediaRecorder.isTypeSupported(type)) ?? "";
+}
+
+export function audioRecordingSupported(): boolean {
+  return (
+    typeof MediaRecorder !== "undefined" &&
+    typeof navigator !== "undefined" &&
+    typeof navigator.mediaDevices?.getUserMedia === "function"
+  );
+}
+
+export function useAudioRecorder(options: AudioRecorderOptions) {
+  const [state, setState] = useState<AudioRecorderState>("idle");
+  const recorderRef = useRef<MediaRecorder | null>(null);
+  const streamRef = useRef<MediaStream | null>(null);
+  const chunksRef = useRef<Blob[]>([]);
+  const abortRef = useRef<AbortController | null>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const cancelledRef = useRef(false);
+  const mountedRef = useRef(true);
+  const onTranscriptRef = useRef(options.onTranscript);
+  const onErrorRef = useRef(options.onError);
+  const transcribeRef = useRef(options.transcribe ?? transcribeAudio);
+  const scopeRef = useRef(options.scopeKey);
+  const jobScopeRef = useRef(options.scopeKey);
+  scopeRef.current = options.scopeKey;
+  onTranscriptRef.current = options.onTranscript;
+  onErrorRef.current = options.onError;
+  transcribeRef.current = options.transcribe ?? transcribeAudio;
+
+  function clearTimer() {
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = null;
+  }
+
+  function releaseStream() {
+    for (const track of streamRef.current?.getTracks() ?? []) track.stop();
+    streamRef.current = null;
+  }
+
+  function settleIdle() {
+    if (mountedRef.current) setState("idle");
+  }
+
+  function cancel() {
+    cancelledRef.current = true;
+    clearTimer();
+    abortRef.current?.abort();
+    abortRef.current = null;
+    const recorder = recorderRef.current;
+    if (recorder && recorder.state !== "inactive") {
+      recorder.stop();
+    } else {
+      recorderRef.current = null;
+      chunksRef.current = [];
+      releaseStream();
+    }
+    settleIdle();
+  }
+
+  function stop() {
+    clearTimer();
+    const recorder = recorderRef.current;
+    if (recorder?.state === "recording" || recorder?.state === "paused") recorder.stop();
+  }
+
+  async function start() {
+    if (!audioRecordingSupported() || state !== "idle") return;
+    cancelledRef.current = false;
+    jobScopeRef.current = options.scopeKey;
+    setState("requesting");
+    let stream: MediaStream;
+    try {
+      stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    } catch {
+      settleIdle();
+      onErrorRef.current?.("Microphone access was denied");
+      return;
+    }
+    if (!mountedRef.current || cancelledRef.current) {
+      for (const track of stream.getTracks()) track.stop();
+      return;
+    }
+
+    streamRef.current = stream;
+    chunksRef.current = [];
+    const mimeType = preferredRecordingMimeType();
+    try {
+      const recorder = new MediaRecorder(stream, mimeType ? { mimeType } : undefined);
+      recorderRef.current = recorder;
+      recorder.ondataavailable = (event) => {
+        if (event.data.size > 0) chunksRef.current.push(event.data);
+      };
+      recorder.onstop = () => void finish(recorder.mimeType || mimeType);
+      recorder.onerror = () => {
+        onErrorRef.current?.("Audio recording failed");
+        cancel();
+      };
+      recorder.start();
+    } catch {
+      recorderRef.current = null;
+      chunksRef.current = [];
+      releaseStream();
+      settleIdle();
+      onErrorRef.current?.("Could not start audio recording");
+      return;
+    }
+    setState("recording");
+    timerRef.current = setTimeout(stop, options.maxDurationMs ?? DEFAULT_MAX_DURATION_MS);
+  }
+
+  async function finish(mimeType: string) {
+    clearTimer();
+    recorderRef.current = null;
+    releaseStream();
+    const chunks = chunksRef.current;
+    chunksRef.current = [];
+    if (cancelledRef.current || !mountedRef.current) return;
+
+    const audio = new Blob(chunks, { type: mimeType || chunks[0]?.type || "audio/webm" });
+    if (audio.size === 0) {
+      onErrorRef.current?.("No audio was recorded");
+      settleIdle();
+      return;
+    }
+    if (audio.size > MAX_AUDIO_BYTES) {
+      onErrorRef.current?.("Recording is larger than 25 MB");
+      settleIdle();
+      return;
+    }
+
+    setState("transcribing");
+    const abort = new AbortController();
+    abortRef.current = abort;
+    try {
+      const result = await transcribeRef.current(audio, abort.signal);
+      if (
+        !cancelledRef.current &&
+        mountedRef.current &&
+        jobScopeRef.current === scopeRef.current
+      ) {
+        await onTranscriptRef.current(result.text);
+      }
+    } catch (error) {
+      if (!abort.signal.aborted && mountedRef.current) {
+        onErrorRef.current?.(error instanceof Error ? error.message : "Transcription failed");
+      }
+    } finally {
+      if (abortRef.current === abort) abortRef.current = null;
+      settleIdle();
+    }
+  }
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+      cancel();
+    };
+  }, []);
+
+  useEffect(() => {
+    if (jobScopeRef.current !== options.scopeKey) cancel();
+  }, [options.scopeKey]);
+
+  return {
+    state,
+    supported: audioRecordingSupported(),
+    start,
+    stop,
+    cancel,
+  };
+}

--- a/web/src/hooks/use-stt-availability.ts
+++ b/web/src/hooks/use-stt-availability.ts
@@ -1,0 +1,26 @@
+import { useEffect, useState } from "react";
+
+import { fetchSttStatus } from "@/lib/api";
+import type { SttStatus } from "@/lib/types";
+
+export function useSttAvailability(): SttStatus | null {
+  const [status, setStatus] = useState<SttStatus | null>(null);
+
+  useEffect(() => {
+    let alive = true;
+    fetchSttStatus()
+      .then((next) => {
+        if (alive) setStatus(next);
+      })
+      .catch(() => {
+        if (alive) {
+          setStatus({ provider: "codex", available: false, reason: "Could not check Codex sign-in" });
+        }
+      });
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  return status;
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -12,6 +12,7 @@ import type {
   PaneHistoryResponse,
   PaneReadResponse,
   SnapshotResponse,
+  SttStatus,
   UpdateInfo,
   UploadResponse,
 } from "./types";
@@ -69,6 +70,7 @@ const GET_TIMEOUT_MS = 10_000;
 const MUTATION_TIMEOUT_MS = 20_000;
 //   - Uploads carry a whole file over the phone's uplink — the most generous budget.
 const UPLOAD_TIMEOUT_MS = 60_000;
+const TRANSCRIPTION_TIMEOUT_MS = 150_000;
 
 /**
  * Compose the caller's abort signal (a loader's `request.signal`, used to supersede a stale poll)
@@ -401,6 +403,38 @@ export function createWorkspace(
 
 export function fetchConfig(): Promise<BridgeConfig> {
   return req<BridgeConfig>("/api/config");
+}
+
+export function fetchSttStatus(): Promise<SttStatus> {
+  return req<SttStatus>("/api/stt/status");
+}
+
+export function transcribeAudio(audio: Blob, signal?: AbortSignal): Promise<{ text: string }> {
+  return trackBusy(
+    (async () => {
+      const res = await fetch("/api/stt/transcribe", {
+        method: "POST",
+        headers: {
+          "content-type": audio.type || "application/octet-stream",
+          [XHR_HEADER]: XHR_HEADER_VALUE,
+        },
+        body: audio,
+        signal: withTimeout(signal, TRANSCRIPTION_TIMEOUT_MS),
+      });
+      captureBuild(res);
+      if (!res.ok) {
+        let message = "Transcription failed";
+        try {
+          const body = (await res.json()) as { error?: unknown };
+          if (typeof body.error === "string") message = body.error;
+        } catch {
+          // Keep the safe fallback; do not surface an upstream HTML/proxy body.
+        }
+        throw new ApiError(message, res.status);
+      }
+      return (await res.json()) as { text: string };
+    })(),
+  );
 }
 
 /**

--- a/web/src/lib/stt-prefs.test.ts
+++ b/web/src/lib/stt-prefs.test.ts
@@ -1,0 +1,29 @@
+import { beforeEach, describe, expect, test } from "vitest";
+
+import {
+  __resetSttPrefs,
+  getSttPrefs,
+  setHandsFree,
+  setSttEnabled,
+} from "./stt-prefs";
+
+describe("STT preferences", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    __resetSttPrefs();
+  });
+
+  test("defaults speech-to-text and hands free to on", () => {
+    expect(getSttPrefs()).toEqual({ enabled: true, handsFree: true });
+  });
+
+  test("persists device-local choices", () => {
+    setSttEnabled(false);
+    setHandsFree(false);
+
+    expect(getSttPrefs()).toEqual({ enabled: false, handsFree: false });
+    expect(localStorage.getItem("collie:stt-prefs:v1")).toBe(
+      JSON.stringify({ enabled: false, handsFree: false }),
+    );
+  });
+});

--- a/web/src/lib/stt-prefs.ts
+++ b/web/src/lib/stt-prefs.ts
@@ -1,0 +1,67 @@
+import { useSyncExternalStore } from "react";
+
+export interface SttPrefs {
+  enabled: boolean;
+  handsFree: boolean;
+}
+
+const STORAGE_KEY = "collie:stt-prefs:v1";
+const DEFAULT_PREFS: SttPrefs = { enabled: true, handsFree: true };
+
+let prefs = load();
+const listeners = new Set<() => void>();
+
+function load(): SttPrefs {
+  try {
+    if (typeof localStorage === "undefined") return DEFAULT_PREFS;
+    const parsed: unknown = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? "null");
+    if (typeof parsed !== "object" || parsed === null) return DEFAULT_PREFS;
+    const value = parsed as Partial<SttPrefs>;
+    return {
+      enabled: typeof value.enabled === "boolean" ? value.enabled : true,
+      handsFree: typeof value.handsFree === "boolean" ? value.handsFree : true,
+    };
+  } catch {
+    return DEFAULT_PREFS;
+  }
+}
+
+function update(patch: Partial<SttPrefs>): void {
+  prefs = { ...prefs, ...patch };
+  try {
+    if (typeof localStorage !== "undefined") {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(prefs));
+    }
+  } catch {
+    // Private mode/quota failure: keep the preference for this page session.
+  }
+  for (const listener of listeners) listener();
+}
+
+export function getSttPrefs(): SttPrefs {
+  return prefs;
+}
+
+export function setSttEnabled(enabled: boolean): void {
+  update({ enabled });
+}
+
+export function setHandsFree(handsFree: boolean): void {
+  update({ handsFree });
+}
+
+export function useSttPrefs(): SttPrefs {
+  return useSyncExternalStore(
+    (listener) => {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+    getSttPrefs,
+    () => DEFAULT_PREFS,
+  );
+}
+
+export function __resetSttPrefs(): void {
+  prefs = load();
+  for (const listener of listeners) listener();
+}

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -291,6 +291,12 @@ export interface BridgeConfig {
   operatorCommands?: OperatorCommand[];
 }
 
+export interface SttStatus {
+  provider: string;
+  available: boolean;
+  reason?: string;
+}
+
 /**
  * Notification type preferences (GET/POST /api/notifications/prefs). Which agent statuses push, set
  * bridge-wide (fans out to every device, like the snooze). Mirrors NotifyPrefs in bridge/notify-prefs.ts.

--- a/web/src/routes/settings.tsx
+++ b/web/src/routes/settings.tsx
@@ -12,6 +12,7 @@ import { SnoozeControl } from "@/components/snooze-control";
 import { ThemeControl } from "@/components/theme-control";
 import { HapticsControl } from "@/components/haptics-control";
 import { UpdateCheckControl } from "@/components/update-check-control";
+import { SttControl } from "@/components/stt-control";
 import { Switch } from "@/components/ui/switch";
 import { fetchConfig } from "@/lib/api";
 import { usePushControl } from "@/hooks/use-push";
@@ -79,6 +80,8 @@ export function SettingsRoute() {
         {/* Device behaviour sits with appearance — both are "how this phone treats you", as opposed
             to the herd/notification settings below. Renders nothing where vibrate is unsupported. */}
         <HapticsControl />
+
+        <SttControl />
 
         <Card className="gap-0 py-0">
           <div className="flex items-center justify-between gap-4 p-4">

--- a/web/src/test/handlers.ts
+++ b/web/src/test/handlers.ts
@@ -190,6 +190,9 @@ export const handlers = [
     }),
   ),
   http.get("/api/config", () => HttpResponse.json({ push: false, vapidPublicKey: "" })),
+  http.get("/api/stt/status", () =>
+    HttpResponse.json({ provider: "codex", available: false, reason: "Codex is not signed in" }),
+  ),
   http.post("/api/notifications/snooze", async ({ request }) => {
     const { snoozedUntil } = (await request.json()) as { snoozedUntil: number | null };
     return HttpResponse.json({ snoozedUntil });

--- a/web/src/test/setup.ts
+++ b/web/src/test/setup.ts
@@ -6,6 +6,7 @@ import { setupServer } from "msw/node";
 import { handlers, resetTypedDraft } from "./handlers";
 import { __resetConnectionHealth } from "@/lib/connection-health";
 import { __resetDraftPrune } from "@/lib/drafts";
+import { __resetSttPrefs } from "@/lib/stt-prefs";
 
 // One MSW server for all tests; tests add per-case overrides with `server.use(...)`.
 export const server = setupServer(...handlers);
@@ -28,6 +29,7 @@ beforeEach(() => {
     // ignore
   }
   __resetDraftPrune();
+  __resetSttPrefs();
 });
 afterEach(() => {
   cleanup();


### PR DESCRIPTION
## Summary

Adds optional speech input to the composer for users who already have an authenticated Codex installation.

A microphone button appears immediately to the left of Send. Recorded speech can either:

- be sent through Collie’s existing guarded reply path; or
- be inserted into the composer as an editable draft.

No OpenAI API key, separate OAuth flow, provider configuration, model selector, or OpenAI SDK is added to Collie.

## Why revisit speech input after #91?

#91 was declined because it made Collie responsible for transcription credentials, provider configuration, an outbound path, and an additional SDK dependency.

This implementation deliberately narrows that ownership boundary:

- Codex remains the owner of authentication and token refresh.
- Collie communicates with the locally installed `codex app-server`.
- Collie never reads or writes Codex auth files or the system keychain.
- Refresh tokens are never exposed to Collie.
- Access tokens exist only in bridge process memory.
- No new runtime dependency is introduced.
- If a usable Codex ChatGPT login is unavailable, the feature remains visible but disabled.

Collie still owns microphone capture and an outbound audio request when the user explicitly records. That remaining tradeoff is documented rather than hidden.

## User experience

- Adds a microphone control immediately before Send.
- Tap to start recording; tap again to transcribe.
- Recording can be cancelled without submitting audio.
- Maximum recording duration is 2 minutes.
- Maximum recording size is 25 MB.
- Recording is cancelled if the user changes pane/session or leaves the composer.
- Preferences are stored per device, following Collie’s existing browser preference pattern.

Two settings are provided:

### Speech to text

Automatically available when an authenticated Codex ChatGPT session is detected. Users can disable it. Without compatible authentication, the setting is greyed out and cannot be enabled.

### Hands free

Enabled by default.

- Enabled: the transcript is sent through the existing guarded reply flow.
- Disabled: the transcript is inserted at the current caret position and is not sent.

Existing typed text is not replaced by a hands-free recording. If submission fails, the transcript is retained as a draft.

## Architecture

The recorder and UI depend on a small internal `SttProvider` interface. This PR ships only a Codex implementation; it does not add other providers or generic provider configuration.

The Codex provider:

- maintains one long-running `codex app-server` process;
- obtains short-lived authentication through its compatibility RPC;
- accepts only ChatGPT authentication, not API-key login;
- asks Codex to refresh after a 401 and retries exactly once;
- supports both current nested and older flat ChatGPT account ID claims;
- serializes transcription requests;
- rejects redirects;
- applies bounded timeouts and sanitized error reporting.

The transcription route uses Collie’s write-access guard. Provider availability uses the read-access guard.

## Deliberately out of scope

- Independent OAuth or token storage
- Reading or modifying `~/.codex/auth.json`
- OpenAI API-key configuration
- Generic endpoint/model settings
- Additional cloud or local STT providers
- Local inference
- Continuing a recording after its originating composer is unmounted

The provider boundary leaves room for future implementations without making them part of this change.

## Privacy and stability

Audio is sent from the bridge host to ChatGPT only after the user starts and completes a recording.

The Codex transcription endpoint is private and undocumented, and the app-server interface is experimental. Either may change upstream. The feature fails closed and becomes unavailable when the Codex integration cannot be used.

## Verification

Automated:

- Bridge test suite: 653 passing
- Codex STT compatibility suite after the account-claim fix: 8 passing
- Web test suite: 2,346 passing, 10 existing todos
- Focused composer suite: 5 passing
- Root and web TypeScript checks passing
- Production build passing
- Version consistency check passing

Manual:

- Tested with an existing Codex ChatGPT login on macOS
- Provider reported available through the running Collie bridge
- A real 2.2-second OGG recording was accepted and transcribed successfully
- Verified both hands-free submission and draft insertion behavior

## Fork versioning

Per the contribution guidance, this PR does not modify `package.json` versions or `CHANGELOG.md`.

Suggested changelog entry:

> **Codex speech input.** When an existing Codex ChatGPT login is available, the composer can record a reply and either send it through the guarded reply path or keep it as an editable draft, without Collie owning OAuth credentials.
