### PR TITLE
fix: the url verb honours COLLIE_PUBLIC_URL (0.32.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to Collie are recorded here. The format follows
 `version` in `herdr-plugin.toml`, `package.json`, and `web/package.json` (enforced by
 `scripts/check-version.sh`). See [`CLAUDE.md`](./CLAUDE.md) → *Versioning* for the bump policy.
 
+## [0.32.1] - 2026-08-23
+
+### Fixed
+
+- **`url` (and `status`/`qr`) honour `COLLIE_PUBLIC_URL`** instead of always inferring the bare tailnet name with no port (#122) (859610d)
+
 ## [0.32.0] - 2026-08-19
 
 ### Added

--- a/herdr-plugin.toml
+++ b/herdr-plugin.toml
@@ -1,6 +1,6 @@
 id = "herdr.collie"
 name = "Collie"
-version = "0.32.0"
+version = "0.32.1"
 min_herdr_version = "0.7.0"
 description = "Mobile web UI to monitor and reply to your agent herd, served over Tailscale"
 platforms = ["linux", "macos"]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "collie",
-  "version": "0.32.0",
+  "version": "0.32.1",
   "private": true,
   "license": "MIT",
   "description": "Collie — a mobile web UI to monitor and reply to your Herdr agent herd over Tailscale",

--- a/scripts/collie-ctl.sh
+++ b/scripts/collie-ctl.sh
@@ -179,6 +179,9 @@ self_dnsname() {
 }
 
 bridge_url() {
+  # An explicit COLLIE_PUBLIC_URL is the operator naming a front door Collie didn't publish —
+  # a reverse proxy, or a `tailscale serve` on a port that isn't 443. Nothing here can infer it.
+  if [ -n "${COLLIE_PUBLIC_URL:-}" ]; then echo "${COLLIE_PUBLIC_URL%/}"; return; fi
   local name; name="$(self_dnsname)"
   if [ -z "$name" ]; then echo "http://127.0.0.1:${PORT} (Tailscale name unavailable)"; return; fi
   if [ "$SERVE_MODE" = "http" ]; then echo "http://${name}:${PORT}"; else echo "https://${name}"; fi

--- a/scripts/collie-ctl.test.sh
+++ b/scripts/collie-ctl.test.sh
@@ -667,6 +667,27 @@ EOF
   assert_contains "$out" "tailnet front door isn't up"
 }
 
+# `url` must defer to an operator-named front door before inferring anything from Tailscale — issue
+# #122: it used to print the bare tailnet name with no port, ignoring COLLIE_PUBLIC_URL entirely.
+test_url_verb_honors_public_url() {
+  setup_case url
+  install_fake_tailscale
+
+  local out
+  out="$(COLLIE_PUBLIC_URL=https://host.example:9443 run_ctl url)" ||
+    fail "url failed with COLLIE_PUBLIC_URL set"
+  assert_eq "$out" "https://host.example:9443"
+
+  # A trailing slash is stripped, not doubled into whatever path handling follows.
+  out="$(COLLIE_PUBLIC_URL=https://host.example:9443/ run_ctl url)" ||
+    fail "url failed with a trailing slash"
+  assert_eq "$out" "https://host.example:9443"
+
+  # Unset: falls back to inferring the tailnet URL, as before.
+  out="$(run_ctl url)" || fail "url failed without COLLIE_PUBLIC_URL"
+  assert_contains "$out" "https://host.example"
+}
+
 # `bootout` doesn't promise to wait for the job to finish tearing down, and the bridge drains
 # connections on SIGTERM — so `restart` (and therefore `update`) can reach `bootstrap` while the old
 # job is still going, which launchd answers with "Bootstrap failed: 5: Input/output error". Unretried
@@ -1249,6 +1270,7 @@ test_launchd_agent_lifecycle
 test_launchd_status_line
 test_tailnet_acl_warning
 test_qr_subcommand
+test_url_verb_honors_public_url
 test_launchd_bootstrap_retries
 test_bun_resolution
 test_non_absolute_bun_never_reaches_path

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "collie-web",
-  "version": "0.32.0",
+  "version": "0.32.1",
   "private": true,
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
`bridge_url()` in `scripts/collie-ctl.sh` always inferred the bare tailnet name with no port, ignoring `COLLIE_PUBLIC_URL` entirely — this fixes it by returning the explicit URL (trailing slash stripped) first, which also brings `status` and `qr` in line since both call `bridge_url` on their non-skip-serve paths.

Fixes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)