### PR TITLE
fix(omp): recognize OMP 18.1.2 composer format

### DIFF
--- a/web/src/lib/harness/omp/chrome.test.ts
+++ b/web/src/lib/harness/omp/chrome.test.ts
@@ -15,7 +15,7 @@ import {
 } from "./chrome";
 import { lineText } from "./markers";
 
-// omp's composer chrome. The whole adapter's Tier-1 value — and its safety half — is here: the box
+// omp's composer chrome. The whole adapter's Tier-1 value — and its safety half — is here: the shape
 // this scanner finds is the statusline, the stranded draft, AND the answer to "may a phone reply be
 // typed right now". A false "yes" types the user's message into whatever modal has the keyboard.
 
@@ -349,6 +349,31 @@ describe("locateComposer — Unicode anywhere in the box must never produce a nu
     // certain ASCII; every terminal that honours VS16 draws it at two columns.
     const buffer = lines(boxRowsPaddedLikeATerminal("1️⃣ deploy > master", "ship it").join("\n"));
     expect(locateComposer(buffer)).not.toBeNull();
+  });
+});
+
+describe("locateComposer — OMP 18.1.2's open-ended prompt row", () => {
+  it("locates the live two-row shape and re-surfaces its status and draft", () => {
+    const status = " idle  GPT-5.6-Sol ────────2%────────1M─";
+    const buffer = lines(["transcript", "", status, `╰─ draft-probe${" ".repeat(80)}`].join("\n"));
+
+    expect(locateComposer(buffer)).toEqual({
+      top: 2,
+      firstDraftRow: 3,
+      bottom: 3,
+      suggestEnd: 4,
+    });
+    expect(hasComposer(buffer)).toBe(true);
+    expect(extractInputDraft(buffer)).toBe("draft-probe");
+    expect(extractStatusLines(buffer).map(lineText)).toEqual([status]);
+    expect(composerPrompt(buffer)).toBe("╰─ draft-probe");
+    expect(stripChrome(buffer).map(lineText)).toEqual(["transcript"]);
+  });
+
+  it("recognises the same shape with an empty draft", () => {
+    const buffer = lines(["status", `╰─ ${" ".repeat(80)}`].join("\n"));
+    expect(hasComposer(buffer)).toBe(true);
+    expect(extractInputDraft(buffer)).toBeNull();
   });
 });
 

