### PR TITLE
feat(nav-tray): F1–F12 behind an F keys disclosure

### DIFF
--- a/web/src/components/nav-tray.test.tsx
+++ b/web/src/components/nav-tray.test.tsx
@@ -368,6 +368,36 @@ describe("NavTray", () => {
     expect(onSend).toHaveBeenCalledExactlyOnceWith(["ctrl+d"]);
   });
 
+  // ── Function keys (#119): F1–F12 behind their own disclosure, same fire/stage path as base keys ──
+
+  it("F keys stay behind their disclosure; expanded, F7/F12 fire as bare keys", async () => {
+    const user = userEvent.setup();
+    const onSend = vi.fn();
+    render(<NavTray onSend={onSend} />);
+
+    // Collapsed by default — the tray's height is unchanged until you ask for F keys.
+    expect(screen.queryByRole("button", { name: "F7" })).toBeNull();
+    await user.click(screen.getByRole("button", { name: "F keys" }));
+
+    await user.click(screen.getByRole("button", { name: "F7" }));
+    await user.click(screen.getByRole("button", { name: "F12" }));
+    expect(onSend.mock.calls).toEqual([[["F7"]], [["F12"]]]);
+  });
+
+  it("an armed modifier composes with an F key — Ctrl + F7 stages ctrl+F7 for review", async () => {
+    const user = userEvent.setup();
+    const onSend = vi.fn();
+    render(<NavTray onSend={onSend} />);
+
+    await user.click(screen.getByRole("button", { name: "Ctrl" })); // arm → composing
+    await user.click(screen.getByRole("button", { name: "F keys" }));
+    await user.click(screen.getByRole("button", { name: "F7" }));
+
+    expect(onSend).not.toHaveBeenCalled(); // staged, not fired
+    await user.click(screen.getByRole("button", { name: "Send" }));
+    expect(onSend).toHaveBeenCalledExactlyOnceWith(["ctrl+F7"]);
+  });
+
   // ── Press echo: the tray used to be silent on success, and the mirror it deferred to can be ~2s
   //    behind, so a key press looked like it went nowhere. ────────────────────────────────────────
 

--- a/web/src/components/nav-tray.tsx
+++ b/web/src/components/nav-tray.tsx
@@ -57,6 +57,11 @@ const CONTROL: CtrlDef[] = [
 
 const DIGITS = ["1", "2", "3", "4", "5", "6", "7", "8", "9"];
 
+// F1–F12 — Herdr's send_keys grammar accepts them bare (HERDR_API.md), and harnesses bind them to
+// real actions (tmux windows, CLI hotkeys, agent-extension views like pi's CE Workflow: F7 opens
+// its orchestrator). Without buttons for them, a phone-only user has no route to any such keybind.
+const FN_KEYS = ["F1", "F2", "F3", "F4", "F5", "F6", "F7", "F8", "F9", "F10", "F11", "F12"];
+
 // Two views behind a segmented toggle: the keys pad (arrows/Esc, Tab/Space/Enter, modifiers, Ctrl
 // presets) and a phone-dialer digit grid. Digits were a cramped nine-across sliver row; on their own
 // tab they get large, thumb-sized targets. The tab is component state only (resets to "keys" each
@@ -67,6 +72,7 @@ type Tab = "keys" | "digits";
 export function NavTray({ onSend, onQueueChange, disabled }: NavTrayProps) {
   const [tab, setTab] = useState<Tab>("keys");
   const [ctrlOpen, setCtrlOpen] = useState(false);
+  const [fkeysOpen, setFkeysOpen] = useState(false);
   const { queue, mods, activeMods, composing, arm, press, pushBase, removeAt, clear, take } =
     useKeyQueue();
   const { pending, confirm, reset } = usePendingConfirm(); // danger ctrl two-tap (immediate path only)
@@ -306,6 +312,23 @@ export function NavTray({ onSend, onQueueChange, disabled }: NavTrayProps) {
                   );
                 })}
               </div>
+            )}
+          </div>
+          {/* Function keys (#119) — same collapsible shape as Presets: collapsed by default so the
+              tray doesn't grow, expanding to a 4×3 grid. They ride the ordinary navBtn path, so the
+              press echo, key-queue staging, and chords with armed modifiers (ctrl+F7, …) all come
+              for free — no special-casing. */}
+          <div>
+            <button
+              type="button"
+              onClick={() => setFkeysOpen((o) => !o)}
+              className="flex items-center gap-1 px-1 py-0.5 text-[11px] font-medium uppercase tracking-wide text-muted-foreground"
+            >
+              F keys
+              <ChevronDown className={cn("size-3 transition-transform", fkeysOpen && "rotate-180")} />
+            </button>
+            {fkeysOpen && (
+              <div className="mt-1 grid grid-cols-4 gap-1.5">{FN_KEYS.map((k) => navBtn(k, [k]))}</div>
             )}
           </div>
         </>


### PR DESCRIPTION
Closes #119.

## The gap

The mobile Keys tray had no function keys. Herdr's `pane.send_keys` grammar accepts `F1`…`F12` bare (HERDR_API.md), and harnesses bind them to real actions — e.g. the pi agent's CE Workflow extension registers F7 → Orchestrator, F8 → Microcompact, F9 → Fleet. From a physical keyboard those work; from the phone they were unreachable.

## The fix

An **F keys** disclosure in the Keys tab, mirroring the existing **Presets** collapsible:

- **Collapsed by default** — the tray's resting height is unchanged; you only pay for F keys when you ask for them.
- Expands to a **4×3 grid of F1–F12**, rendered through the ordinary `navBtn` path, so everything the tray already does comes for free:
  - press echo (fill + ✓ on accept),
  - key-queue staging when composing,
  - chords with armed modifiers (`ctrl+F7`, `alt+F3`, …) — all twelve keys also become reachable *as modifiers' bases*, not just bare.

## Tests

Two cases added to `nav-tray.test.tsx`, both green (33/33 in the file, `tsc --noEmit` clean):

- F keys stay behind the disclosure; expanded, F7/F12 fire as bare `["F7"]` / `["F12"]`.
- An armed Ctrl + F7 tap stages `ctrl+F7` for review instead of firing — the compose path applies to F keys like any base key.

## Notes

- Verified end-to-end on a live install first (a hand-patched F7/F8/F9 row): Collie → `pane.send_keys ["F7"]` → Herdr → pane → the extension's F7 handler. This PR is the generic version of that patch.
- The issue also floats a longer-term idea — user-defined key macros per install — which this deliberately doesn't attempt; the disclosure is the minimal generic fix.
