### PR TITLE
feat(quick-dock): let the operator declare their own quick replies

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -57,6 +57,11 @@ COLLIE_SUBMIT_KEYS=Enter
 # Likewise your own preset chords: `keys.toml` next to this file, from `keys.toml.example`
 # (README → Your own key presets).
 
+# --- Quick-dock replies ---
+# And your own one-tap phrases: `quick-replies.toml` next to this file, from
+# `quick-replies.toml.example` (README → Your own quick replies). This is also where you replace
+# the shipped English phrases with another language.
+
 # --- Pane history (the agent's own session log) ---
 # On by default. This is the ONLY scrollback most agent panes can have: an agent TUI runs on the
 # terminal's alternate screen, which keeps no scrollback ring, so history is read from the log the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,6 +139,10 @@ the unit name; the Herdr action runs from anywhere.
   Ctrl presets on the panes they address (ADR 0018 again), and only those presets: the tray's
   keyboard is fixed. Both files share one reader (`bridge/operator-file.ts`) and one scope ladder
   (`web/src/lib/operator-scope.ts`); teach both, never one.
+- **`quick-replies.toml` is the third on that contract** — the operator's groups replace the Quick
+  dock's shipped phrases on the panes they address (ADR 0018 once more), shell panes included when
+  a row is scoped to them. Same reader, same scope ladder: the three files differ in grammar and
+  never in posture, so teach all three or none.
 - **PWA** via `vite-plugin-pwa` (`web/vite.config.ts`): manifest + `sw.js`, registered manually
   from `virtual:pwa-register` in `main.tsx` (bundled = CSP-safe). Install/SW need a **secure
   context** — over plain HTTP they no-op silently (Chrome insecure-origin flag, or HTTPS, to test).

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ public access, Collie isn't built for it. Read the
 - [Install](#install)
 - [First run — what you'll see](#first-run--what-youll-see)
 - [Configure](#configure) · [Your own slash commands](#your-own-slash-commands) ·
-  [Multi-session](#multi-session)
+  [Your own quick replies](#your-own-quick-replies) · [Multi-session](#multi-session)
 - [Dark mode / light mode](#dark-mode--light-mode)
 - [Commands](#commands)
 - [Manage & update](#manage--update)
@@ -336,6 +336,28 @@ is fixed and not configurable. Chords are herdr's spelling: `ctrl+c` (never `C-c
 `ctrl+F7`; `PageUp`/`Home`/`End`/`Delete` are not accepted. No restart — edits are live. Verify:
 open a pane, tap **Keys → Presets**, your buttons are there. Rejected row?
 `journalctl --user -u collie -n 20` names it and why.
+
+### Your own quick replies
+
+The Quick dock's one-tap phrases are yours to replace, in `quick-replies.toml` next to the other two:
+
+```bash
+cp quick-replies.toml.example "$(herdr plugin config-dir herdr.collie)/quick-replies.toml"
+```
+
+```toml
+[[replies]]
+scope = "claude"             # optional; omit for every pane
+title = "confirm"
+items = ["yes", "no"]        # sent verbatim, one per button
+```
+
+A pane your rows match shows only your groups, in place of the shipped ones
+([ADR 0018](./.adr/0018-operator-command-rows-replace-the-catalog.md)). The shipped phrases are
+English (`yes`, `commit and push`); this is the way to work in another language, or to give a
+harness that wants `approve` the word it wants. `scope = "shell"` reaches a plain shell pane, which
+otherwise gets only `y`/`n`. No restart — edits are live. Verify: open a pane, tap **Quick**, your
+groups are there. Rejected row? `journalctl --user -u collie -n 20` names it and why.
 
 ### Multi-session
 

--- a/bridge/config.ts
+++ b/bridge/config.ts
@@ -149,6 +149,11 @@ export interface Config {
    */
   keysFile: string;
   /**
+   * Where the operator's Quick-dock groups live — `quick-replies.toml`, the third sibling in the
+   * same dir, read the same way (bridge/operator-quick-replies.ts) and likewise never read here.
+   */
+  quickRepliesFile: string;
+  /**
    * Tailscale identity gate. If set, any request carrying a `Tailscale-User-Login` header
    * (injected by `tailscale serve`) must match this login — a mismatching tailnet user is
    * rejected. A request with no such header still passes (direct-loopback callers don't get one),
@@ -282,6 +287,7 @@ export function loadConfig(): Config {
     submitKeys: submitKeys.length ? submitKeys : ["Enter"],
     commandsFile: join(configDir, "commands.toml"),
     keysFile: join(configDir, "keys.toml"),
+    quickRepliesFile: join(configDir, "quick-replies.toml"),
     trustedUser: process.env.COLLIE_TRUSTED_USER ?? "",
     auditContent: envEnum("COLLIE_AUDIT_CONTENT", ["preview", "none"] as const, "preview"),
     deviceHeader: (process.env.COLLIE_DEVICE_HEADER ?? "").trim(),

--- a/bridge/operator-quick-replies.test.ts
+++ b/bridge/operator-quick-replies.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  createOperatorQuickReplies,
+  validateOperatorQuickReplies,
+} from "./operator-quick-replies.ts";
+import type { OperatorFileIo } from "./operator-file.ts";
+
+// The Quick dock's escape hatch: the operator's own groups, replacing the shipped English phrases
+// on the panes their rows address. Driven exactly like the keys.toml suite — the validator with
+// parsed TOML, the reader through a fake io.
+
+const quiet = () => {};
+
+/** Parse a TOML source the way the reader does, then validate it — the whole grammar in one call. */
+function rows(toml: string) {
+  return validateOperatorQuickReplies(Bun.TOML.parse(toml), quiet);
+}
+
+describe("validateOperatorQuickReplies", () => {
+  test("reads a group, scoped and unscoped", () => {
+    expect(
+      rows(`
+        [[replies]]
+        title = "confirm"
+        items = ["ja", "nein"]
+
+        [[replies]]
+        scope = "Claude"
+        title = "common"
+        items = ["weiter", "nochmal"]
+      `),
+    ).toEqual([
+      { title: "confirm", items: ["ja", "nein"] },
+      { agent: "claude", title: "common", items: ["weiter", "nochmal"] },
+    ]);
+  });
+
+  test("no file and no rows are both simply empty", () => {
+    expect(validateOperatorQuickReplies(undefined, quiet)).toEqual([]);
+    expect(validateOperatorQuickReplies(null, quiet)).toEqual([]);
+    expect(rows("")).toEqual([]);
+  });
+
+  test("a malformed row is dropped, the rest of the file survives", () => {
+    expect(
+      rows(`
+        [[replies]]
+        title = ""
+        items = ["x"]
+
+        [[replies]]
+        title = "no items"
+        items = []
+
+        [[replies]]
+        title = "not a string"
+        items = ["ok", 7]
+
+        [[replies]]
+        title = "blank item"
+        items = ["ok", "  "]
+
+        [[replies]]
+        title = "kept"
+        items = ["yes"]
+      `),
+    ).toEqual([{ title: "kept", items: ["yes"] }]);
+  });
+
+  test("an unusable scope drops the row rather than widening it to every pane", () => {
+    // Fail closed: reading a broken scope as "unscoped" would aim the row at panes the operator
+    // never addressed — the opposite of what typing a scope was for.
+    expect(
+      rows(`
+        [[replies]]
+        scope = ""
+        title = "confirm"
+        items = ["ja"]
+
+        [[replies]]
+        scope = 7
+        title = "common"
+        items = ["weiter"]
+      `),
+    ).toEqual([]);
+  });
+
+  test("items are trimmed", () => {
+    expect(rows(`[[replies]]\ntitle = "confirm"\nitems = ["  ja  "]`)).toEqual([
+      { title: "confirm", items: ["ja"] },
+    ]);
+  });
+
+  test("a redefined title wins in place, keeping the dock's order", () => {
+    expect(
+      rows(`
+        [[replies]]
+        title = "confirm"
+        items = ["first"]
+
+        [[replies]]
+        title = "common"
+        items = ["middle"]
+
+        [[replies]]
+        title = "confirm"
+        items = ["second"]
+      `),
+    ).toEqual([
+      { title: "confirm", items: ["second"] },
+      { title: "common", items: ["middle"] },
+    ]);
+  });
+
+  test("the same title under two scopes is two rows", () => {
+    expect(
+      rows(`
+        [[replies]]
+        title = "confirm"
+        items = ["global"]
+
+        [[replies]]
+        scope = "claude"
+        title = "confirm"
+        items = ["scoped"]
+      `),
+    ).toEqual([
+      { title: "confirm", items: ["global"] },
+      { agent: "claude", title: "confirm", items: ["scoped"] },
+    ]);
+  });
+
+  test("a replies key that is not an array costs the file, not a crash", () => {
+    expect(rows(`replies = "nope"`)).toEqual([]);
+  });
+});
+
+describe("createOperatorQuickReplies", () => {
+  /** A fake disk whose mtime and text the test drives. */
+  function fakeIo(state: { mtime: number | null; text: string; reads: number }): OperatorFileIo {
+    return {
+      mtime: async () => state.mtime,
+      read: async () => {
+        state.reads += 1;
+        return state.text;
+      },
+    };
+  }
+
+  test("re-reads only when the mtime moves", async () => {
+    const state = { mtime: 1, text: `[[replies]]\ntitle = "a"\nitems = ["x"]`, reads: 0 };
+    const read = createOperatorQuickReplies("/cfg/quick-replies.toml", fakeIo(state), quiet);
+    expect(await read()).toEqual([{ title: "a", items: ["x"] }]);
+    expect(await read()).toEqual([{ title: "a", items: ["x"] }]);
+    expect(state.reads).toBe(1);
+
+    state.text = `[[replies]]\ntitle = "b"\nitems = ["y"]`;
+    state.mtime = 2;
+    expect(await read()).toEqual([{ title: "b", items: ["y"] }]);
+    expect(state.reads).toBe(2);
+  });
+
+  test("a missing file is empty, not an error", async () => {
+    const state = { mtime: null, text: "", reads: 0 };
+    const read = createOperatorQuickReplies("/cfg/quick-replies.toml", fakeIo(state), quiet);
+    expect(await read()).toEqual([]);
+  });
+
+  test("a file that stops parsing keeps serving the last good rows", async () => {
+    const state = { mtime: 1, text: `[[replies]]\ntitle = "a"\nitems = ["x"]`, reads: 0 };
+    const read = createOperatorQuickReplies("/cfg/quick-replies.toml", fakeIo(state), quiet);
+    expect(await read()).toEqual([{ title: "a", items: ["x"] }]);
+
+    state.text = "[[replies]] this is not toml";
+    state.mtime = 2;
+    expect(await read()).toEqual([{ title: "a", items: ["x"] }]);
+  });
+});

--- a/bridge/operator-quick-replies.ts
+++ b/bridge/operator-quick-replies.ts
@@ -1,0 +1,135 @@
+import { createOperatorFileReader, diskIo, type OperatorFileIo } from "./operator-file.ts";
+import type { OperatorQuickReplyRow } from "./types.ts";
+
+// The operator's own Quick-dock groups, read from `quick-replies.toml` next to their `.env` — the
+// third sibling of `commands.toml` and `keys.toml`, down to the discovery rule and the mtime-checked
+// live reload (operator-file.ts owns all three).
+//
+// WHY THIS FILE EXISTS. The shipped dock is a list of English phrases ("yes", "commit and push"),
+// and web/src/lib/quick-replies.ts says as much: that list is content policy, not detection. An
+// operator whose harness prefers "approve" over "yes", or who simply works in another language, has
+// no route to either today — the palette and the tray both grew one, the dock did not.
+//
+// Replacement (not merge) is the resolution rule, for the reason ADR 0018 gives; resolution itself
+// lives client-side in `web/src/lib/quick-replies.ts`. This module only decides what a row IS.
+
+/** A parsed `quick-replies.toml` document, before a byte of it is believed. */
+interface QuickRepliesDocument {
+  replies?: unknown;
+}
+
+/**
+ * Turn a parsed TOML document into dock groups, dropping anything malformed with one warning line.
+ *
+ * Pure and total: it never throws and never reads a file, so the grammar is unit-testable without
+ * fs. Every rejection is a DROP of the offending row, never of the file — one typo'd row must not
+ * cost the operator the rest of their groups.
+ *
+ * ```toml
+ * [[replies]]
+ * scope = "claude"              # optional; omitted = addresses every pane
+ * title = "confirm"             # required; the group's heading, and its identity
+ * items = ["yes", "no"]         # required; sent verbatim, one per button
+ * ```
+ *
+ * Nothing is defaulted into existence: a row with no `title` or no usable `items` is a row that
+ * would render as a nameless or empty group, so it is dropped and said out loud instead.
+ */
+export function validateOperatorQuickReplies(
+  doc: QuickRepliesDocument | null | undefined,
+  warn = defaultWarn,
+): OperatorQuickReplyRow[] {
+  const rows = doc?.replies;
+  if (rows === undefined || rows === null) return [];
+  if (!Array.isArray(rows)) {
+    warn("`replies` must be an array of [[replies]] tables — ignoring the file's rows");
+    return [];
+  }
+  const out: OperatorQuickReplyRow[] = [];
+  const at = new Map<string, number>();
+  for (const raw of rows) {
+    if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+      warn("ignoring a row that is not a [[replies]] table");
+      continue;
+    }
+    const row = raw as Record<string, unknown>;
+    const title = typeof row.title === "string" ? row.title.trim() : "";
+    if (title === "") {
+      warn(`ignoring a row with no title: ${JSON.stringify(row.items)}`);
+      continue;
+    }
+    const items = readItems(row.items, title, warn);
+    if (items === null) continue;
+    let agent = "";
+    if (row.scope !== undefined) {
+      // Fail closed. Dropping an unusable scope would WIDEN the row to every pane — the opposite of
+      // what a scope was typed for.
+      if (typeof row.scope !== "string" || row.scope.trim() === "") {
+        warn(`ignoring "${title}" — scope must be a non-empty agent name`);
+        continue;
+      }
+      agent = row.scope.trim().toLowerCase();
+    }
+    const parsed: OperatorQuickReplyRow = {
+      ...(agent ? { agent } : {}),
+      title,
+      items,
+    };
+    // Identity is scope+title, matching keys.toml's scope+label: two groups sharing one heading on
+    // one pane would be two sections a thumb cannot tell apart. The later row wins IN PLACE, so
+    // correcting a group does not reshuffle the dock.
+    const key = `${agent} ${title}`;
+    const prev = at.get(key);
+    if (prev !== undefined) {
+      warn(`"${title}" redefined — the later row wins`);
+      out[prev] = parsed;
+      continue;
+    }
+    at.set(key, out.length);
+    out.push(parsed);
+  }
+  return out;
+}
+
+/** The row's `items` array, trimmed of blanks — or null (already warned) when nothing is left. */
+function readItems(value: unknown, title: string, warn: (message: string) => void): string[] | null {
+  if (!Array.isArray(value) || value.length === 0) {
+    warn(`ignoring "${title}" — items must be a non-empty array of strings`);
+    return null;
+  }
+  const items: string[] = [];
+  for (const entry of value) {
+    if (typeof entry !== "string") {
+      // Unlike a key chord, one bad item does not change what the others send — but a row is a
+      // group the operator composed, and silently serving a shorter one hides the typo. Drop the
+      // row so the warning is the only surprise.
+      warn(`ignoring "${title}" — ${JSON.stringify(entry)} is not a string`);
+      return null;
+    }
+    const item = entry.trim();
+    // A blank button would type nothing and submit — the one tap that looks harmless and is not.
+    if (item === "") {
+      warn(`ignoring "${title}" — an item is blank`);
+      return null;
+    }
+    items.push(item);
+  }
+  return items;
+}
+
+function defaultWarn(message: string): void {
+  console.warn(`[quick-replies] ${message}`);
+}
+
+/**
+ * A reader for the operator's `quick-replies.toml` — the same mtime cache, the same "no file is not
+ * an error" rule and the same hold-the-last-good-rows failure posture `commands.toml` and
+ * `keys.toml` get, because it is literally the same reader (operator-file.ts).
+ */
+export function createOperatorQuickReplies(
+  path: string,
+  io: OperatorFileIo = diskIo,
+  warn = defaultWarn,
+): () => Promise<OperatorQuickReplyRow[]> {
+  return createOperatorFileReader(path, validateOperatorQuickReplies, io, warn);
+}

--- a/bridge/server.test.ts
+++ b/bridge/server.test.ts
@@ -56,6 +56,7 @@ function cfg(overrides: Partial<Config> = {}): Config {
     submitKeys: ["Enter"],
     commandsFile: "/nope/commands.toml",
     keysFile: "/nope/keys.toml",
+    quickRepliesFile: "/nope/quick-replies.toml",
     trustedUser: "",
     auditContent: "preview",
     deviceHeader: "",

--- a/bridge/server.ts
+++ b/bridge/server.ts
@@ -9,6 +9,7 @@ import { computeEtag, gzipJsonResponse, notModified } from "./http-cache.ts";
 import type { NotifyPrefs, NotifyPrefsStore } from "./notify-prefs.ts";
 import { createOperatorCommands } from "./operator-commands.ts";
 import { createOperatorKeys } from "./operator-keys.ts";
+import { createOperatorQuickReplies } from "./operator-quick-replies.ts";
 import {
   DEFAULT_PROMPT_TAIL_LINES,
   verifyExpectedPrompt,
@@ -153,6 +154,8 @@ export function startServer(opts: {
   const operatorCommands = createOperatorCommands(cfg.commandsFile);
   // Its sibling, on the same contract: one reader, one mtime cache, keys.toml off the hot path.
   const operatorKeys = createOperatorKeys(cfg.keysFile);
+  // The third on that contract: the Quick dock's groups, quick-replies.toml off the hot path.
+  const operatorQuickReplies = createOperatorQuickReplies(cfg.quickRepliesFile);
   const journals = cfg.transcript ? buildJournalRegistry(cfg.journalRoots) : null;
   const transcripts = cfg.transcript ? new TranscriptStore() : null;
   /** Does this agent have a journal at all — the snapshot's History-affordance gate. */
@@ -306,6 +309,7 @@ export function startServer(opts: {
         // with no restart. The path is cfg's, never the request's.
         const mine = await operatorCommands();
         const myKeys = await operatorKeys();
+        const myReplies = await operatorQuickReplies();
         return json({
           push: push.enabled,
           vapidPublicKey: push.publicKey,
@@ -315,6 +319,8 @@ export function startServer(opts: {
           ...(mine.length > 0 ? { operatorCommands: mine } : {}),
           // Same omit-when-empty rule: an operator with no keys.toml ships the payload they had.
           ...(myKeys.length > 0 ? { operatorKeys: myKeys } : {}),
+          // And once more for quick-replies.toml.
+          ...(myReplies.length > 0 ? { operatorQuickReplies: myReplies } : {}),
         } satisfies BridgeConfig, req.headers.get("accept-encoding"));
       }
       if (pathname === "/api/subscribe" && req.method === "POST") {

--- a/bridge/types.ts
+++ b/bridge/types.ts
@@ -332,6 +332,24 @@ export interface OperatorKeyRow {
   danger: boolean;
 }
 
+/**
+ * One operator-declared Quick-dock group (a `[[replies]]` row in their `quick-replies.toml`). A
+ * pane any of these rows address shows them INSTEAD of the shipped groups; a pane none of them
+ * address keeps the shipped ones (ADR 0018, the same rule `commands.toml` and `keys.toml` follow).
+ *
+ * The shipped phrases are English, which is a content choice rather than a technical one — an
+ * operator working in another language, or one whose harness wants "approve" over "yes", has no
+ * route to that today.
+ */
+export interface OperatorQuickReplyRow {
+  /** Herdr agent name this applies to, lowercased. Omitted = every agent. */
+  agent?: string;
+  /** The group's heading, and its identity within one scope. */
+  title: string;
+  /** The literal strings sent — each is typed into the pane and submitted verbatim. */
+  items: string[];
+}
+
 /** GET /api/config — bridge capabilities and the build id (push setup + stale-cache detection). */
 export interface BridgeConfig {
   push: boolean;
@@ -342,6 +360,8 @@ export interface BridgeConfig {
   operatorCommands?: OperatorCommand[];
   /** The operator's own Keys-tray presets. Absent/empty when there is no `keys.toml`. */
   operatorKeys?: OperatorKeyRow[];
+  /** The operator's own Quick-dock groups. Absent/empty when there is no `quick-replies.toml`. */
+  operatorQuickReplies?: OperatorQuickReplyRow[];
 }
 
 /** Rank for triage ordering — lower sorts first ("NEEDS YOU" at the top). */

--- a/quick-replies.toml.example
+++ b/quick-replies.toml.example
@@ -1,0 +1,48 @@
+# Your own groups for Collie's Quick dock. Copy to your plugin config dir, next to `.env`:
+#   cp quick-replies.toml.example "$(herdr plugin config-dir herdr.collie)/quick-replies.toml"
+#
+# This file configures the one-tap replies behind the composer's Quick button. Each row is one
+# labelled group; each item is typed into the pane and submitted verbatim.
+#
+# On a pane your rows address, YOUR rows are the whole dock — the shipped groups are replaced, not
+# merged into (ADR 0018). A pane none of them address keeps them untouched, and this file with every
+# row commented out (as shipped) leaves every pane exactly as shipped.
+#
+# Edits are picked up live — no restart. Reload the page to see them.
+#
+# Fields: `title` (required, the group's heading and its identity), `items` (required, one or more
+# strings sent verbatim), `scope` (a herdr agent name — omit it and the row addresses every pane).
+#
+# `scope` takes an agent family: claude, codex, pi, opencode, omp, grok — or `shell` for a plain
+# shell pane, which by default gets only y/n.
+
+# The shipped dock, restated — start here and edit the phrases.
+# [[replies]]
+# title = "confirm"
+# items = ["yes", "no"]
+#
+# [[replies]]
+# title = "common"
+# items = ["continue", "commit and push", "retry", "skip"]
+
+# Working in another language? Replace the phrases; the harness reads them as prose either way.
+# [[replies]]
+# title = "bestätigen"
+# items = ["ja", "nein"]
+#
+# [[replies]]
+# title = "häufig"
+# items = ["weiter", "committe und pushe", "nochmal", "überspringen"]
+
+# A shell has no notion of continuing a turn, so it ships with just y/n. Scope a row to it when your
+# replacement should reach it too.
+# [[replies]]
+# scope = "shell"
+# title = "bestätigen"
+# items = ["j", "n"]
+
+# One harness that wants different words than the rest.
+# [[replies]]
+# scope = "codex"
+# title = "confirm"
+# items = ["approve", "reject"]

--- a/web/src/components/quick-actions.tsx
+++ b/web/src/components/quick-actions.tsx
@@ -5,6 +5,7 @@ import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { ECHO_DONE_MS, useActionEcho } from "@/hooks/use-action-echo";
 import type { EchoPhase } from "@/hooks/use-action-echo";
+import { useOperatorQuickReplies } from "@/lib/operator-config";
 import { quickRepliesFor } from "@/lib/quick-replies";
 
 interface QuickActionsContentProps {
@@ -84,7 +85,7 @@ export function QuickActionsContent({
   isShell,
   disabled,
 }: QuickActionsContentProps) {
-  const groups = quickRepliesFor(agent, isShell);
+  const groups = quickRepliesFor(agent, isShell, useOperatorQuickReplies());
   const echo = useActionEcho();
   const closeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 

--- a/web/src/lib/operator-config.ts
+++ b/web/src/lib/operator-config.ts
@@ -1,7 +1,7 @@
 import { useEffect, useSyncExternalStore } from "react";
 
 import { fetchConfig } from "@/lib/api";
-import type { OperatorCommand, OperatorKeyRow } from "@/lib/types";
+import type { OperatorCommand, OperatorKeyRow, OperatorQuickReplyRow } from "@/lib/types";
 
 // The operator's own rows — their `commands.toml` palette AND their `keys.toml` tray presets — read
 // from ONE /api/config call and held in module state. Both files ride the same request because both
@@ -25,6 +25,7 @@ import type { OperatorCommand, OperatorKeyRow } from "@/lib/types";
 
 let current: readonly OperatorCommand[] = [];
 let currentKeys: readonly OperatorKeyRow[] = [];
+let currentReplies: readonly OperatorQuickReplyRow[] = [];
 let inflight: Promise<void> | null = null;
 let loaded = false;
 const listeners = new Set<() => void>();
@@ -41,6 +42,7 @@ export function loadOperatorCommands(): Promise<void> {
     .then((cfg) => {
       current = cfg.operatorCommands ?? [];
       currentKeys = cfg.operatorKeys ?? [];
+      currentReplies = cfg.operatorQuickReplies ?? [];
       loaded = true;
       emit();
     })
@@ -59,6 +61,10 @@ export function getOperatorCommands(): readonly OperatorCommand[] {
 
 export function getOperatorKeys(): readonly OperatorKeyRow[] {
   return currentKeys;
+}
+
+export function getOperatorQuickReplies(): readonly OperatorQuickReplyRow[] {
+  return currentReplies;
 }
 
 export function subscribeOperatorConfig(cb: () => void): () => void {
@@ -85,10 +91,23 @@ export function useOperatorKeys(): readonly OperatorKeyRow[] {
   return useSyncExternalStore(subscribeOperatorConfig, getOperatorKeys, getOperatorKeys);
 }
 
+/** Reactive read of the Quick-dock groups. Same one-shot fetch, same contract. */
+export function useOperatorQuickReplies(): readonly OperatorQuickReplyRow[] {
+  useEffect(() => {
+    void loadOperatorCommands();
+  }, []);
+  return useSyncExternalStore(
+    subscribeOperatorConfig,
+    getOperatorQuickReplies,
+    getOperatorQuickReplies,
+  );
+}
+
 /** Test helper — reset module state between cases. */
 export function __resetOperatorCommands(): void {
   current = [];
   currentKeys = [];
+  currentReplies = [];
   inflight = null;
   loaded = false;
   listeners.clear();

--- a/web/src/lib/quick-replies.test.ts
+++ b/web/src/lib/quick-replies.test.ts
@@ -42,3 +42,46 @@ describe("quickRepliesFor", () => {
     }
   });
 });
+
+// The operator's own groups (their `quick-replies.toml`, ADR 0018): on a pane their rows address,
+// those rows ARE the dock.
+describe("quickRepliesFor with operator rows", () => {
+  const german = [{ title: "bestätigen", items: ["ja", "nein"] }];
+
+  it("replaces the shipped groups on a pane the rows address", () => {
+    expect(quickRepliesFor("claude", false, german)).toEqual(german);
+  });
+
+  it("leaves a pane untouched when no row addresses it", () => {
+    const scoped = [{ agent: "codex", title: "bestätigen", items: ["ja"] }];
+    expect(quickRepliesFor("claude", false, scoped)).toEqual(quickRepliesFor("claude", false));
+    expect(quickRepliesFor("codex", false, scoped)).toEqual([
+      { title: "bestätigen", items: ["ja"] },
+    ]);
+  });
+
+  it("reaches a shell too — an operator's language is not an agent-only choice", () => {
+    expect(quickRepliesFor("shell", true, german)).toEqual(german);
+    const shellOnly = [{ agent: "shell", title: "confirm", items: ["j", "n"] }];
+    expect(quickRepliesFor("shell", true, shellOnly)).toEqual([
+      { title: "confirm", items: ["j", "n"] },
+    ]);
+    // ...and a shell-scoped row must not leak onto an agent pane.
+    expect(quickRepliesFor("claude", false, shellOnly)).toEqual(quickRepliesFor("claude", false));
+  });
+
+  it("an empty list is exactly the shipped behaviour", () => {
+    expect(quickRepliesFor("claude", false, [])).toEqual(quickRepliesFor("claude", false));
+    expect(quickRepliesFor("shell", true, [])).toEqual(quickRepliesFor("shell", true));
+  });
+
+  it("a narrower row wins over an unscoped one, as everywhere else", () => {
+    const mixed = [
+      { title: "confirm", items: ["global"] },
+      { agent: "claude", title: "confirm", items: ["scoped"] },
+    ];
+    expect(quickRepliesFor("claude", false, mixed)).toEqual([
+      { title: "confirm", items: ["scoped"] },
+    ]);
+  });
+});

--- a/web/src/lib/quick-replies.ts
+++ b/web/src/lib/quick-replies.ts
@@ -13,6 +13,9 @@
 // is keyed per agent anyway so a real divergence (a harness that wants "approve" over "yes") is a
 // one-line addition rather than a restructuring.
 
+import { rowsFor } from "@/lib/operator-scope";
+import type { OperatorQuickReplyRow } from "@/lib/types";
+
 export interface QuickReplyGroup {
   /** Lowercase section label shown above the grid. */
   title: string;
@@ -49,7 +52,19 @@ const CATALOG: Record<string, readonly QuickReplyGroup[]> = {};
 export function quickRepliesFor(
   agent: string | undefined | null,
   isShell: boolean,
+  mine: readonly OperatorQuickReplyRow[] = [],
 ): readonly QuickReplyGroup[] {
+  // The operator's own groups REPLACE the shipped ones on a pane they address, never merge into
+  // them (ADR 0018) — the same rule `commands.toml` and `keys.toml` follow. A pane none of their
+  // rows reach is untouched, and an operator who declared nothing gets every pane exactly as
+  // shipped.
+  //
+  // A shell is scoped like any other pane: `scope = "shell"` addresses it, an unscoped row reaches
+  // it too. That is deliberate — an operator who replaces the dock in another language means the
+  // y/n pair as much as the rest of it, and a shell that silently kept English would be the one
+  // pane their file could not reach.
+  const aimed = rowsFor(mine, isShell ? "shell" : agent, (row) => row.title);
+  if (aimed.length > 0) return aimed.map((row) => ({ title: row.title, items: row.items }));
   if (isShell) return SHELL;
   if (agent != null && Object.hasOwn(CATALOG, agent)) return CATALOG[agent];
   return AGENT;

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -304,6 +304,21 @@ export interface OperatorKeyRow {
   danger?: boolean;
 }
 
+/**
+ * One operator-declared Quick-dock group (a `[[replies]]` table in their `quick-replies.toml`).
+ * Mirrors OperatorQuickReplyRow in bridge/types.ts. Resolved against the shipped groups by
+ * `quickRepliesFor()`, which hands a pane these rows instead of the shipped ones when any of them
+ * address it.
+ */
+export interface OperatorQuickReplyRow {
+  /** Herdr agent name this applies to, lowercased. Omitted = every agent. */
+  agent?: string;
+  /** The group's heading, and its identity within one scope. */
+  title: string;
+  /** The literal strings sent — each is typed into the pane and submitted verbatim. */
+  items: string[];
+}
+
 export interface BridgeConfig {
   push: boolean;
   vapidPublicKey: string;
@@ -313,6 +328,8 @@ export interface BridgeConfig {
   operatorCommands?: OperatorCommand[];
   /** The operator's own Keys-tray presets. Absent when there is no `keys.toml`. */
   operatorKeys?: OperatorKeyRow[];
+  /** The operator's own Quick-dock groups. Absent when there is no `quick-replies.toml`. */
+  operatorQuickReplies?: OperatorQuickReplyRow[];
 }
 
 /**


### PR DESCRIPTION
The Quick dock is the last operator surface with a hardcoded list. The palette got `commands.toml`, the Keys tray got `keys.toml` — the dock still ships fixed English phrases. `quick-replies.ts` says as much in its own header: that list is content policy, not detection.

So an operator working in another language has no route to it, and neither does one whose harness would rather be told `approve` than `yes`. I hit the first case: my agents read German, the dock did not.

This adds `quick-replies.toml` on the same contract as its two siblings: same reader (`operator-file.ts`), same scope ladder (`operator-scope.ts`), replace rather than merge per ADR 0018, live behind the mtime check.

```toml
[[replies]]
scope = "claude"          # optional; omit for every pane
title = "bestätigen"
items = ["ja", "nein"]
```

One deliberate decision worth your eye: **a shell pane is addressable**, via `scope = "shell"`. An unscoped row reaches it too. The shipped `y`/`n` is the right default, but an operator replacing the dock in another language means that pair as much as the rest, and a shell that silently stayed English would be the one pane their file could not reach. Easy to argue the other way; say so and I'll change it.

Without the file, the `/api/config` payload and the rendered dock are byte-identical to before.

I left `CHANGELOG.md` alone: `check-version.sh` ties the newest heading to a version number, and that bump is yours to make.

Eleven tests cover the bridge grammar. A bad scope drops its row rather than widening it to every pane, one malformed row costs the file none of its other groups, a redefined title wins in place, and when the file stops parsing the reader keeps serving the last rows that worked. Five more cover the client resolution. The full suites still pass (672 bridge, 3434 web), as do both typechecks and a production build.
