### PR TITLE
fix(codex): recognize dim status suffix

### DIFF
--- a/web/src/lib/harness/codex.test.ts
+++ b/web/src/lib/harness/codex.test.ts
@@ -297,6 +297,26 @@ describe("the styled status-row acceptor fails closed", () => {
     expect(isStatusRow(text, line)).toBe(true);
   });
 
+  it("accepts Codex's dim final status field", () => {
+    // Current Codex paints the final collaboration-mode field together with its separator:
+    // `...<coloured cwd><dim> · Main [default]</dim>`. This is the live shape that left Collie's
+    // composer visible but made the reply pre-flight report that no input box was on screen.
+    const { text, line } = row(
+      `  ${FG}gpt-5.6-sol medium${OFF}${SEP}${FG2}/tmp/project${OFF}${DIM} · Main [default]${OFF}`,
+    );
+    expect(isStatusRow(text, line)).toBe(true);
+  });
+
+  it("accepts the dim suffix only after two painted fields and only at the end", () => {
+    const tooEarly = row(`  ${FG}model${OFF}${DIM} · Main [default]${OFF}`);
+    expect(isStatusRow(tooEarly.text, tooEarly.line)).toBe(false);
+
+    const notFinal = row(
+      `  ${FG}model${OFF}${SEP}${FG2}/dir${OFF}${DIM} · Main [default]${OFF}${SEP}${FG}extra${OFF}`,
+    );
+    expect(isStatusRow(notFinal.text, notFinal.line)).toBe(false);
+  });
+
   it("refuses the same text with no styling at all", () => {
     const { text, line } = row("  gpt-5.6-sol default · /tmp/collie-codex-sandbox");
     expect(isStatusRow(text, line)).toBe(false);

--- a/web/src/lib/harness/codex/markers.ts
+++ b/web/src/lib/harness/codex/markers.ts
@@ -45,9 +45,11 @@ export function rstrip(text: string): string {
 // STATUS_ROW stays as the fast path for rows that still carry `Context`, and it is the ONLY
 // text-shaped acceptor. The styled acceptor keys on RENDERER PAINT — an unstyled two-space
 // indent, coloured non-dim fields, and dim ` · ` separators — and never on field names, because
-// field names are exactly the part the operator configures. A text-only lookalike pasted or
-// echoed into the transcript (`  model · Context 50% left` typed by hand, or prose that happens
-// to contain ` · `) carries no SGR at all, so it is still refused.
+// field names are exactly the part the operator configures. Current Codex may paint one final
+// low-priority field together with its separator as a single dim segment (` · Main [default]`);
+// that suffix is accepted only after two ordinary coloured fields and only at the end. A text-only
+// lookalike pasted or echoed into the transcript (`  model · Context 50% left` typed by hand, or
+// prose that happens to contain ` · `) carries no SGR at all, so it is still refused.
 //
 // Still unsupported: a DISABLED status line (`tui.status_line = null`). There is then no row
 // under the prompt to anchor on, and the rows that remain are transcript. Anchoring the composer
@@ -86,6 +88,16 @@ function isSeparatorSegment(segment: AnsiSegment): boolean {
   return segment.fg === undefined && segment.bg === undefined && segment.bold !== true;
 }
 
+/** One final low-priority field that Codex paints in the same dim segment as its separator. */
+function isDimSuffixFieldSegment(segment: AnsiSegment): boolean {
+  if (!segment.text.startsWith(STATUS_SEPARATOR)) return false;
+  const field = segment.text.slice(STATUS_SEPARATOR.length);
+  if (field.length === 0 || field !== field.trim()) return false;
+  if (CONTROL_CHARS.test(field) || codePointCount(field) > MAX_STATUS_FIELD_CHARS) return false;
+  if (segment.dim !== true) return false;
+  return segment.fg === undefined && segment.bg === undefined && segment.bold !== true;
+}
+
 /** The unstyled two-space indent Codex opens the row with. */
 function isIndentSegment(segment: AnsiSegment): boolean {
   if (segment.text !== STATUS_INDENT) return false;
@@ -114,8 +126,9 @@ function foldTrailingPadding(segments: AnsiSegment[]): AnsiSegment[] | null {
 /**
  * The 0.150.1 default status row, recognised by its PAINT. All of these must hold, or the row is
  * refused: the styled line must be the same row as `text`; the segments must read as an unstyled
- * two-space indent then `field (sep field)*`; and the field count must stay in bounds. Prose that
- * happens to contain ` \u00b7 ` fails on the paint, which is the whole point of the guard.
+ * two-space indent then `field (sep field)*`, optionally ending with one combined dim
+ * `sep + field` segment after two ordinary fields; and the field count must stay in bounds. Prose
+ * that happens to contain ` \u00b7 ` fails on the paint, which is the whole point of the guard.
  */
 function isStyledStatusRow(text: string, line: StyledLine): boolean {
   const rowText = rstrip(text);
@@ -128,16 +141,23 @@ function isStyledStatusRow(text: string, line: StyledLine): boolean {
   if (!isIndentSegment(segments[0]!)) return false;
 
   let fields = 0;
-  for (let i = 1; i < segments.length; i++) {
-    const expectField = (i - 1) % 2 === 0;
-    const segment = segments[i]!;
-    if (expectField) {
-      if (!isFieldSegment(segment)) return false;
+  let i = 1;
+  while (i < segments.length) {
+    if (!isFieldSegment(segments[i]!)) return false;
+    fields++;
+    i++;
+    if (i === segments.length) break;
+
+    const separator = segments[i]!;
+    if (isDimSuffixFieldSegment(separator)) {
+      if (fields < MIN_STATUS_FIELDS || i !== segments.length - 1) return false;
       fields++;
-    } else if (!isSeparatorSegment(segment)) return false;
+      i++;
+      break;
+    }
+    if (!isSeparatorSegment(separator) || i === segments.length - 1) return false;
+    i++;
   }
-  // An even index past the indent is a field slot; ending on a separator leaves it unfilled.
-  if ((segments.length - 1) % 2 === 0) return false;
   return fields >= MIN_STATUS_FIELDS && fields <= MAX_STATUS_FIELDS;
 }
 


### PR DESCRIPTION
## The symptom

Every reply sent from Collie to a current Codex pane was refused with:

> The agent's input box isn't on screen — a menu or dialog is probably up. Nothing was typed.

The composer was visibly present and held an ordinary one-line draft (`test`); no dialog was open.

## The cause

Current Codex paints the final collaboration-mode status field together with its separator as one
dim ANSI segment:

```text
<coloured model> · <coloured cwd><dim> · Main [default]</dim>
```

Collie's context-less status-row detector accepted only alternating coloured fields and standalone
dim separators. It therefore rejected this valid status row, so `locateComposer` returned `null`
and the guarded reply path refused to type.

This is separate from #140: that PR fixes deeper indentation in multiline draft continuation rows;
this failure occurs with a one-line draft and is in the status-row parser.

## The fix

Accept one combined dim `separator + field` suffix only when it follows at least two ordinary
coloured fields and is the final segment. The existing paint checks, field bounds, control-character
rejection, and tail-anchored prompt/status shape remain intact. Unstyled lookalikes still fail closed.

## Evidence

The parser was run directly against the affected live pane's `format:ansi` output after the change:

```json
{"composerReady":true,"draft":"test","status":["  gpt-5.6-sol medium · ~/.herdr/worktrees/kausate/feature-kau-6102-repair-dex-services-and-run-tabs · Main [default]"]}
```

The rebuilt Collie page was reloaded against that pane; the false refusal disappeared and the draft
remained ready to send.

## Tests

- pre-push backend typecheck and web typecheck: passed
- backend suite: 691 passed
- `collie-ctl.test.sh`: passed
- web suite: 3,827 passed / 30 todo
- production build: passed
- `scripts/check-version.sh`: passed at 0.36.0

Per `CLAUDE.md`, version files and `CHANGELOG.md` remain untouched because this is a fork PR.

Suggested changelog line:

```text
- Codex replies work with the dim collaboration-mode status suffix — the composer gate recognises the final ` · Main [default]` renderer segment without accepting unstyled lookalikes
```