--- a/web/src/lib/harness/omp/chrome.ts
+++ b/web/src/lib/harness/omp/chrome.ts
@@ -25,6 +25,7 @@ import {
   composerGhost,
   isBlank,
   isComposerTop,
+  isOpenComposerBottom,
   lineText,
   opensBox,
   rstrip,
@@ -128,6 +129,9 @@ export interface ComposerBox {
  *     ╰─ <draft tail> ────╯      (a) the bottom border — the anchor everything else hangs off
  *     ❯ <palette row…>           (a) 0..MAX_SUGGESTION_ROWS non-blank, non-BOX rows, up to the tail
  *
+ * OMP 18.1.2 also emits a clipped two-row form: an arbitrary status row directly above an
+ * open-ended `╰─ <draft>` prompt. The prompt's missing right chrome is its anchor; other boxes close
+ * corner-to-corner, so they cannot enter that branch.
  * Every gate is a glyph predicate or an adjacency; none is a measurement. See the block above for why
  * the width equalities that used to co-sign (b) and (c) are gone and must stay gone.
  */
@@ -192,6 +196,7 @@ export function locateComposer(lines: StyledLine[]): ComposerBox | null {
     }
   }
   const suggestEnd = end + 1;
+  const openBottom = isOpenComposerBottom(texts[bottom]!);
 
   // (b) Continuation rows of a wrapped draft, walking up from the bottom border. The two-space gutter
   //     is the whole predicate, and it is not asked to carry the claim alone: the walk starts on a row
@@ -202,6 +207,14 @@ export function locateComposer(lines: StyledLine[]): ComposerBox | null {
   let i = bottom - 1;
   while (i >= 0 && bottom - i <= MAX_DRAFT_ROWS && composerContText(texts[i]!) !== null) {
     i--;
+  }
+
+  // OMP 18.1.2's clipped shape has no `╭…╮` top border. Its open-ended `╰─ <draft>` row is the
+  // discriminator, and the non-blank row directly above the continuation run is the standalone
+  // statusline to re-surface. A miss here stays fail-closed for destructive pre-type work.
+  if (openBottom) {
+    if (i < 0 || isBlank(texts[i]!)) return null;
+    return { top: i, firstDraftRow: i + 1, bottom, suggestEnd };
   }
 
   // (c) The top border — the LAST anchor checked, which is what pays for `isComposerTop` being loose
@@ -357,19 +370,15 @@ export function extractInputDraft(lines: StyledLine[]): string | null {
  * Whether omp's free-text composer is on screen at the tail — i.e. whether typing a reply would land
  * in the input box at all, rather than in a modal that has the keyboard.
  *
- * This is the highest-leverage function in the adapter. Before it existed, `omp` had no adapter at
- * all, so `sendGuardedReply` took the legacy one-shot path: type AND submit in a single call. A user
- * replying from their phone while one of omp's modals held the keyboard therefore fired the submit
- * key at THAT modal — the text is swallowed and the key confirms whatever row the modal had
- * highlighted. A definite `false` here is what makes the reply pre-flight refuse before a byte is
- * typed, and all ELEVEN captures in this corpus with a modal on screen answer `false`
- * (chrome.test.ts) — six pickers and five Ask-tool screens. omp's tool-approval dialog is NOT among
- * them: it was never captured, so its answer here is inferred from those eleven, not measured.
+ * This is the highest-leverage function in the adapter. A definite `false` makes the reply pre-flight
+ * refuse before a byte is typed; a `true` also authorises the prompt-bound pre-clear sweep. Both the
+ * closed OMP 17 box and OMP 18.1.2's open-ended prompt row are therefore parsed above before this
+ * function answers.
  *
  * "On screen at the tail" is meant strictly, and step (a)'s box rule is what makes it true: a composer
  * border with one of omp's boxes painted UNDER it answers `false`, because whatever that box is has
- * the keyboard. Without that rule this would only have said "a composer border exists somewhere in the
- * last 64 rows", which a dialog stacked straight onto the composer satisfies.
+ * the keyboard. Without that rule this would only have said "a composer border exists somewhere in
+ * the last 64 rows", which a dialog stacked straight onto the composer satisfies.
  */
 export function hasComposer(lines: StyledLine[]): boolean {
   return locateComposer(lines) !== null;

--- a/web/src/lib/harness/omp/markers.test.ts
+++ b/web/src/lib/harness/omp/markers.test.ts
@@ -57,6 +57,12 @@ describe("composerBottomText", () => {
     expect(composerBottomText(row("omp--draft-wrapped.txt", 29))!.trim()).toBe("hand");
   });
 
+  it("reads OMP 18.1.2's open-ended prompt row", () => {
+    expect(composerBottomText("╰─ draft-probe   ")).toBe("draft-probe");
+    expect(composerBottomText("╰─   ")).toBe("");
+    expect(composerBottomText("╰────────╯")).toBeNull();
+  });
+
   it("rejects every other box bottom — the one-space gutter is the discriminator", () => {
     expect(composerBottomText(row("omp--menu-dismissed.txt", 20))).toBeNull(); // `╰───┴───╯`
     expect(composerBottomText(row("omp--select-menu.txt", 55))).toBeNull(); // Ask box `╰───╯`
@@ -81,6 +87,11 @@ describe("composerGhost — omp's inline completion suggestion", () => {
   it("claims it just the same when the draft carries a foreground of its own", () => {
     const borderRow = `${CORNER}╰─ ${DRAFT}list the files in this repo${SUGGEST}sitory\x1b[0m${PAD}${CORNER} ─╯\x1b[0m`;
     expect(composerGhost(splitLines(parseAnsi(borderRow))[0]!)).toBe("sitory");
+  });
+
+  it("claims the trailing suggestion from an open-ended OMP 18.1.2 prompt", () => {
+    const promptRow = `${CORNER}╰─ ${DRAFT}draft-probe${SUGGEST}s\x1b[0m${PAD}`;
+    expect(composerGhost(splitLines(parseAnsi(promptRow))[0]!)).toBe("s");
   });
 
   it("reads it off the real captures, and leaves the plain one alone", () => {

--- a/web/src/lib/harness/omp/markers.ts
+++ b/web/src/lib/harness/omp/markers.ts
@@ -49,22 +49,37 @@ export function isComposerTop(text: string): boolean {
   return COMPOSER_TOP.test(rstrip(text));
 }
 
-// The composer's BOTTOM border, and the single most load-bearing literal in this adapter: omp writes
-// the LAST fragment of the draft INTO the bottom border, between a `╰─ ` opener and a ` ─╯` closer, so
-// the border carries a one-space gutter on each side that nothing else in the TUI has. Across the
-// whole 59-fixture corpus (38 claude + 21 omp) this shape occurs exactly ONCE per composer capture and
-// nowhere else: every other omp box — the welcome panel, a tool-result box, an Ask dialog, `/model`,
-// `/settings` — closes corner-to-corner with an unbroken rule (`╰────╯`) and no gutter. That is why
-// the composer gate can be lexical here where Claude's had to be positional.
+// OMP 17's classic composer writes the LAST fragment of the draft into a closed bottom border,
+// between a `╰─ ` opener and a ` ─╯` closer. OMP 18.1.2 can clip the right chrome entirely on a wide
+// pane and leave the same prompt row open-ended (`╰─ draft` or bare `╰─`). Both forms keep the
+// discriminator that other OMP boxes lack: after `╰─` comes either a one-space draft gutter or the
+// end of the row, never another rule glyph.
 const COMPOSER_BOTTOM = /^╰─ ([\s\S]*) ─╯$/;
-/** The opener `COMPOSER_BOTTOM` matches, whose length is where the row's inner span starts. */
+const OPEN_COMPOSER_BOTTOM = /^╰─(?: ([\s\S]*))?$/;
+/** Both supported composer rows share this opener; the draft span begins immediately after it. */
 const BOTTOM_OPEN = "╰─ ";
 
-/** The draft tail written into the composer's bottom border (UNTRIMMED — the caller decides), or null
- *  when the line is not that border. An empty composer yields `""`, which is a match, not a miss. */
+interface ParsedComposerBottom {
+  draft: string;
+  openEnded: boolean;
+}
+
+function parseComposerBottom(text: string): ParsedComposerBottom | null {
+  const stripped = rstrip(text);
+  const closed = COMPOSER_BOTTOM.exec(stripped);
+  if (closed !== null) return { draft: closed[1]!, openEnded: false };
+  const open = OPEN_COMPOSER_BOTTOM.exec(stripped);
+  return open === null ? null : { draft: open[1] ?? "", openEnded: true };
+}
+
+/** The draft tail written into either composer row (UNTRIMMED), or null for every other box bottom. */
 export function composerBottomText(text: string): string | null {
-  const m = COMPOSER_BOTTOM.exec(rstrip(text));
-  return m === null ? null : m[1]!;
+  return parseComposerBottom(text)?.draft ?? null;
+}
+
+/** Whether OMP clipped the row's right chrome — this shape has no separate top border to require. */
+export function isOpenComposerBottom(text: string): boolean {
+  return parseComposerBottom(text)?.openEnded === true;
 }
 
 // omp paints an INLINE COMPLETION SUGGESTION — a "ghost" — into the composer, after the operator's
@@ -114,7 +129,7 @@ export function composerBottomText(text: string): string | null {
 // failure the operator actually feels. The previous rule was WORSE here, not better: with an unstyled
 // draft it claimed the whole gradient (`ultrathink`), where this one claims `k`.
 export function composerGhost(line: StyledLine): string {
-  const inner = COMPOSER_BOTTOM.exec(rstrip(lineText(line)))?.[1];
+  const inner = parseComposerBottom(lineText(line))?.draft;
   if (inner === undefined || inner.length === 0) return "";
   const start = BOTTOM_OPEN.length;
   const end = start + inner.length;


### PR DESCRIPTION
## Summary

- recognize OMP 18.1.2's open-ended `╰─ <draft>` prompt row alongside the classic closed `╰─ <draft> ─╯` form
- treat the standalone row above the open prompt as OMP's status chrome
- reuse the same draft and inline-suggestion extraction for both formats
- preserve the fail-closed modal rule: corner-to-corner picker/dialog boxes still do not qualify as composers

Fixes #149.

## Verification

- `bunx vitest run src/lib/harness/omp/markers.test.ts src/lib/harness/omp/chrome.test.ts src/lib/harness/omp.test.ts src/lib/reply-action.test.ts src/components/composer.test.tsx` — 717 passed, 9 existing todos
- `bun run typecheck`
- live smoke against an isolated OMP 18.1.2 pane: Collie's normal type box submitted `/context`, cleared the local draft, and OMP rendered the context report
