### PR TITLE
test(cli): canonicalize temporary paths on macOS

### DIFF
--- a/scripts/collie-cli.test.sh
+++ b/scripts/collie-cli.test.sh
@@ -36,6 +36,7 @@ fi
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 BIN="${ROOT}/bin/collie"
 TMP_ROOT="$(mktemp -d)"
+TMP_ROOT="$(cd "$TMP_ROOT" && pwd -P)"
 # The real PATH, for the two sections that need genuine `git` / `mkdir` / `bash` alongside the fakes
 # (`build` and `update` drive real throwaway git repos and a real filesystem). Everything before them
 # runs on a scratch PATH only; the fake directory always comes FIRST, so a fake never loses to a real


### PR DESCRIPTION
## Summary

- Canonicalize the CLI test harness `TMP_ROOT` with physical `pwd -P`; strict command/CWD/argv assertions stay unchanged.
- No production code, version, or dependency changes.

## Root cause

On macOS, `/var` resolves to `/private/var`; `mktemp -d` returns logical `/var/folders/...`, while a Bun-spawned shell's `$PWD` reports physical `/private/var/folders/...`. Raw equality fails despite the same directory and correct command order and arguments.

## Solution rationale

Canonicalize the scratch root once before deriving fixtures, aligning the path vocabulary at the test boundary rather than changing production behavior or weakening assertions. This follows existing upstream portability practice.

## Validation

- On macOS, the former strict build/CWD assertion passed and the suite progressed to the unrelated final beacon section.
- `bun test ./bridge ./cli ./scripts`: 3,201 passed.
- `scripts/collie-ctl.test.sh`: passed.
- Web: 3,844 passed, 18 todo under the Node 26 compatibility option `NODE_OPTIONS=--no-experimental-webstorage`.
- Lint, root and web typechecks, version gates, and the production build passed.
- The final macOS beacon assertion remains an unrelated Linux `/proc` limitation; this is not a claim that the complete CLI shell suite is green on macOS.
