### PR TITLE
fix(codex): recognize v0.150.1 status row

### DIFF
--- a/web/src/lib/harness/codex.test.ts
+++ b/web/src/lib/harness/codex.test.ts
@@ -130,6 +130,19 @@ describe("chrome", () => {
     expect(locateComposer(splitLines(parseAnsi(real)))).not.toBeNull();
   });
 
+  it("locates the v0.150.1 status row with Context directly after the model", () => {
+    const screen = [
+      "› a message waiting to send",
+      "",
+      "  gpt-5.6-sol high · Context 68% left · main · +295 -1 · weekly 94% left",
+    ].join("\n");
+    const lines = splitLines(parseAnsi(screen));
+
+    expect(locateComposer(lines)).not.toBeNull();
+    expect(codexAdapter.composerReady!(lines)).toBe(true);
+    expect(codexAdapter.extractInputDraft(lines)).toBe("a message waiting to send");
+  });
+
   it("a draft that wraps past 8 rows is still a composer", () => {
     // The old bound of 8 stranded a phone wrap: locateComposer returned null and the pane
     // reported a dialog. 1 prompt + 8 continuations is 9 rows, the first case that failed.

--- a/web/src/lib/harness/codex/markers.ts
+++ b/web/src/lib/harness/codex/markers.ts
@@ -22,19 +22,24 @@ export function rstrip(text: string): string {
   return text.replace(/\s+$/, "");
 }
 
-// The status row under the composer: `  <model> · <cwd> · Context N% left[ · weekly N% left]`.
-// Everything before the Context token is OPAQUE — model names and directories change per
-// session and per release, and this file must never match them. What IS the grammar: the
-// two-space indent, at least two ` · `-separated fields before the token, and the token itself
-// (`left`, with `used` accepted — both spellings ship in the v0.149.0 binary). Requiring the
-// leading fields keeps a transcript line that merely mentions a context percentage from
-// claiming the row (review repro: `model · Context 50% left` at column 0 must not match).
+// The status row under the composer. v0.149.0 put at least two fields before Context:
+// `  <model> · <cwd> · Context N% left[ · weekly N% left]`. v0.150.1 moved Context directly
+// after the model and put branch/change fields after it:
+// `  <model> · Context N% left · <branch> · <changes> · weekly N% left`.
+//
+// Everything around the Context token is OPAQUE — model names, directories and branch names
+// change per session and release. What IS the grammar: the two-space indent, the model field,
+// the Context token (`left`, with `used` also accepted), plus either another field before Context
+// (the old shape) or one after it (the new shape). Requiring that extra field keeps a minimal
+// status-like prose row from claiming the composer; requiring the indent keeps a transcript line
+// that merely mentions a context percentage from claiming it at column 0.
 //
 // KNOWN LIMIT: Codex's status line is operator-configurable (`tui.status_line`, including
 // `null` to disable it). A custom or disabled status line never matches, so the composer is
 // never located and the pane falls back to the raw mirror with replies refused — safe, but
 // this adapter's lift only engages on the DEFAULT status line.
-const STATUS_ROW = /^ {2}\S.* · .* · .*Context \d+% (left|used)\b/;
+const STATUS_ROW =
+  /^ {2}\S.* · (?:(?:.* · )+Context \d+% (?:left|used)\b|Context \d+% (?:left|used)\b · \S)/;
 
 /** True when the row could be the composer's status line. Never decisive alone — the composer
  *  is located by the prompt-row-above-status shape at the buffer tail, not by any single row. */


### PR DESCRIPTION
## Problem

Codex CLI v0.150.1 moved `Context` directly after the model in the default status row. The Codex adapter still requires two fields before `Context`, so guarded replies type the message but never verify it and never send Enter.

## Fix

Accept both layouts while requiring an extra field on either side of `Context`. This preserves the false-positive guard.

## Verification

- Added a failing v0.150.1 regression test
- 3,437 frontend tests pass, with 18 existing todos
- 686 backend tests pass
- Control-script lifecycle suite passes
- Backend and frontend typechecks pass
- Production web bundle builds