### PR TITLE
Fix Codex CLI first-class harness adapter

### DIFF
--- a/HERDR_API.md
+++ b/HERDR_API.md
@@ -84,6 +84,10 @@ the socket assumptions behind the design in [`ARCHITECTURE.md`](./ARCHITECTURE.m
     first and wrong hypothesis.
   - A `\n` inside `text` is delivered as a real newline keypress, not as pasted content. What the TUI
     does with it (submit vs. insert) is the harness's choice, not something the paste framing hides.
+  - A 2026-08-26 Herdr 0.8.0 Codex probe sent 1,123 synthetic ASCII bytes in one RPC and the
+    composer retained exactly the first 1,024. Two ordered sub-1,024-byte RPCs retained all 1,123.
+    The Codex guarded path therefore transports one logical input as Unicode-safe chunks; it still
+    verifies the complete logical message before sending Enter and never retries a partial write.
 - **An ack means "herdr took the bytes", never "the TUI acted on them".** Both `send_text` and
   `send_keys` return before the target program has read, let alone rendered, anything. So a
   successful RPC pair is not evidence a reply was delivered — a focused TUI dialog can swallow the

--- a/bridge/server.test.ts
+++ b/bridge/server.test.ts
@@ -536,6 +536,25 @@ describe("pane write prompt binding", () => {
     expect(client.texts).toEqual([["w1:p1", "hello"]]);
   });
 
+  test("matching expected_prompt submits an existing Codex draft without retyping it", async () => {
+    const client = new FakePaneClient();
+    client.text = "some output\n› ship it please\n\n  model · project · Context 99% left";
+    const { audit } = auditEntries();
+    const res = await replyPane(
+      client as unknown as HerdrClient,
+      cfg(),
+      "w1:p1",
+      request({ text: "", submit: true, expected_prompt: "› ship it please" }),
+      audit,
+      null,
+      "default",
+    );
+
+    expect(res.status).toBe(200);
+    expect(client.texts).toEqual([]);
+    expect(client.keys).toEqual([["w1:p1", cfg().submitKeys]]);
+  });
+
   test("stale expected_prompt returns prompt_changed and sends no keys", async () => {
     const client = new FakePaneClient();
     client.text = "Command finished";

--- a/web/src/components/agent-chat.test.tsx
+++ b/web/src/components/agent-chat.test.tsx
@@ -250,6 +250,15 @@ const STATUS_TEXT = [
   "  ← for agents",
 ].join("\n");
 
+const CODEX_SLASH_TEXT = [
+  "Codex output",
+  "\x1b[48;2;61;64;64m                                                            \x1b[0m",
+  "\x1b[48;2;61;64;64m\x1b[1m›\x1b[0m\x1b[48;2;61;64;64m /status                                             \x1b[0m",
+  "\x1b[48;2;61;64;64m                                                            \x1b[0m",
+  "  \x1b[1m\x1b[38;5;6m/status  show current session configuration and token usage\x1b[0m",
+  "  /\x1b[1mstatus\x1b[0mline  \x1b[2mconfigure which items appear in the status line\x1b[0m",
+].join("\n");
+
 // A minimal multi-question wizard tail (stepper header + current question) — enough for the REAL
 // wizard detector to lift it into the native WizardBlock inside AgentChat's mirror.
 const WIZARD_TEXT = [
@@ -419,6 +428,13 @@ describe("AgentChat — block-grammar scoping (an agent with no adapter)", () =>
     expect(strip.textContent).toBe("Local Llama (xhigh) · plan");
     expect(screen.queryByText(/Shift\+Tab:mode/)).toBeNull();
     expect(screen.queryByText("╭")).toBeNull();
+  });
+
+  it("keeps an exact Codex slash palette raw while treating its command as recoverable input", () => {
+    const codexAgent = { ...opencodeAgent, agent: "codex", paneId: "w8:p4" };
+    renderChat({ text: CODEX_SLASH_TEXT, agent: codexAgent });
+    expect(screen.getByText(/show current session configuration/).closest("pre")).not.toBeNull();
+    expect(screen.getByText(/configure which items appear/).closest("pre")).not.toBeNull();
   });
 });
 

--- a/web/src/components/composer.test.tsx
+++ b/web/src/components/composer.test.tsx
@@ -1445,6 +1445,59 @@ describe("Composer — terminal-draft preview", () => {
     await waitFor(() => expect(box).toHaveValue("")); // cleared after send
   });
 
+  it("Codex working draft Take over clears the queue composer before retyping and queues once", async () => {
+    const user = userEvent.setup();
+    const draft = "finish the current review";
+    const queuePane = (value: string) =>
+      [
+        "• Working (3s • esc to interrupt)",
+        "",
+        `› ${value}`,
+        "",
+        "  tab to queue message                                       100% context left",
+      ].join("\n");
+    let livePane = queuePane(draft);
+    const wire: Array<
+      { kind: "keys"; keys: string[] } | { kind: "reply"; text: string; submit: boolean }
+    > = [];
+    server.use(
+      http.get(/\/api\/pane\/[^/]+$/, () =>
+        HttpResponse.json({ paneId: "w1:p1", text: livePane, truncated: false, revision: 1 }),
+      ),
+      http.post(/\/api\/pane\/[^/]+\/keys$/, async ({ request }) => {
+        const body = (await request.json()) as { keys: string[] };
+        wire.push({ kind: "keys", keys: body.keys });
+        livePane = queuePane("Ask Codex to do anything");
+        return HttpResponse.json({ ok: true });
+      }),
+      http.post(/\/api\/pane\/[^/]+\/reply$/, async ({ request }) => {
+        const body = (await request.json()) as { text: string; submit: boolean };
+        wire.push({ kind: "reply", text: body.text, submit: body.submit });
+        livePane = body.submit ? queuePane("Ask Codex to do anything") : queuePane(body.text);
+        return HttpResponse.json({ ok: true });
+      }),
+    );
+    renderDraftHarness({ agent: "codex", terminalDraft: draft });
+    await screen.findByText(/draft in terminal/i);
+
+    await user.click(screen.getByRole("button", { name: /take over/i }));
+    const box = screen.getByPlaceholderText(/type a reply/i);
+    expect(box).toHaveValue(draft);
+    await user.click(screen.getByRole("button", { name: "Send" }));
+
+    await waitFor(() => expect(box).toHaveValue(""));
+    expect(wire).toHaveLength(3);
+    expect(wire[0]).toMatchObject({ kind: "keys" });
+    if (wire[0]?.kind === "keys") {
+      expect(wire[0].keys[0]).toBe("ctrl+k");
+      expect(wire[0].keys.slice(1).every((key) => key === "Backspace")).toBe(true);
+    }
+    expect(wire.slice(1)).toEqual([
+      { kind: "reply", text: draft, submit: false },
+      { kind: "reply", text: "", submit: true },
+    ]);
+  }, 15_000);
+
   it("read-only device: shows the preview and allows Take over (local copy), writing nothing to the terminal", async () => {
     const user = userEvent.setup();
     const keyCalls: string[] = [];

--- a/web/src/fixtures/panes/README.md
+++ b/web/src/fixtures/panes/README.md
@@ -35,8 +35,10 @@ and the observed commands were approved with no dialog painted.
 | `codex--trust-prompt.txt` | First screen in an untrusted directory: trust paragraph, `› 1. Yes, continue / 2. No, quit`, `Press enter to continue`. Digit 2 live-probed: quit immediately | `blocked` |
 | `codex--fresh-idle.txt` | Welcome banner box, tips, empty `› Ask Codex to do anything` composer, status row | `idle` |
 | `codex--draft.txt` | One-line draft on the `› ` row | `idle` |
+| `codex--custom-status-draft.txt` | **Synthetic structure fixture** for an operator-configured status row that omits `Context`: generic model/project/branch/rate/permission/session fields below a one-line draft. It contains no copied live Pane text, identity, path, UUID, quota, project, branch, message, or device value | `idle` |
 | `codex--draft-wrapped.txt` | Long draft word-wrapped onto a two-space-indented continuation row | `idle` |
 | `codex--working.txt` | `• Working (3s • esc to interrupt)` above a still-visible composer (Codex queues mid-turn) | `working` |
+| `codex--working-draft-queue-hint.txt` | **Synthetic structure fixture** derived from the official Codex TUI queue-footer snapshots and structurally checked against a disposable local Codex 0.149.1 Pane: a half-written `›` draft, bounded blank composer height, and trailing `tab to queue message … context left` chrome. The real probe used one blank row and the official snapshot uses six; tests cover 0–12. No live Pane content or identity is copied | `working` |
 | `codex--approval-exec.txt` | Exec approval: header, Environment/Reason, `$ command`, options `1. Yes, proceed (y)` / `2. …don't ask again… (p)` / `3. No… (esc)`, enter/esc footer. Digits 1 and 3 live-probed (1 ran the command, 3 rejected it — file verified absent); `y` probed too | `blocked` |
 | `codex--ask-fruit.txt` | `request_user_input` card: `Question 1/1` header, options with descriptions plus the auto-added `None of the above`, notes footer. Digit live-probed: answers AND submits | `blocked` |
 | `codex--ask-wizard-q1.txt` | Two-question set, `Question 1/2`; footer adds `←/→ to navigate questions`. Digit probed: answers and advances | `blocked` |

--- a/web/src/fixtures/panes/codex--custom-status-draft.txt
+++ b/web/src/fixtures/panes/codex--custom-status-draft.txt
@@ -1,0 +1,7 @@
+OpenAI Codex
+
+• Ready for the next instruction.
+
+› ship it please
+
+  model-example balanced · demo-project · feature/demo · weekly 80% left · Workspace Write · demo-session

--- a/web/src/fixtures/panes/codex--working-draft-queue-hint.txt
+++ b/web/src/fixtures/panes/codex--working-draft-queue-hint.txt
@@ -1,0 +1,10 @@
+• Working (3s • esc to interrupt)
+
+› finish the current review
+
+
+
+
+
+
+  tab to queue message                                       100% context left

--- a/web/src/lib/harness/codex.test.ts
+++ b/web/src/lib/harness/codex.test.ts
@@ -33,10 +33,12 @@ const PINNED = [
   "codex--ask-notes-focused.txt",
   "codex--ask-wizard-q1.txt",
   "codex--ask-wizard-q2.txt",
+  "codex--custom-status-draft.txt",
   "codex--draft-wrapped.txt",
   "codex--draft.txt",
   "codex--fresh-idle.txt",
   "codex--trust-prompt.txt",
+  "codex--working-draft-queue-hint.txt",
   "codex--working.txt",
 ];
 
@@ -71,7 +73,7 @@ function fixtureLines(name: string) {
 }
 
 describe("composerReady — the gate the reply path pre-flights on", () => {
-  it.each(["codex--fresh-idle.txt", "codex--draft.txt", "codex--draft-wrapped.txt", "codex--working.txt"])(
+  it.each(["codex--fresh-idle.txt", "codex--draft.txt", "codex--draft-wrapped.txt", "codex--working.txt", "codex--working-draft-queue-hint.txt", "codex--custom-status-draft.txt"])(
     "%s: the composer is on screen ⇒ true",
     (name) => {
       expect(codexAdapter.composerReady!(fixtureLines(name))).toBe(true);
@@ -95,7 +97,89 @@ describe("chrome", () => {
 
   it("extracts a one-line draft, and null for the placeholder", () => {
     expect(codexAdapter.extractInputDraft(fixtureLines("codex--draft.txt"))).toBe("hi there");
+    expect(codexAdapter.extractInputDraft(fixtureLines("codex--custom-status-draft.txt"))).toBe(
+      "ship it please",
+    );
+    expect(codexAdapter.extractInputDraft(fixtureLines("codex--working-draft-queue-hint.txt"))).toBe(
+      "finish the current review",
+    );
     expect(codexAdapter.extractInputDraft(fixtureLines("codex--fresh-idle.txt"))).toBeNull();
+  });
+
+  it("recovers a working draft above the official queue-message footer", () => {
+    const lines = fixtureLines("codex--working-draft-queue-hint.txt");
+    expect(locateComposer(lines)).not.toBeNull();
+    expect(codexAdapter.composerReady!(lines)).toBe(true);
+    expect(codexAdapter.extractInputDraft(lines)).toBe("finish the current review");
+    const status = codexAdapter.extractStatusLines(lines);
+    expect(status).toHaveLength(1);
+    expect(lineText(status[0]!).trim()).toMatch(/^tab to queue message/);
+  });
+
+  it("accepts live and official bounded queue-footer heights, but not an unbounded gap", () => {
+    const screen = (blankRows: number) =>
+      splitLines(
+        parseAnsi(
+          [
+            "› finish the current review",
+            ...Array.from({ length: blankRows }, () => ""),
+            "  tab to queue message                                       100% context left",
+          ].join("\n"),
+        ),
+      );
+
+    for (const blankRows of [0, 1, 6, 12]) {
+      expect(codexAdapter.composerReady!(screen(blankRows)), `${blankRows} blank rows`).toBe(true);
+      expect(codexAdapter.extractInputDraft(screen(blankRows))).toBe("finish the current review");
+    }
+    expect(codexAdapter.composerReady!(screen(13))).toBe(false);
+    expect(codexAdapter.extractInputDraft(screen(13))).toBeNull();
+  });
+
+  it("does not confuse Codex ask/question footers with the working queue footer", () => {
+    for (const name of ["codex--ask-fruit.txt", "codex--ask-wizard-q1.txt", "codex--ask-wizard-q2.txt", "codex--ask-notes-focused.txt"]) {
+      const lines = fixtureLines(name);
+      expect(locateComposer(lines), name).toBeNull();
+      expect(codexAdapter.composerReady!(lines), name).toBe(false);
+    }
+  });
+
+  it("recognises a bounded customized status row without assigning meaning to its fields", () => {
+    const lines = fixtureLines("codex--custom-status-draft.txt");
+    const box = locateComposer(lines);
+    expect(box).not.toBeNull();
+    expect(codexAdapter.composerReady!(lines)).toBe(true);
+    const status = codexAdapter.extractStatusLines(lines);
+    expect(status).toHaveLength(1);
+    expect(lineText(status[0]!)).not.toContain("Context");
+    expect(lineText(status[0]!)).toContain(" · ");
+  });
+
+  it("recognises the strict styled two-field renderer without accepting its plain-text lookalike", () => {
+    const styled = [
+      "› ship it please",
+      "",
+      "  \x1b[38;5;6mmodel-example\x1b[0m\x1b[2m · \x1b[0m\x1b[38;5;3mdemo-project\x1b[0m",
+    ].join("\n");
+    const plain = ["› ship it please", "", "  model-example · demo-project"].join("\n");
+    const wrongSeparatorStyle = [
+      "› ship it please",
+      "",
+      "  \x1b[38;5;6mmodel-example\x1b[0m · \x1b[38;5;3mdemo-project\x1b[0m",
+    ].join("\n");
+    const wrongFieldStyle = [
+      "› ship it please",
+      "",
+      "  model-example\x1b[2m · \x1b[0m\x1b[38;5;3mdemo-project\x1b[0m",
+    ].join("\n");
+
+    const styledLines = splitLines(parseAnsi(styled));
+    expect(locateComposer(styledLines)).not.toBeNull();
+    expect(codexAdapter.composerReady!(styledLines)).toBe(true);
+    expect(codexAdapter.extractInputDraft(styledLines)).toBe("ship it please");
+    expect(locateComposer(splitLines(parseAnsi(plain)))).toBeNull();
+    expect(locateComposer(splitLines(parseAnsi(wrongSeparatorStyle)))).toBeNull();
+    expect(locateComposer(splitLines(parseAnsi(wrongFieldStyle)))).toBeNull();
   });
 
   it("joins a wrapped draft back into the typed sentence", () => {
@@ -128,6 +212,34 @@ describe("chrome", () => {
     // The real row shape (two fields before the token) still locates.
     const real = ["› draft text", "", "  model x · /some/dir · Context 50% left"].join("\n");
     expect(locateComposer(splitLines(parseAnsi(real)))).not.toBeNull();
+  });
+
+  it("rejects ambiguous or unbounded customized status rows", () => {
+    const locate = (status: string) =>
+      locateComposer(splitLines(parseAnsi(["› draft text", "", status].join("\n"))));
+
+    expect(locate("model · project · branch")).toBeNull(); // no two-space status indent
+    expect(locate("   model · project · branch")).toBeNull(); // continuation/deeper indent
+    expect(locate("  model · project")).toBeNull(); // too few fields
+    expect(locate("  model ·  · branch")).toBeNull(); // empty field
+    expect(locate("  model · project · branch\tname")).toBeNull(); // terminal control
+    expect(locate(`  model · ${"x".repeat(161)} · branch`)).toBeNull(); // one field too long
+    expect(locate(`  ${Array.from({ length: 13 }, (_, i) => `field-${i}`).join(" · ")}`)).toBeNull();
+    expect(locate(`  ${Array.from({ length: 4 }, () => "x".repeat(130)).join(" · ")}`)).toBeNull();
+  });
+
+  it("keeps disabled, missing, torn, and transcript-only status evidence fail-closed", () => {
+    const screens = [
+      ["› draft text"],
+      ["› draft text", "", "  model · project"],
+      ["› earlier transcript echo", "• Working (3s • esc to interrupt)"],
+      ["  model · project · branch", "", "› draft text"],
+    ];
+    for (const screen of screens) {
+      const lines = splitLines(parseAnsi(screen.join("\n")));
+      expect(locateComposer(lines), screen.join(" | ")).toBeNull();
+      expect(codexAdapter.composerReady!(lines), screen.join(" | ")).toBe(false);
+    }
   });
 
   it("a draft that wraps past 8 rows is still a composer", () => {
@@ -164,8 +276,106 @@ describe("codexBuildBlocks", () => {
     }
   });
 
+  it("hides an empty input box and its status row", () => {
+    const lines = fixtureLines("codex--fresh-idle.txt");
+    const placeholder = lines
+      .flatMap((line) => line.segments)
+      .find((segment) => segment.text.includes("Ask Codex to do anything"));
+    expect(placeholder?.dim).toBe(true);
+    expect(codexAdapter.extractInputDraft(lines)).toBeNull();
+
+    const blocks = codexAdapter.buildBlocks(lines);
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]?.kind).toBe("raw");
+    if (blocks[0]?.kind !== "raw") return;
+    const visible = blocks[0].lines.map(lineText).join("\n");
+    expect(visible).not.toContain("› Ask Codex to do anything");
+    expect(visible).not.toContain("Context");
+    expect(
+      blocks[0].lines.at(-1)!.segments.every(
+        (segment) => segment.style.backgroundColor === undefined,
+      ),
+    ).toBe(true);
+  });
+
+  it("hides the whole empty three-row composer while Codex is working", () => {
+    const blocks = codexAdapter.buildBlocks(fixtureLines("codex--working.txt"));
+    expect(blocks[0]?.kind).toBe("raw");
+    if (blocks[0]?.kind !== "raw") return;
+    const visible = blocks[0].lines.map(lineText).join("\n");
+    expect(visible).toContain("Working");
+    expect(visible).not.toContain("› Ask Codex to do anything");
+    expect(visible).not.toContain("Context");
+    expect(
+      blocks[0].lines.at(-1)!.segments.every(
+        (segment) => segment.style.backgroundColor === undefined,
+      ),
+    ).toBe(true);
+  });
+
+  it("keeps the same words when they are an ordinary non-dim draft", () => {
+    const lines = splitLines(
+      parseAnsi(
+        [
+          "some output",
+          "",
+          "› Ask Codex to do anything",
+          "",
+          "  model-example · demo-project · Context 99% left",
+        ].join("\n"),
+      ),
+    );
+    expect(codexAdapter.extractInputDraft(lines)).toBe("Ask Codex to do anything");
+    const blocks = codexAdapter.buildBlocks(lines);
+    expect(blocks[0]?.kind).toBe("raw");
+    if (blocks[0]?.kind === "raw") {
+      expect(blocks[0].lines.map(lineText).join("\n")).toContain("› Ask Codex to do anything");
+    }
+  });
+
+  it.each([
+    ["codex--draft.txt", "hi there", "Context"],
+    ["codex--custom-status-draft.txt", "ship it please", "weekly 80% left"],
+    ["codex--working-draft-queue-hint.txt", "finish the current review", "tab to queue message"],
+  ])("%s: keeps a non-empty input box visible but removes the status/footer row", (name, draft, status) => {
+    const blocks = codexAdapter.buildBlocks(fixtureLines(name));
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]?.kind).toBe("raw");
+    if (blocks[0]?.kind !== "raw") return;
+    const visible = blocks[0].lines.map(lineText).join("\n");
+    expect(visible).toContain(`› ${draft}`);
+    expect(visible).not.toContain(status);
+    expect(lineText(blocks[0].lines.at(-1)!).trim()).toBe("");
+  });
+
+  it("preserves the background-painted row above a non-empty native composer", () => {
+    const lines = fixtureLines("codex--draft.txt");
+    const box = locateComposer(lines)!;
+    const blocks = codexAdapter.buildBlocks(lines);
+    expect(blocks[0]?.kind).toBe("raw");
+    if (blocks[0]?.kind !== "raw") return;
+    expect(blocks[0].lines[box.promptRow - 1]).toBe(lines[box.promptRow - 1]);
+    expect(
+      blocks[0].lines[box.promptRow - 1]!.segments.some(
+        (segment) => segment.style.backgroundColor !== undefined,
+      ),
+    ).toBe(true);
+  });
+
+  it("keeps every native blank composer row and removes exactly the queue footer", () => {
+    const lines = fixtureLines("codex--working-draft-queue-hint.txt");
+    const blocks = codexAdapter.buildBlocks(lines);
+    expect(blocks[0]?.kind).toBe("raw");
+    if (blocks[0]?.kind !== "raw") return;
+    const prompt = blocks[0].lines.findIndex((line) => lineText(line).startsWith("› "));
+    expect(prompt).toBeGreaterThanOrEqual(0);
+    expect(blocks[0].lines.slice(prompt + 1).filter((line) => lineText(line) === "")).toHaveLength(6);
+    expect(blocks[0].lines.map(lineText).join("\n")).not.toContain("tab to queue message");
+  });
+
   it("lifts the trust prompt with digit keys — both probed on the captured widget", () => {
-    const prompt = codexAdapter.buildBlocks(fixtureLines("codex--trust-prompt.txt")).find(
+    const blocks = codexAdapter.buildBlocks(fixtureLines("codex--trust-prompt.txt"));
+    const prompt = blocks.find(
       (b) => b.kind === "prompt-select",
     );
     expect(prompt?.kind).toBe("prompt-select");
@@ -173,6 +383,10 @@ describe("codexBuildBlocks", () => {
     expect(prompt.prompt.family).toBe("trust");
     expect(prompt.prompt.options.map((o) => o.label)).toEqual(["Yes, continue", "No, quit"]);
     expect(prompt.prompt.options.map((o) => o.keys)).toEqual([["1"], ["2"]]);
+    expect(blocks[0]?.kind).toBe("raw");
+    if (blocks[0]?.kind === "raw") {
+      expect(blocks[0].lines.map(lineText).join("\n")).toContain("Do you trust the contents");
+    }
   });
 
   it("lifts the exec approval from its one-shot Yes / reject pair only", () => {

--- a/web/src/lib/harness/codex/chrome.ts
+++ b/web/src/lib/harness/codex/chrome.ts
@@ -15,6 +15,7 @@ import {
   PLACEHOLDER,
   promptText,
   rstrip,
+  isQueueHintRow,
   skipBlanksUp,
 } from "./markers";
 
@@ -31,25 +32,79 @@ export interface ComposerBox {
 // Claude. A run deeper than this is not a composer (fail closed — locateComposer returns null).
 const MAX_DRAFT_ROWS = 100;
 
+// While a task runs, Codex lets the composer occupy several blank visual rows and replaces the
+// normal status summary with `tab to queue message …` at the bottom. Official TUI snapshots use six
+// blank rows for the ordinary height. Keep a little repaint/viewport slack, still far below the
+// draft-row bound and only on the exact fixed queue-footer path.
+const MAX_QUEUE_HINT_GAP = 12;
+
 // Continuation rows are exactly two-space-indented text. Deeper indents belong to dialogs and
 // transcript blocks; a `› ` or `• ` row is never a continuation.
 const CONTINUATION = /^ {2}\S/;
+const PROMPT_PREFIX = "› ";
+
+/** The exact placeholder text is still a valid thing an operator might deliberately type. Codex
+ * distinguishes its empty hint by painting the whole body dim, so presentation/extraction should
+ * use that renderer evidence too instead of discarding an ordinary non-dim draft with those words. */
+function isEmptyPlaceholder(line: StyledLine): boolean {
+  const text = rstrip(lineText(line));
+  if (promptText(text) !== PLACEHOLDER) return false;
+
+  const bodyStart = PROMPT_PREFIX.length;
+  const bodyEnd = bodyStart + PLACEHOLDER.length;
+  let offset = 0;
+  let sawBody = false;
+  for (const segment of line.segments) {
+    const next = offset + segment.text.length;
+    if (Math.max(offset, bodyStart) < Math.min(next, bodyEnd)) {
+      sawBody = true;
+      if (segment.dim !== true) return false;
+    }
+    offset = next;
+    if (offset >= bodyEnd) break;
+  }
+  return sawBody;
+}
+
+/** Codex's native composer is three rows tall in the captured renderer: one background-painted
+ * blank above the prompt, the prompt itself, and one or more layout rows below it. The parser is
+ * intentionally anchored at the prompt, so presentation separately claims that one upper row only
+ * when it is blank and carries the exact same background as the prompt. A plain transcript separator
+ * stays outside the composer. */
+function presentationStart(lines: StyledLine[], box: ComposerBox): number {
+  if (box.promptRow === 0) return box.promptRow;
+  const above = lines[box.promptRow - 1]!;
+  if (!isBlank(lineText(above))) return box.promptRow;
+  const background = above.segments.find(
+    (segment) => segment.style.backgroundColor !== undefined,
+  )?.style.backgroundColor;
+  if (background === undefined) return box.promptRow;
+  return lines[box.promptRow]!.segments.some(
+    (segment) => segment.style.backgroundColor === background,
+  )
+    ? box.promptRow - 1
+    : box.promptRow;
+}
 
 /** The composer at the buffer tail, or null (a dialog owns the screen, or the frame is torn). */
 export function locateComposer(lines: StyledLine[]): ComposerBox | null {
   const texts = lines.map((l) => rstrip(lineText(l)));
   const statusRow = lastNonBlankIndex(texts);
-  if (statusRow < 0 || !isStatusRow(texts[statusRow]!)) return null;
+  if (statusRow < 0 || !isStatusRow(texts[statusRow]!, lines[statusRow])) return null;
 
   // One blank row separates the prompt/draft run from the status row (every capture); above the
   // gap the run is CONTIGUOUS non-blank rows — wrapped-draft continuations under the `› ` prompt.
-  const top = skipBlanksUp(texts, statusRow - 1);
+  const top = skipBlanksUp(
+    texts,
+    statusRow - 1,
+    isQueueHintRow(texts[statusRow]!) ? MAX_QUEUE_HINT_GAP : undefined,
+  );
   if (top < 0) return null;
   for (let i = top; i >= 0 && top - i < MAX_DRAFT_ROWS; i--) {
     const t = texts[i]!;
     if (promptText(t) !== null) return { promptRow: i, statusRow };
     // A blank or foreign-shaped row inside the run means this status row is not under a composer.
-    if (isBlank(t) || !CONTINUATION.test(t) || isStatusRow(t)) return null;
+    if (isBlank(t) || !CONTINUATION.test(t) || isStatusRow(t, lines[i])) return null;
   }
   return null;
 }
@@ -62,6 +117,19 @@ export function stripChrome(lines: StyledLine[]): StyledLine[] {
   const box = locateComposer(lines);
   if (box === null) return lines;
   return lines.slice(0, box.promptRow);
+}
+
+/**
+ * Presentation policy, deliberately separate from composer detection and reply authorization:
+ * hide an empty native composer (Collie's own input replaces it), but keep a non-empty prompt/draft
+ * visible for diagnosis. Dialogs have no located composer and remain byte-for-byte raw.
+ */
+export function presentChrome(lines: StyledLine[]): StyledLine[] {
+  const box = locateComposer(lines);
+  if (box === null) return lines;
+  return extractInputDraft(lines) === null
+    ? lines.slice(0, presentationStart(lines, box))
+    : lines.slice(0, box.statusRow);
 }
 
 /** The status row, styled, for the strip above the phone composer. Empty when no composer. */
@@ -89,7 +157,9 @@ export function extractInputDraft(lines: StyledLine[]): string | null {
     parts.push(texts[i]!.trim());
   }
   const draft = parts.filter((p) => p !== "").join(" ");
-  if (draft === "" || draft === PLACEHOLDER) return null;
+  if (draft === "" || (draft === PLACEHOLDER && isEmptyPlaceholder(lines[box.promptRow]!))) {
+    return null;
+  }
   return draft;
 }
 
@@ -98,9 +168,16 @@ export function composerReady(lines: StyledLine[]): boolean {
   return locateComposer(lines) !== null;
 }
 
-/** The literal on-screen prompt row a destructive pre-clear sweep is bound to. */
+/** The literal on-screen prompt/draft run a destructive write is bound to. Ending at the last draft
+ * continuation keeps a wrapped message inside the bridge's bounded tail window; naming only the
+ * first `›` row would permanently 409 once six or more non-blank wrap rows sat beneath it. */
 export function composerPrompt(lines: StyledLine[]): string | null {
   const box = locateComposer(lines);
   if (box === null) return null;
-  return rstrip(lineText(lines[box.promptRow]!));
+  let end = box.statusRow;
+  while (end > box.promptRow + 1 && isBlank(lineText(lines[end - 1]!))) end--;
+  return lines
+    .slice(box.promptRow, end)
+    .map((line) => rstrip(lineText(line)))
+    .join("\n");
 }

--- a/web/src/lib/harness/codex/index.ts
+++ b/web/src/lib/harness/codex/index.ts
@@ -1,5 +1,6 @@
-// The Codex adapter. Chrome/status/draft are Tier 1: the boxless `› ` composer plus its
-// dot-separated status row are stripped from the mirror and re-surfaced natively. Interactive
+// The Codex adapter. Chrome/status/draft are Tier 1: the boxless `› ` composer remains visible in
+// the mirror for diagnosis, while its trailing status/footer row is stripped and re-surfaced
+// natively. Interactive
 // kinds with dated captures and notes (all under this directory): the folder-trust prompt
 // (`prompt-select`, family trust), exec approvals (`prompt-select`, family permission —
 // classified by row: the one-shot Yes and the reject become buttons, persistent rows never do),
@@ -12,55 +13,66 @@
 // the captured screen. Registered as `agent: "codex"`; variant folding belongs in
 // `canonicalAgent`, never here.
 
-import { trimTrailingBlank, type Block, type StyledLine } from "../../blocks";
+import type { Block, StyledLine } from "../../blocks";
 import type { HarnessAdapter } from "../types";
 import {
-  composerPrompt,
-  composerReady,
-  extractInputDraft,
+  composerPrompt as chromeComposerPrompt,
+  composerReady as chromeComposerReady,
+  extractInputDraft as extractChromeInputDraft,
   extractStatusLines,
-  stripChrome,
+  presentChrome,
 } from "./chrome";
 import { detectApprovalRegion } from "./approval";
 import { detectAskRegion } from "./ask";
 import { detectTrustRegion } from "./trust";
+import { codexDraftCarriesSend } from "./paste";
+import { slashComposerReady, slashInputDraft, slashPromptRegion } from "./slash";
+
+export function extractInputDraft(lines: StyledLine[]): string | null {
+  return extractChromeInputDraft(lines) ?? slashInputDraft(lines);
+}
+
+function composerReady(lines: StyledLine[]): boolean {
+  return chromeComposerReady(lines) || slashComposerReady(lines);
+}
+
+function composerPrompt(lines: StyledLine[]): string | null {
+  return chromeComposerPrompt(lines) ?? slashPromptRegion(lines);
+}
 
 export function codexBuildBlocks(lines: StyledLine[]): Block[] {
   const trust = detectTrustRegion(lines);
   if (trust) {
-    const before = trimTrailingBlank(lines.slice(0, trust.startLine));
-    const blocks: Block[] = [];
-    if (before.length > 0) blocks.push({ kind: "raw", lines: before });
-    blocks.push({ kind: "prompt-select", prompt: trust.model, lines: lines.slice(trust.startLine) });
-    return blocks;
+    return [
+      { kind: "raw", lines },
+      { kind: "prompt-select", prompt: trust.model, lines: lines.slice(trust.startLine) },
+    ];
   }
 
   const approval = detectApprovalRegion(lines);
   if (approval) {
-    const before = trimTrailingBlank(lines.slice(0, approval.startLine));
-    const blocks: Block[] = [];
-    if (before.length > 0) blocks.push({ kind: "raw", lines: before });
-    blocks.push({
-      kind: "prompt-select",
-      prompt: approval.model,
-      lines: lines.slice(approval.startLine),
-    });
-    return blocks;
+    return [
+      { kind: "raw", lines },
+      {
+        kind: "prompt-select",
+        prompt: approval.model,
+        lines: lines.slice(approval.startLine),
+      },
+    ];
   }
 
   const ask = detectAskRegion(lines);
   if (ask) {
-    const before = trimTrailingBlank(lines.slice(0, ask.startLine));
-    const blocks: Block[] = [];
-    if (before.length > 0) blocks.push({ kind: "raw", lines: before });
-    blocks.push({ kind: "prompt-select", prompt: ask.model, lines: lines.slice(ask.startLine) });
-    return blocks;
+    return [
+      { kind: "raw", lines },
+      { kind: "prompt-select", prompt: ask.model, lines: lines.slice(ask.startLine) },
+    ];
   }
 
-  return [{ kind: "raw", lines: stripChrome(lines) }];
+  return [{ kind: "raw", lines: presentChrome(lines) }];
 }
 
-export { extractStatusLines, extractInputDraft };
+export { extractStatusLines };
 
 export const codexAdapter: HarnessAdapter = {
   agent: "codex",
@@ -69,4 +81,5 @@ export const codexAdapter: HarnessAdapter = {
   extractInputDraft,
   composerReady,
   composerPrompt,
+  draftCarriesSend: codexDraftCarriesSend,
 };

--- a/web/src/lib/harness/codex/markers.ts
+++ b/web/src/lib/harness/codex/markers.ts
@@ -9,6 +9,7 @@
 // Pure functions, no I/O, no React.
 
 import { isBlank, lineText, type StyledLine } from "../../blocks";
+import type { AnsiSegment } from "../../ansi";
 
 // `lineText` / `isBlank` are properties of a StyledLine, not of any grammar, so they live in the
 // neutral core (lib/blocks.ts). Re-exported here so the Codex grammars keep their single import
@@ -30,16 +31,123 @@ export function rstrip(text: string): string {
 // leading fields keeps a transcript line that merely mentions a context percentage from
 // claiming the row (review repro: `model · Context 50% left` at column 0 must not match).
 //
-// KNOWN LIMIT: Codex's status line is operator-configurable (`tui.status_line`, including
-// `null` to disable it). A custom or disabled status line never matches, so the composer is
-// never located and the pane falls back to the raw mirror with replies refused — safe, but
-// this adapter's lift only engages on the DEFAULT status line.
+// Codex's status line is operator-configurable (`tui.status_line`, including `null`). The default
+// signature remains the strongest fast path. A configured row cannot be keyed on field NAMES,
+// though: every field is optional and an ordinary valid row may omit `Context` entirely. Its stable
+// renderer grammar is the two-space indent plus bounded, non-empty ` · `-separated fields. This is
+// only one link in locateComposer's evidence chain — the row must still be the buffer tail beneath
+// a bounded column-zero `›` prompt/draft run. A disabled line deliberately remains unsupported: a
+// lone transcript echo and a live empty composer would otherwise be indistinguishable.
 const STATUS_ROW = /^ {2}\S.* · .* · .*Context \d+% (left|used)\b/;
+
+const CUSTOM_STATUS_MIN_FIELDS = 3;
+const CUSTOM_STATUS_MAX_FIELDS = 12;
+const CUSTOM_STATUS_MAX_FIELD_CHARS = 160;
+const CUSTOM_STATUS_MAX_CHARS = 512;
+const CONTROL = /[\u0000-\u001f\u007f-\u009f]/;
+const QUEUE_HINT = /^ {2}tab to queue(?: message)?(?: · [^·\r\n]{1,160})?(?: {2,}\d+% context left)?$/;
+
+function codePointLength(value: string): number {
+  return [...value].length;
+}
+
+function isCustomStatusRow(text: string): boolean {
+  const row = rstrip(text);
+  if (
+    !row.startsWith("  ") ||
+    row.startsWith("   ") ||
+    CONTROL.test(row) ||
+    codePointLength(row) > CUSTOM_STATUS_MAX_CHARS
+  ) {
+    return false;
+  }
+
+  const fields = row.slice(2).split(" · ");
+  if (fields.length < CUSTOM_STATUS_MIN_FIELDS || fields.length > CUSTOM_STATUS_MAX_FIELDS) {
+    return false;
+  }
+  return fields.every(
+    (field) =>
+      field.length > 0 &&
+      field === field.trim() &&
+      codePointLength(field) <= CUSTOM_STATUS_MAX_FIELD_CHARS,
+  );
+}
+
+function hasNoStyle(segment: AnsiSegment, exceptDim = false): boolean {
+  return (
+    segment.fg === undefined &&
+    segment.bg === undefined &&
+    segment.bold !== true &&
+    (exceptDim || segment.dim !== true) &&
+    segment.italic !== true &&
+    segment.underline !== true &&
+    segment.strike !== true
+  );
+}
+
+function isStyledStatusField(segment: AnsiSegment, allowTrailingPadding = false): boolean {
+  const value = allowTrailingPadding ? rstrip(segment.text) : segment.text;
+  return (
+    segment.fg !== undefined &&
+    segment.bg === undefined &&
+    segment.bold !== true &&
+    segment.dim !== true &&
+    segment.italic !== true &&
+    segment.underline !== true &&
+    segment.strike !== true &&
+    value.length > 0 &&
+    value === value.trim() &&
+    codePointLength(value) <= CUSTOM_STATUS_MAX_FIELD_CHARS
+  );
+}
+
+/**
+ * The compact two-field renderer observed on older/custom Codex builds. Text alone is insufficient:
+ * `  model · Context 50% left` is an existing transcript-lookalike repro. The real widget paints
+ * four exact SGR segments: unstyled two-space indent, coloured field, dim separator, coloured field.
+ */
+function isStyledTwoFieldStatusRow(text: string, line: StyledLine | undefined): boolean {
+  const row = rstrip(text);
+  if (
+    line === undefined ||
+    line.segments.length !== 4 ||
+    CONTROL.test(row) ||
+    codePointLength(row) > CUSTOM_STATUS_MAX_CHARS
+  ) {
+    return false;
+  }
+  const [indent, first, separator, second] = line.segments;
+  return (
+    indent!.text === "  " &&
+    hasNoStyle(indent!) &&
+    isStyledStatusField(first!) &&
+    separator!.text === " · " &&
+    separator!.dim === true &&
+    hasNoStyle(separator!, true) &&
+    isStyledStatusField(second!, true) &&
+    rstrip(lineText(line)) === row
+  );
+}
+
+/** Codex replaces its normal status summary with this fixed running-composer footer while a draft
+ *  can be queued. The prefix is official TUI chrome, not a user status field; ask/question footers
+ *  use different wording (`tab to add notes`, `enter to submit…`) and remain dialogs. */
+export function isQueueHintRow(text: string): boolean {
+  const row = rstrip(text);
+  return !CONTROL.test(row) && codePointLength(row) <= CUSTOM_STATUS_MAX_CHARS && QUEUE_HINT.test(row);
+}
 
 /** True when the row could be the composer's status line. Never decisive alone — the composer
  *  is located by the prompt-row-above-status shape at the buffer tail, not by any single row. */
-export function isStatusRow(text: string): boolean {
-  return STATUS_ROW.test(rstrip(text));
+export function isStatusRow(text: string, line?: StyledLine): boolean {
+  const row = rstrip(text);
+  return (
+    STATUS_ROW.test(row) ||
+    isCustomStatusRow(row) ||
+    isStyledTwoFieldStatusRow(row, line) ||
+    isQueueHintRow(row)
+  );
 }
 
 // The `› ` prompt row. Column 0 — but transcript ECHOES of submitted messages paint the same
@@ -52,7 +160,7 @@ export function promptText(text: string): string | null {
   return m === null ? null : m[1]!;
 }
 
-/** The empty composer's placeholder, captured verbatim; a draft equal to it is no draft. */
+/** The empty composer's placeholder, captured verbatim; chrome also requires its dim renderer style. */
 export const PLACEHOLDER = "Ask Codex to do anything";
 
 /** Index of the last non-blank row in `texts`, or -1 when the buffer is all blank. */
@@ -68,11 +176,11 @@ export function lastNonBlankIndex(texts: string[]): number {
 const MAX_SECTION_GAP = 2;
 
 /** The nearest non-blank row at or above `i`, or -1 when the blank gap exceeds the bound. */
-export function skipBlanksUp(texts: string[], i: number): number {
+export function skipBlanksUp(texts: string[], i: number, maxGap = MAX_SECTION_GAP): number {
   let gap = 0;
   while (i >= 0 && isBlank(texts[i]!)) {
     i--;
-    if (++gap > MAX_SECTION_GAP) return -1;
+    if (++gap > maxGap) return -1;
   }
   return i;
 }

--- a/web/src/lib/harness/codex/paste.test.ts
+++ b/web/src/lib/harness/codex/paste.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  CODEX_INPUT_CHUNK_BYTES,
+  codexDraftCarriesSend,
+  codexInputChunks,
+} from "./paste";
+
+describe("Codex input chunks", () => {
+  it("round-trips text with every chunk below the byte boundary", () => {
+    const sent = `${"a".repeat(899)}🙂${"界".repeat(400)}`;
+    const chunks = codexInputChunks(sent);
+    expect(chunks.join("")).toBe(sent);
+    expect(chunks.length).toBeGreaterThan(1);
+    expect(chunks.every((chunk) => new TextEncoder().encode(chunk).length <= CODEX_INPUT_CHUNK_BYTES)).toBe(
+      true,
+    );
+  });
+
+  it("returns no write for empty text and does not split a short message", () => {
+    expect(codexInputChunks("")).toEqual([]);
+    expect(codexInputChunks("hello")).toEqual(["hello"]);
+  });
+});
+
+describe("Codex large-paste evidence", () => {
+  it("accepts only the exact Unicode character count", () => {
+    const sent = "x".repeat(1001);
+    expect(codexDraftCarriesSend(sent, "[Pasted Content 1001 chars]")).toBe(true);
+    expect(codexDraftCarriesSend(sent, "[Pasted Content 1000 chars]")).toBe(false);
+    expect(codexDraftCarriesSend(`${sent}🙂`, "[Pasted Content 1002 chars]")).toBe(true);
+    expect(codexDraftCarriesSend("x".repeat(1000), "[Pasted Content 1000 chars]")).toBe(false);
+    expect(codexDraftCarriesSend("", "[Pasted Content 0 chars]")).toBe(false);
+  });
+
+  it("accepts Codex's collision suffix but no surrounding or malformed text", () => {
+    const sent = "y".repeat(1006);
+    expect(codexDraftCarriesSend(sent, "[Pasted Content 1006 chars] #2")).toBe(true);
+    expect(codexDraftCarriesSend(sent, "[Pasted Content 1006 chars] #10")).toBe(true);
+    expect(codexDraftCarriesSend(sent, "prefix [Pasted Content 1006 chars]")).toBe(false);
+    expect(codexDraftCarriesSend(sent, "[Pasted Content 01006 chars]")).toBe(false);
+    expect(codexDraftCarriesSend(sent, "[Pasted Content 1006 chars] #1")).toBe(false);
+  });
+});

--- a/web/src/lib/harness/codex/paste.ts
+++ b/web/src/lib/harness/codex/paste.ts
@@ -1,0 +1,49 @@
+// Codex replaces a sufficiently large paste with one atomic token while keeping the full payload
+// internally: `[Pasted Content N chars]` (optionally suffixed ` #2`, ` #3`, … when equal-sized
+// placeholders coexist). This is public, documented Codex TUI behavior. The reply guard cannot find
+// the original text on screen in that state, so the exact Unicode character count is supplemental
+// evidence that THIS send reached the composer. It never accepts surrounding text or a mismatched
+// count, and it only widens evidence after a real Codex composer has already been located.
+
+const LARGE_PASTE_CHAR_THRESHOLD = 1000;
+const PASTED_CONTENT = /^\[Pasted Content ([1-9]\d*) chars\](?: #(?:[2-9]|[1-9]\d+))?$/;
+
+// Herdr 0.8.0's pane.send_text path accepted only the first 1,024 bytes of one live-probed write.
+// Stay below that boundary and below Codex's >1,000-character paste-placeholder threshold. Each
+// chunk remains a complete Unicode scalar sequence, so no UTF-8 character is split across RPCs.
+export const CODEX_INPUT_CHUNK_BYTES = 900;
+export const CODEX_CHUNK_SETTLE_MS = 35;
+
+function utf8Bytes(char: string): number {
+  const codePoint = char.codePointAt(0)!;
+  if (codePoint <= 0x7f) return 1;
+  if (codePoint <= 0x7ff) return 2;
+  if (codePoint <= 0xffff) return 3;
+  return 4;
+}
+
+export function codexInputChunks(text: string): string[] {
+  if (text === "") return [];
+  const chunks: string[] = [];
+  let parts: string[] = [];
+  let bytes = 0;
+  for (const char of text) {
+    const size = utf8Bytes(char);
+    if (parts.length > 0 && bytes + size > CODEX_INPUT_CHUNK_BYTES) {
+      chunks.push(parts.join(""));
+      parts = [];
+      bytes = 0;
+    }
+    parts.push(char);
+    bytes += size;
+  }
+  if (parts.length > 0) chunks.push(parts.join(""));
+  return chunks;
+}
+
+export function codexDraftCarriesSend(sent: string, draft: string): boolean {
+  const match = PASTED_CONTENT.exec(draft.trim());
+  if (match === null) return false;
+  const count = Number(match[1]);
+  return count > LARGE_PASTE_CHAR_THRESHOLD && count === [...sent].length;
+}

--- a/web/src/lib/harness/codex/slash.test.ts
+++ b/web/src/lib/harness/codex/slash.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+
+import { parseAnsi } from "../../ansi";
+import { splitLines } from "../../blocks";
+import {
+  locateSlashPalette,
+  slashComposerReady,
+  slashInputDraft,
+  slashPromptRegion,
+} from "./slash";
+
+const BG = "\x1b[48;2;61;64;64m";
+const RESET = "\x1b[0m";
+const SELECTED = "\x1b[1m\x1b[38;5;6m";
+
+function palette(
+  command = "/status",
+  options: ReadonlyArray<readonly [string, string]> = [
+    ["/status", "show current session configuration and token usage"],
+    ["/statusline", "configure which items appear in the status line"],
+  ],
+): string {
+  return [
+    "some output",
+    `${BG}                                                            ${RESET}`,
+    `${BG}\x1b[1m›${RESET}${BG} ${command}                                             ${RESET}`,
+    `${BG}                                                            ${RESET}`,
+    ...options.map(([name, description], index) =>
+      index === 0
+        ? `  ${SELECTED}${name}  ${description}${RESET}`
+        : `  /\x1b[1m${name!.slice(1, command.length)}${RESET}${name!.slice(command.length)}  \x1b[2m${description}${RESET}`,
+    ),
+  ].join("\n");
+}
+
+describe("Codex exact slash palette", () => {
+  it.each([
+    [
+      "/status",
+      [
+        ["/status", "show current session configuration and token usage"],
+        ["/statusline", "configure which items appear in the status line"],
+      ],
+    ],
+    ["/fast", [["/fast", "1.5x speed, increased usage"]]],
+    ["/model", [["/model", "choose a model and reasoning effort"]]],
+    ["/compact", [["/compact", "summarize the conversation"]]],
+    ["/new", [["/new", "start a new conversation"]]],
+    ["/help", [["/help", "show available commands"]]],
+  ] as const)("recognizes and binds %s", (command, options) => {
+    const lines = splitLines(parseAnsi(palette(command, options)));
+    expect(locateSlashPalette(lines)).toMatchObject({ command });
+    expect(slashComposerReady(lines)).toBe(true);
+    expect(slashInputDraft(lines)).toBe(command);
+    expect(slashPromptRegion(lines)).toContain(`› ${command}\n`);
+    expect(slashPromptRegion(lines)?.trimEnd().endsWith(options.at(-1)![1])).toBe(true);
+  });
+
+  it("rejects a partial filter even when its first result is selected", () => {
+    const lines = splitLines(parseAnsi(palette("/sta")));
+    expect(locateSlashPalette(lines)).toBeNull();
+  });
+
+  it("rejects prompt prose without the renderer signature or exact selected option", () => {
+    const plain = splitLines(
+      parseAnsi(["› /status", "", "  /status  show current status"].join("\n")),
+    );
+    expect(locateSlashPalette(plain)).toBeNull();
+
+    const wrong = splitLines(
+      parseAnsi(palette("/status", [["/statusline", "configure the status line"]])),
+    );
+    expect(locateSlashPalette(wrong)).toBeNull();
+  });
+
+  it("rejects missing renderer rows, unbounded options, and output below the palette", () => {
+    const valid = palette("/fast", [["/fast", "1.5x speed, increased usage"]]);
+    expect(
+      locateSlashPalette(
+        splitLines(
+          parseAnsi(valid.replace(`${BG}                                                            ${RESET}\n`, "")),
+        ),
+      ),
+    ).toBeNull();
+    expect(
+      locateSlashPalette(
+        splitLines(
+          parseAnsi(
+            palette(
+              "/fast",
+              Array.from({ length: 13 }, (_, index) => [
+                index === 0 ? "/fast" : `/fast-${index}`,
+                `option ${index}`,
+              ]),
+            ),
+          ),
+        ),
+      ),
+    ).toBeNull();
+    expect(locateSlashPalette(splitLines(parseAnsi(`${valid}\nordinary output`)))).toBeNull();
+  });
+});

--- a/web/src/lib/harness/codex/slash.ts
+++ b/web/src/lib/harness/codex/slash.ts
@@ -1,0 +1,121 @@
+// Codex slash commands temporarily replace the ordinary prompt/status tail with a filtered command
+// palette. A guarded reply that just typed `/status` therefore cannot use locateComposer: the status
+// row is intentionally gone, even though the exact text is still visible and Enter would submit the
+// selected command. This classifier accepts only the renderer-owned exact-command state: a
+// background-painted `› /command` input, its lower background row, and a first cyan/bold option whose
+// command equals the complete query. Partial filters and arbitrary prompt-shaped transcript prose
+// stay fail-closed.
+
+import type { AnsiSegment } from "../../ansi";
+import type { StyledLine } from "../../blocks";
+import { isBlank, lastNonBlankIndex, lineText, promptText, rstrip } from "./markers";
+
+const COMMAND = /^\/[a-z][a-z0-9_-]{0,63}$/;
+const OPTION = /^ {2}\/[a-z][a-z0-9_-]{0,63} {2,}\S.{0,480}$/;
+const MAX_OPTIONS = 12;
+const MAX_TRAILING_BLANKS = 2;
+
+export interface SlashPalette {
+  promptRow: number;
+  lastOptionRow: number;
+  command: string;
+}
+
+function unstyled(segment: AnsiSegment): boolean {
+  return (
+    segment.fg === undefined &&
+    segment.bg === undefined &&
+    segment.bold !== true &&
+    segment.dim !== true &&
+    segment.italic !== true &&
+    segment.underline !== true &&
+    segment.strike !== true
+  );
+}
+
+function backgroundBlank(line: StyledLine, background: string): boolean {
+  return (
+    isBlank(lineText(line)) &&
+    line.segments.length > 0 &&
+    line.segments.every((segment) => segment.bg === background)
+  );
+}
+
+function promptCommand(line: StyledLine): { command: string; background: string } | null {
+  const command = promptText(rstrip(lineText(line)));
+  if (command === null || !COMMAND.test(command) || line.segments.length !== 2) return null;
+  const [marker, body] = line.segments;
+  if (
+    marker?.text !== "›" ||
+    marker.bg === undefined ||
+    marker.bold !== true ||
+    marker.dim === true ||
+    body === undefined ||
+    body.bg !== marker.bg ||
+    body.bold === true ||
+    body.dim === true ||
+    rstrip(body.text) !== ` ${command}`
+  ) {
+    return null;
+  }
+  return { command, background: marker.bg };
+}
+
+function selectedExactOption(line: StyledLine, command: string): boolean {
+  if (line.segments.length !== 2) return false;
+  const [indent, selected] = line.segments;
+  if (
+    indent?.text !== "  " ||
+    !unstyled(indent) ||
+    selected === undefined ||
+    selected.fg === undefined ||
+    selected.bg !== undefined ||
+    selected.bold !== true ||
+    selected.dim === true
+  ) {
+    return false;
+  }
+  return new RegExp(`^${command.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")} {2,}\\S`).test(
+    rstrip(selected.text),
+  );
+}
+
+/** Exact slash palette at the buffer tail, or null. Pure; no pane access. */
+export function locateSlashPalette(lines: StyledLine[]): SlashPalette | null {
+  const texts = lines.map((line) => rstrip(lineText(line)));
+  const last = lastNonBlankIndex(texts);
+  if (last < 3 || lines.length - 1 - last > MAX_TRAILING_BLANKS) return null;
+
+  const firstCandidate = Math.max(1, last - MAX_OPTIONS - 1);
+  for (let promptRow = last - 2; promptRow >= firstCandidate; promptRow--) {
+    const prompt = promptCommand(lines[promptRow]!);
+    if (prompt === null) continue;
+    if (!backgroundBlank(lines[promptRow - 1]!, prompt.background)) continue;
+    if (!backgroundBlank(lines[promptRow + 1]!, prompt.background)) continue;
+
+    const firstOption = promptRow + 2;
+    const optionCount = last - firstOption + 1;
+    if (optionCount < 1 || optionCount > MAX_OPTIONS) continue;
+    if (!selectedExactOption(lines[firstOption]!, prompt.command)) continue;
+    if (!texts.slice(firstOption, last + 1).every((text) => OPTION.test(text))) continue;
+    return { promptRow, lastOptionRow: last, command: prompt.command };
+  }
+  return null;
+}
+
+export function slashInputDraft(lines: StyledLine[]): string | null {
+  return locateSlashPalette(lines)?.command ?? null;
+}
+
+export function slashComposerReady(lines: StyledLine[]): boolean {
+  return locateSlashPalette(lines) !== null;
+}
+
+export function slashPromptRegion(lines: StyledLine[]): string | null {
+  const palette = locateSlashPalette(lines);
+  if (palette === null) return null;
+  return lines
+    .slice(palette.promptRow, palette.lastOptionRow + 1)
+    .map((line) => rstrip(lineText(line)))
+    .join("\n");
+}

--- a/web/src/lib/harness/types.ts
+++ b/web/src/lib/harness/types.ts
@@ -39,22 +39,22 @@ export interface HarnessAdapter {
    */
   composerReady?(lines: StyledLine[]): boolean;
   /**
-   * The literal on-screen text of the composer's own prompt row — the region a DESTRUCTIVE write
-   * aimed at that row may be bound to. Null = no composer at the tail (the same screens
+   * Literal on-screen text from the composer's prompt/draft tail — the region a DESTRUCTIVE write
+   * aimed at that composer may be bound to. Null = no composer at the tail (the same screens
    * `composerReady` answers false about).
    *
    * The reply path's pre-clear sweep (`ctrl+k` + a run of Backspaces, lib/reply-action.ts) is the one
    * keystroke burst in the app that is authorised by a client-side read rather than by a dialog
-   * model, so it has no `signature` to carry. This is its equivalent: pass the row through as
+   * model, so it has no `signature` to carry. This is its equivalent: pass the region through as
    * `expected_prompt` and the bridge re-reads the pane immediately before `send_keys`, 409ing the
    * write if that row is no longer there (bridge/server.ts `checkPromptBinding`). That collapses the
    * window between "a read said composer" and "the keys land" from a network round-trip to two local
    * RPCs — the same mitigation `lib/dialog-guard.ts` gives every tap.
    *
    * OPTIONAL, and absence means the sweep goes out unbound, which is the pre-existing behaviour. The
-   * bridge accepts a region only if it still matches within the last few non-blank rows, so an
-   * adapter should return a row that sits AT the tail — one whose own harness paints many rows below
-   * it would refuse legitimate sweeps, which is worse than leaving this out.
+   * bridge accepts a region only if its match ends within the last few non-blank rows, so an adapter
+   * with a wrapping composer should include enough of the tail for the match to end there. A region
+   * whose final row sits too high would refuse legitimate sweeps, which is worse than leaving it out.
    */
   composerPrompt?(lines: StyledLine[]): string | null;
   /**

--- a/web/src/lib/reply-action.test.ts
+++ b/web/src/lib/reply-action.test.ts
@@ -13,16 +13,39 @@ const BOX_RULE = "─".repeat(40); // clears the 20-glyph border threshold in ha
 const paneWithDraft = (draft: string) => `some output\n${BOX_RULE}\n❯ ${draft}\n${BOX_RULE}`;
 // A focused permission dialog: no input box at the tail at all, so extractInputDraft sees nothing.
 const paneWithDialog = "Do you want to proceed?\n ❯ 1. Yes\n   2. No\n\n Esc to cancel";
+const CODEX_PALETTE_BG = "\x1b[48;2;61;64;64m";
+const CODEX_PALETTE_RESET = "\x1b[0m";
+
+function codexSlashPalette(command: "/status" | "/fast"): string {
+  const options =
+    command === "/status"
+      ? [
+          ["/status", "show current session configuration and token usage"],
+          ["/statusline", "configure which items appear in the status line"],
+        ]
+      : [["/fast", "1.5x speed, increased usage"]];
+  return [
+    "some output",
+    `${CODEX_PALETTE_BG}${" ".repeat(80)}${CODEX_PALETTE_RESET}`,
+    `${CODEX_PALETTE_BG}\x1b[1m›${CODEX_PALETTE_RESET}${CODEX_PALETTE_BG} ${command}${" ".repeat(60)}${CODEX_PALETTE_RESET}`,
+    `${CODEX_PALETTE_BG}${" ".repeat(80)}${CODEX_PALETTE_RESET}`,
+    ...options.map(([name, description], index) =>
+      index === 0
+        ? `  \x1b[1m\x1b[38;5;6m${name}  ${description}${CODEX_PALETTE_RESET}`
+        : `  /\x1b[1m${name.slice(1, command.length)}${CODEX_PALETTE_RESET}${name.slice(command.length)}  \x1b[2m${description}${CODEX_PALETTE_RESET}`,
+    ),
+  ].join("\n");
+}
 
 /** Record every reply POST, and let the fake pane's screen be swapped per test. */
 function harness(screen: () => string) {
-  const calls: Array<{ text: string; submit: boolean }> = [];
+  const calls: Array<{ text: string; submit: boolean; expected_prompt?: string }> = [];
   server.use(
     http.get(/\/api\/pane\/[^/]+$/, () =>
       HttpResponse.json({ paneId: "w1:p1", text: screen(), truncated: false, revision: 1 }),
     ),
     http.post(/\/api\/pane\/[^/]+\/reply$/, async ({ request }) => {
-      const body = (await request.json()) as { text: string; submit: boolean };
+      const body = (await request.json()) as (typeof calls)[number];
       calls.push(body);
       return HttpResponse.json({ ok: true });
     }),
@@ -200,6 +223,270 @@ describe("sendGuardedReply", () => {
       { text: "ship it please", submit: false },
       { text: "", submit: true },
     ]);
+  });
+
+  it("types, verifies, and submits once with a bounded customized Codex status row", async () => {
+    let calls: Array<{ text: string; submit: boolean }> = [];
+    const codexPane = (draft: string) =>
+      [
+        "some output",
+        "",
+        `› ${draft}`,
+        "",
+        "  model-example balanced · demo-project · feature/demo · weekly 80% left · Workspace Write · demo-session",
+      ].join("\n");
+    calls = harness(() =>
+      codexPane(calls.some((call) => !call.submit) ? "ship it please" : "Ask Codex to do anything"),
+    );
+
+    const out = await sendGuardedReply({
+      paneId: "w1:p1",
+      text: "ship it please",
+      agent: "codex",
+      ...instant,
+    });
+
+    expect(out).toEqual({ status: "sent" });
+    expect(calls).toEqual([
+      { text: "ship it please", submit: false },
+      { text: "", submit: true, expected_prompt: "› ship it please" },
+    ]);
+  });
+
+  it("withholds submit when a dialog replaces a customized Codex composer after typing", async () => {
+    let calls: Array<{ text: string; submit: boolean }> = [];
+    const composer = [
+      "some output",
+      "",
+      "› Ask Codex to do anything",
+      "",
+      "  model-example · demo-project · weekly 80% left · Workspace Write",
+    ].join("\n");
+    const dialog = [
+      "  Would you like to run the following command?",
+      "  $ synthetic-command",
+      "› 1. Yes, proceed (y)",
+      "  2. No, and tell Codex what to do differently (esc)",
+      "  Press enter to confirm or esc to cancel",
+    ].join("\n");
+    calls = harness(() => (calls.length === 0 ? composer : dialog));
+
+    const out = await sendGuardedReply({
+      paneId: "w1:p1",
+      text: "please do not approve anything",
+      agent: "codex",
+      ...instant,
+    });
+
+    expect(out.status).toBe("stalled");
+    expect(calls).toEqual([{ text: "please do not approve anything", submit: false }]);
+  });
+
+  it("verifies and submits once with Codex's strict styled two-field status row", async () => {
+    let calls: Array<{ text: string; submit: boolean }> = [];
+    const pane = (draft: string) =>
+      [
+        "some output",
+        "",
+        `› ${draft}`,
+        "",
+        "  \x1b[38;5;6mmodel-example\x1b[0m\x1b[2m · \x1b[0m\x1b[38;5;3mdemo-project\x1b[0m",
+      ].join("\n");
+    calls = harness(() =>
+      pane(calls.some((call) => !call.submit) ? "ship it please" : "Ask Codex to do anything"),
+    );
+
+    const out = await sendGuardedReply({
+      paneId: "w1:p1",
+      text: "ship it please",
+      agent: "codex",
+      ...instant,
+    });
+
+    expect(out).toEqual({ status: "sent" });
+    expect(calls).toEqual([
+      { text: "ship it please", submit: false },
+      { text: "", submit: true, expected_prompt: "› ship it please" },
+    ]);
+  });
+
+  it("chunks a long Codex input, verifies the complete draft, and binds submit", async () => {
+    const sent = "x".repeat(1001);
+    const firstRow = "x".repeat(500);
+    const secondRow = "x".repeat(501);
+    const calls: Array<{ text: string; submit: boolean; expected_prompt?: string }> = [];
+    const pane = [
+      "some output",
+      "",
+      `› ${firstRow}`,
+      `  ${secondRow}`,
+      "",
+      "  model-example · demo-project · Context 99% left",
+    ].join("\n");
+    server.use(
+      http.get(/\/api\/pane\/[^/]+$/, () =>
+        HttpResponse.json({ paneId: "w1:p1", text: pane, truncated: false, revision: 1 }),
+      ),
+      http.post(/\/api\/pane\/[^/]+\/reply$/, async ({ request }) => {
+        calls.push((await request.json()) as (typeof calls)[number]);
+        return HttpResponse.json({ ok: true });
+      }),
+    );
+
+    const out = await sendGuardedReply({ paneId: "w1:p1", text: sent, agent: "codex", ...instant });
+
+    expect(out).toEqual({ status: "sent" });
+    expect(calls).toEqual([
+      { text: "x".repeat(900), submit: false },
+      { text: "x".repeat(101), submit: false },
+      {
+        text: "",
+        submit: true,
+        expected_prompt: `› ${firstRow}\n  ${secondRow}`,
+      },
+    ]);
+  });
+
+  it("reports a later Codex chunk failure as partial delivery and never verifies or submits", async () => {
+    const sent = "x".repeat(1001);
+    const calls: Array<{ text: string; submit: boolean }> = [];
+    server.use(
+      http.get(/\/api\/pane\/[^/]+$/, () =>
+        HttpResponse.json({
+          paneId: "w1:p1",
+          text: "› Ask Codex to do anything\n\n  model · project · Context 99% left",
+          truncated: false,
+          revision: 1,
+        }),
+      ),
+      http.post(/\/api\/pane\/[^/]+\/reply$/, async ({ request }) => {
+        calls.push((await request.json()) as (typeof calls)[number]);
+        return calls.length === 1
+          ? HttpResponse.json({ ok: true })
+          : HttpResponse.json({ ok: false, error: "second chunk rejected" });
+      }),
+    );
+
+    const out = await sendGuardedReply({ paneId: "w1:p1", text: sent, agent: "codex", ...instant });
+
+    expect(out).toEqual({
+      status: "error",
+      error: "second chunk rejected",
+      textDelivered: true,
+    });
+    expect(calls).toEqual([
+      { text: "x".repeat(900), submit: false },
+      { text: "x".repeat(101), submit: false },
+    ]);
+  });
+
+  it("waits for two identical Codex prompt tails before binding Enter", async () => {
+    const calls: Array<{ text: string; submit: boolean; expected_prompt?: string }> = [];
+    let reads = 0;
+    const status = "  model-example · demo-project · Context 99% left";
+    const screens = [
+      ["› Ask Codex to do anything", "", status].join("\n"),
+      ["› ship it please", "", status].join("\n"),
+      ["› ship it", "  please", "", status].join("\n"),
+      ["› ship it", "  please", "", status].join("\n"),
+    ];
+    server.use(
+      http.get(/\/api\/pane\/[^/]+$/, () => {
+        const text = screens[Math.min(reads, screens.length - 1)]!;
+        reads += 1;
+        return HttpResponse.json({ paneId: "w1:p1", text, truncated: false, revision: reads });
+      }),
+      http.post(/\/api\/pane\/[^/]+\/reply$/, async ({ request }) => {
+        calls.push((await request.json()) as (typeof calls)[number]);
+        return HttpResponse.json({ ok: true });
+      }),
+    );
+
+    const out = await sendGuardedReply({
+      paneId: "w1:p1",
+      text: "ship it please",
+      agent: "codex",
+      ...instant,
+    });
+
+    expect(out).toEqual({ status: "sent" });
+    expect(reads).toBe(4);
+    expect(calls).toEqual([
+      { text: "ship it please", submit: false },
+      { text: "", submit: true, expected_prompt: "› ship it\n  please" },
+    ]);
+  });
+
+  it.each(["/status", "/fast"] as const)(
+    "submits exact Codex slash command %s only after its stable palette verifies it",
+    async (command) => {
+      const calls: Array<{ text: string; submit: boolean; expected_prompt?: string }> = [];
+      const idle = [
+        "› Ask Codex to do anything",
+        "",
+        "  model-example · demo-project · Context 99% left",
+      ].join("\n");
+      server.use(
+        http.get(/\/api\/pane\/[^/]+$/, () =>
+          HttpResponse.json({
+            paneId: "w1:p1",
+            text: calls.length === 0 ? idle : codexSlashPalette(command),
+            truncated: false,
+            revision: calls.length,
+          }),
+        ),
+        http.post(/\/api\/pane\/[^/]+\/reply$/, async ({ request }) => {
+          calls.push((await request.json()) as (typeof calls)[number]);
+          return HttpResponse.json({ ok: true });
+        }),
+      );
+
+      const out = await sendGuardedReply({
+        paneId: "w1:p1",
+        text: command,
+        agent: "codex",
+        ...instant,
+      });
+
+      const descriptions =
+        command === "/status"
+          ? [
+              "  /status  show current session configuration and token usage",
+              "  /statusline  configure which items appear in the status line",
+            ]
+          : ["  /fast  1.5x speed, increased usage"];
+      expect(out).toEqual({ status: "sent" });
+      expect(calls).toEqual([
+        { text: command, submit: false },
+        {
+          text: "",
+          submit: true,
+          expected_prompt: [`› ${command}`, "", ...descriptions].join("\n"),
+        },
+      ]);
+    },
+  );
+
+  it("gives Codex a longer read-only verification window without retyping", async () => {
+    let sleeps = 0;
+    const calls = harness(
+      () =>
+        ["› Ask Codex to do anything", "", "  model-example · demo-project · Context 99% left"].join(
+          "\n",
+        ),
+    );
+    const out = await sendGuardedReply({
+      paneId: "w1:p1",
+      text: "message that never appears",
+      agent: "codex",
+      sleep: async () => {
+        sleeps += 1;
+      },
+    });
+
+    expect(out.status).toBe("stalled");
+    expect(sleeps).toBe(15);
+    expect(calls).toEqual([{ text: "message that never appears", submit: false }]);
   });
 
   // omp paints an inline completion suggestion after the operator's text, in its own colour. It is

--- a/web/src/lib/reply-action.ts
+++ b/web/src/lib/reply-action.ts
@@ -21,6 +21,7 @@ import { fetchPane, sendReply } from "./api";
 import { parseAnsi } from "./ansi";
 import { splitLines } from "./blocks";
 import { adapterFor, type HarnessAdapter } from "./harness";
+import { CODEX_CHUNK_SETTLE_MS, codexInputChunks } from "./harness/codex/paste";
 import { POLL_ATTEMPTS, POLL_DELAY_MS, defaultSleep, type Sleep } from "./harness/guard";
 import { detectNoEchoPrompt } from "./no-echo";
 
@@ -48,6 +49,7 @@ export type ReplyOutcome =
 
 /** Minimum visible characters that must match before we believe the input box holds OUR text. */
 export const MIN_MATCH_CHARS = 8;
+const CODEX_POLL_ATTEMPTS = 16;
 
 const REGEXP_META = /[.*+?^${}()|[\]\\]/g;
 
@@ -222,7 +224,7 @@ export interface GuardedReplyArgs {
    * the guard re-confirms before typing.
    *
    * The argument carries the evidence FORWARD, not just the permission. `promptRegion` is the prompt
-   * row the adapter saw on the pane the pre-flight just read, and a caller that sends destructive
+   * tail the adapter saw on the pane the pre-flight just read, and a caller that sends destructive
    * keys must pass it to `api.sendKeys` as `expected_prompt`: an ordering guarantee alone cannot
    * bound the gap between the read and the keys, because that gap is a network round-trip and the
    * only limit on it is GET_TIMEOUT_MS. Binding hands the last word to the bridge, which re-reads
@@ -235,7 +237,7 @@ export interface GuardedReplyArgs {
 /** What the pre-flight's live read saw, handed to the caller's pre-type work. */
 export interface ComposerSeen {
   /**
-   * The composer's own prompt row, verbatim on screen, for binding a destructive write to it
+   * The composer's own prompt/draft tail, verbatim on screen, for binding a destructive write to it
    * (`api.sendKeys(..., expectedPrompt)`). `null` when the adapter has no `composerPrompt` — then the
    * write goes out unbound, which is the pre-existing behaviour and the reason the hook is optional.
    */
@@ -275,26 +277,46 @@ export async function sendGuardedReply(args: GuardedReplyArgs): Promise<ReplyOut
   const aborted = await runPreType?.();
   if (aborted) return aborted;
 
-  let typed;
-  try {
-    typed = await sendReply(args.paneId, args.text, false, args.session);
-  } catch (e) {
-    return { status: "error", error: message(e) };
-  }
-  if (!typed.ok) return { status: "error", error: typed.error };
-
   const sleep = args.sleep ?? defaultSleep;
+  const chunks = adapter.agent === "codex" ? codexInputChunks(args.text) : [args.text];
+  let textDelivered = false;
+  for (let index = 0; index < chunks.length; index++) {
+    let typed;
+    try {
+      typed = await sendReply(args.paneId, chunks[index]!, false, args.session);
+    } catch (e) {
+      return {
+        status: "error",
+        error: message(e),
+        ...(textDelivered ? { textDelivered: true } : {}),
+      };
+    }
+    if (!typed.ok) {
+      const partial = textDelivered || typed.textDelivered === true;
+      return {
+        status: "error",
+        error: typed.error,
+        ...(partial ? { textDelivered: true } : {}),
+      };
+    }
+    textDelivered = true;
+    if (index + 1 < chunks.length) await sleep(CODEX_CHUNK_SETTLE_MS);
+  }
+
   // The last screen a verification read actually saw, kept only so the stall below can be named. The
   // pre-flight catches almost every password prompt before a byte is typed, but not all of them: a
   // harness with no `composerReady`, and a `force` the operator armed against a mis-detected screen,
   // both arrive here having typed the secret into a prompt that will never echo it.
   let lastSeen: string | null = null;
-  for (let attempt = 0; attempt < POLL_ATTEMPTS; attempt++) {
+  let stableCodexPrompt: string | undefined;
+  const pollAttempts = adapter.agent === "codex" ? CODEX_POLL_ATTEMPTS : POLL_ATTEMPTS;
+  for (let attempt = 0; attempt < pollAttempts; attempt++) {
     // Read BEFORE the first sleep: pane.read is an on-demand live read, not a cached poll, so the
     // text is often already on screen by the time the type call returns. That saves a whole
     // POLL_DELAY_MS off the common path — the old blind flow always paid a fixed 350ms here.
     if (attempt > 0) await sleep(POLL_DELAY_MS);
     let draft: string | null = null;
+    let promptRegion: string | undefined;
     try {
       const fresh = await fetchPane(args.paneId, args.requestedLines, args.session);
       const lines = splitLines(parseAnsi(fresh.text));
@@ -308,18 +330,33 @@ export async function sendGuardedReply(args: GuardedReplyArgs): Promise<ReplyOut
       const composerVisible = adapter.composerReady?.(lines) ?? false;
       lastSeen = composerVisible ? null : detectNoEchoPrompt(lines);
       draft = adapter.extractInputDraft(lines);
+      promptRegion = adapter.composerPrompt?.(lines) ?? undefined;
     } catch {
+      stableCodexPrompt = undefined;
       continue; // transient read failure — the bounded loop is the timeout
     }
-    if (draftCarriesSend(args.text, draft)) return submitOnly(args);
+    const submitPrompt = adapter.agent === "codex" ? promptRegion : undefined;
     // The adapter gets a second look, and only a second look: a harness can SWALLOW what we typed and
     // paint a token of its own instead (Claude collapses anything past its paste threshold into
-    // `[Pasted text #N +M lines]`), so the box never holds our words and the match above structurally
-    // cannot succeed — the send stalls forever while every retry re-collapses. The adapter is the only
-    // thing that knows its harness's token and whether this one is consistent with THIS send
-    // (.adr/0010). It can only widen the evidence, never narrow it, so a harness without the
-    // capability is untouched.
-    if (draft !== null && adapter.draftCarriesSend?.(args.text, draft)) return submitOnly(args);
+    // `[Pasted text #N +M lines]`), so the box never holds our words and the generic match
+    // structurally cannot succeed. Only that harness knows whether its token fits THIS send
+    // (.adr/0010); the capability can widen evidence, never narrow it.
+    const verified =
+      draftCarriesSend(args.text, draft) ||
+      (draft !== null && adapter.draftCarriesSend?.(args.text, draft) === true);
+    if (verified) {
+      if (adapter.agent !== "codex") return submitOnly(args, submitPrompt);
+      // Codex can expose a matching windowed slice before its wrapped composer has finished
+      // repainting. Binding Enter to that first transient layout races the bridge's immediate read
+      // and returns prompt_changed even though the full draft arrived. Require two consecutive,
+      // byte-identical prompt/draft regions. The second read is read-only; text is never retyped.
+      if (submitPrompt !== undefined && submitPrompt === stableCodexPrompt) {
+        return submitOnly(args, submitPrompt);
+      }
+      stableCodexPrompt = submitPrompt;
+      continue;
+    }
+    stableCodexPrompt = undefined;
   }
 
   // The text never showed up on the input line. The likeliest cause is a dialog holding focus and
@@ -472,9 +509,12 @@ async function oneShot(args: GuardedReplyArgs): Promise<ReplyOutcome> {
  * bridge's configured submit keys (COLLIE_SUBMIT_KEYS). So the submit-key contract stays
  * server-owned and this whole guard needs no bridge change.
  */
-async function submitOnly(args: GuardedReplyArgs): Promise<ReplyOutcome> {
+async function submitOnly(
+  args: GuardedReplyArgs,
+  expectedPrompt?: string,
+): Promise<ReplyOutcome> {
   try {
-    const res = await sendReply(args.paneId, "", true, args.session);
+    const res = await sendReply(args.paneId, "", true, args.session, expectedPrompt);
     if (res.ok) return { status: "sent" };
     // The text is verifiably sitting in the input box and only the submit key failed — same shape as
     // the bridge's own partial-failure case. Tell the caller not to resend.


### PR DESCRIPTION
The original implementation of Codex CLI first-class adapter lacks compatibility, especially when user is using a customized status bar configuration. This is a fix of this issue. I also extends the Codex adapter to recognize customized composers, working/queued drafts, large inputs, stable wrapped prompts, and exact slash-command palettes while preserving Collie's fail-closed dialog safety.

To summarize the problem, when someone try to send message to a codex agent with **Collie 0.33.0+** and customized status bar, the message wouldn't be send and Collie would report such error:

> Message didn't reach the input box

The following content is generated by my agent and I hope would give you an overview of my PR.

---

## Original problem

Collie's Codex adapter identified a writable composer by looking for a tail `›` prompt followed by the default status line containing:

`Context N% left/used`

That assumption breaks when users customize `tui.status_line` and omit the `Context` field. The real composer remains visible, but `composerReady` and draft extraction fail, so
Collie may type the message and then permanently withhold Enter.

Several other valid Codex states had the same symptom:

- Compact two-field customized status lines were not recognized.
- While Codex was working, `tab to queue message` replaced the normal status line.
- Large input could appear as `[Pasted Content N chars]`.
- A large `pane.send_text` write could retain only its first 1,024 bytes.
- Wrapped input could reflow after the first successful read, invalidating prompt binding.
- Typing `/status`, `/fast`, or another slash command replaced the status line with the slash-command palette, making every slash command unverifiable.

## Supported features

### Customized Codex status lines

- Keeps the existing default `Context N% left/used` path.
- Accepts bounded customized status lines without assigning semantic meaning to their fields.
- Supports 3–12 bounded ` · `-separated fields.
- Supports compact two-field status lines only when they match Codex's strict ANSI renderer signature.
- Continues rejecting disabled, missing, malformed, overlong, torn, or transcript-like status rows.

### Working and queued drafts

- Recognizes the official `tab to queue message` footer while Codex is working.
- Recovers a half-written queued draft without including the footer.
- Preserves the native blank composer layout.
- Keeps request-user-input, wizard, notes, approval, and other dialogs outside the composer grammar.

### Composer presentation and draft recovery

- Treats the dim `Ask Codex to do anything` placeholder as an empty composer.
- Does not discard the same words when they are ordinary non-dim user input.
- Hides only an empty native composer.
- Keeps non-empty idle and working drafts visible for recovery and diagnosis.
- Removes only the located status/footer row from non-empty composers.
- Keeps native dialogs visible alongside their structured controls.

### Reliable guarded submit

- Splits Codex input into Unicode-safe chunks of at most 900 UTF-8 bytes.
- Never retries a partially delivered chunk sequence.
- Reports later chunk failures as partial delivery and withholds Enter.
- Accepts `[Pasted Content N chars]` only when `N` exactly matches the current message's Unicode scalar count.
- Gives Codex a longer bounded read-only verification window.
- Requires two consecutive identical verified prompt/draft tails before submit.
- Binds the final Enter to the complete stable prompt/draft region rather than only the first wrapped `›` row.
- Still emits at most one Enter and never retypes during verification.

### Exact slash-command palettes

- Recognizes a complete no-argument `/command` only when it exactly matches the first cyan/bold selected palette option.
- Supports commands such as `/status`, `/fast`, `/model`, `/compact`, `/new`, and `/help` through the same generic grammar.
- Keeps the palette visible as raw terminal output.
- Requires two stable palette reads and a final server-side prompt binding before Enter.
- Partial filters such as `/sta`, inline arguments, mismatched selections, renderer-free lookalikes, dialogs, and output below the palette remain fail-closed.

## Safety properties

This does not restore blind Enter submission.

The Codex adapter still requires independently bounded tail evidence before treating a screen as writable. A dialog transition, ambiguous status row, incomplete slash filter,
changed prompt region, or failed read causes Collie to withhold Enter.

Other harness adapters are unchanged.

## Verification

- Backend: 713 tests passed, plus lifecycle contracts.
- Web focused Codex/reply coverage: 867 tests passed, 6 existing todos.
- Complete Web suite: 3,499 tests passed, 18 existing todos.
- Both TypeScript configurations passed.
- Production PWA build passed.
- No version or CHANGELOG changes are included, following the repository's fork-PR policy.
