### PR TITLE
fix(contrib/windows): the supervised bridge runs headless, not in a terminal tab

### DIFF
--- a/contrib/windows/README.md
+++ b/contrib/windows/README.md
@@ -29,7 +29,9 @@ powershell.exe -NoProfile -ExecutionPolicy Bypass -File contrib\windows\collie-c
 ```
 
 `start` registers a Task Scheduler job (`herdr.collie`, override with `COLLIE_TASK_NAME`) that runs
-at logon, restarts after failures, and outlives Herdr. `status` prints the same readiness banner the
+at logon, restarts after failures, and outlives Herdr. It launches through `conhost --headless`
+so the bridge gets a pseudoconsole with no window: a bare `powershell.exe` action would surface
+on Windows 11 as a Windows Terminal tab, which kills the bridge when someone closes it. `status` prints the same readiness banner the
 POSIX script does; `logs` tails the bridge's stdout/stderr, including the pair preserved from the
 last crash. Config is the usual `.env` in the plugin config dir
 ([`.env.example`](../../.env.example) documents every key).

--- a/contrib/windows/collie-ctl.ps1
+++ b/contrib/windows/collie-ctl.ps1
@@ -223,7 +223,13 @@ function Register-CollieTask {
   $arguments = '-NoProfile -NonInteractive -ExecutionPolicy Bypass -File "{0}" -TaskConfigDir "{1}" -TaskSocketPath "{2}" _exec-bridge' -f $ctl, $script:ConfigDir, $script:SocketPath
   $identity = [Security.Principal.WindowsIdentity]::GetCurrent().Name
 
-  $action = New-ScheduledTaskAction -Execute $powershell -Argument $arguments -WorkingDirectory $script:PluginRoot
+  # No console, so the bridge is not a closable Windows Terminal tab; the launcher is still $powershell.
+  $conhost = Join-Path $env:SystemRoot "System32\conhost.exe"
+  $action = if (Test-Path -LiteralPath $conhost) {
+    New-ScheduledTaskAction -Execute $conhost -Argument ('--headless "{0}" {1}' -f $powershell, $arguments) -WorkingDirectory $script:PluginRoot
+  } else {
+    New-ScheduledTaskAction -Execute $powershell -Argument $arguments -WorkingDirectory $script:PluginRoot
+  }
   $trigger = New-ScheduledTaskTrigger -AtLogOn -User $identity
   $principal = New-ScheduledTaskPrincipal -UserId $identity -LogonType Interactive -RunLevel (Get-CollieTaskRunLevel)
   $settings = New-ScheduledTaskSettingsSet `

--- a/contrib/windows/collie-ctl.test.ps1
+++ b/contrib/windows/collie-ctl.test.ps1
@@ -148,6 +148,8 @@ COLLIE_HOST="127.0.0.1"
   Assert-Equal $script:registered.Principal.RunLevel "Limited" "task privilege"
   Assert-Equal $script:registered.Settings.ExecutionTimeLimit ([TimeSpan]::Zero) "task execution limit"
   Assert-Equal $script:registered.Settings.RestartCount 999 "task restart policy"
+  Assert-Contains $script:registered.Action.Execute "conhost.exe" "task launcher is headless"
+  Assert-Contains $script:registered.Action.Argument "--headless" "task action asks for no console"
 
   $env:COLLIE_TASK_RUN_LEVEL = "highest"
   function Test-Administrator { $true }


### PR DESCRIPTION
## What

`Register-CollieTask` registers the supervised bridge as `Execute = powershell.exe` under an
Interactive principal. That allocates a real console, and on Windows 11 the default console host is
Windows Terminal — so the bridge that is meant to run in the background shows up as a tab titled
`C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe`.

It isn't only cosmetic. The tab owns the launcher, so closing it kills the bridge; `RestartCount 999`
/ `RestartInterval PT1M` then brings both the bridge and the tab back about a minute later. From the
operator's side it reads as a terminal window that refuses to stay closed.

This wraps the same command in `conhost.exe --headless`, which runs it on a pseudoconsole with no
window at all.

## Why this shape

- **The launcher doesn't move.** `conhost --headless` execs powershell as its child, so the `$PID`
  that `_exec-bridge` writes to `$script:PidFile` is still the powershell process, the
  `Contains($controlScript)` / `Contains("_exec-bridge")` check in `Stop-RecordedCollieProcesses`
  still matches it, and `taskkill /PID … /T /F` still reaches bun through it. conhost exits with its
  child, so Task Scheduler's restart policy is unaffected.
- **Not `-WindowStyle Hidden`** — the console is allocated before the script can hide it, so it
  flashes.
- **Not the task's `Hidden` setting** — that hides the task from the Task Scheduler UI, not the
  window.
- **Not an S4U / session-0 principal.** It would also remove the window, but it changes where the
  bridge runs; the Interactive principal is load-bearing for reaching Herdr's socket in the user
  session and resolving `bun` from the user's PATH.
- Falls back to the previous bare action when `conhost.exe` is absent.

## Verified on

Windows 11 Pro 26200, Windows Terminal 1.24, Herdr plugin `herdr.collie`, PowerShell 5.1 launcher.
Before: `WindowsTerminal.exe → powershell.exe → bun.exe` with a visible tab. After:
`conhost.exe --headless → powershell.exe → bun.exe`, no window handle on any process in the chain,
bridge reachable as usual. `contrib\windows\collie-ctl.test.ps1` passes (`OK Windows lifecycle
tests`); two assertions added for the wrap.

## Notes

- Per `CLAUDE.md`, no version bump and no `CHANGELOG.md` entry — fork PR. Suggested line if you want
  one: `Fixed — Windows: the supervised bridge no longer opens a Windows Terminal tab (conhost --headless).`
- Happy to add an `.adr/` entry if you think "why not `-WindowStyle Hidden` / S4U" is the kind of
  question that will come back; I left the reasoning as a comment at the registration site instead.
