### PR TITLE
fix(web): omp panes fall back to an initials tile

### DIFF
--- a/web/src/components/agent-icon-data.ts
+++ b/web/src/components/agent-icon-data.ts
@@ -2,14 +2,23 @@
 // official logo, paired with the brand's tile color. Sources (all verified against each project's
 // own favicon/site): Claude + Codex(OpenAI) via Simple Icons (CC0); pi via Simple Icons / pi.dev
 // favicon (#09090b tile); opencode via opencode.ai's site mark (#080808 tile, theme_color); agy
-// (Antigravity) via its Google-blue #1A73E8 tile, keyed under both "agy" and "antigravity".
+// (Antigravity) via its Google-blue #1A73E8 tile, keyed under both "agy" and "antigravity"; omp via
+// omp.sh/favicon.svg (#0f0a14 tile, and the one mark whose official paint is a gradient — `grad`).
 // To refresh: re-run the fetch in CHANGELOG and replace the `d` strings.
 
 export interface AgentBrand {
   /** Tile background — the agent's official brand color. */
   bg: string;
-  /** Mark color, chosen for contrast on `bg`. */
+  /** Mark color, chosen for contrast on `bg`. Ignored when `grad` is set — it is then the colour a
+   *  future flattening would take, which for omp is the gradient's mid stop. */
   fg: string;
+  /** Stops of the mark's own gradient, top-left → bottom-right, evenly spaced, for a brand whose
+   *  official mark IS a gradient (omp). Not a contrast device: flat `#9B4DFF` on omp's tile measures
+   *  4.56:1 and would read fine. It is fidelity — flattening ships a mark omp itself never paints.
+   *
+   *  Two stops minimum, by type: one stop (or none) is a gradient that paints nothing, and a mark
+   *  referencing it goes invisible on every surface at once. Absent is how a brand says "flat". */
+  grad?: readonly [string, string, ...string[]];
   /** "fill" for solid silhouettes, "stroke" for outlined marks (opencode). */
   mode: "fill" | "stroke";
   /** 24×24 path data. */
@@ -25,4 +34,17 @@ export const AGENT_BRANDS = new Map<string, AgentBrand>([
   ["opencode", { bg: "#080808", fg: "#FFFFFF", mode: "stroke", d: "M8.75 8.75V2.75H21.25V15.25H15.25M15.25 8.75H2.75V21.25H15.25V8.75Z" }],
   ["agy", { bg: "#1A73E8", fg: "#FFFFFF", mode: "fill", d: "M12 2L2 22h4.5l2-4.5h7l2 4.5H22L12 2zm0 6.5L14.2 14H9.8L12 8.5z" }],
   ["antigravity", { bg: "#1A73E8", fg: "#FFFFFF", mode: "fill", d: "M12 2L2 22h4.5l2-4.5h7l2 4.5H22L12 2zm0 6.5L14.2 14H9.8L12 8.5z" }],
+  // omp (oh-my-pi): the π from omp.sh/favicon.svg, its 64×64 mark rescaled ×0.6 and centred to fill
+  // 24×24 (the tile adds its own padding) — the same path, not a redrawing. Gradient stops are that
+  // favicon's, and match the TUI's own welcome mark.
+  [
+    "omp",
+    {
+      bg: "#0F0A14",
+      fg: "#9B4DFF",
+      mode: "fill",
+      grad: ["#ED4ABF", "#9B4DFF", "#5AD8E6"],
+      d: "M1.2 0h21.6v4.8h-6v19.2h-4.8V4.8H8.4v13.2H3.6V4.8H1.2z",
+    },
+  ],
 ]);

--- a/web/src/components/agent-icon.test.tsx
+++ b/web/src/components/agent-icon.test.tsx
@@ -3,7 +3,7 @@ import { render, screen } from "@testing-library/react";
 import { AgentIcon } from "./agent-icon";
 
 describe("AgentIcon", () => {
-  it.each(["claude", "codex", "pi", "opencode", "agy", "antigravity"])(
+  it.each(["claude", "codex", "pi", "opencode", "agy", "antigravity", "omp"])(
     "renders the %s brand logo as an inline-SVG app-icon tile",
     (agent) => {
       const { container } = render(<AgentIcon agent={agent} />);
@@ -12,6 +12,13 @@ describe("AgentIcon", () => {
       expect(svg!.querySelector("path")).not.toBeNull();
       // The tile carries its own solid brand background (theme-independent contrast).
       expect(svg!.querySelector("rect")?.getAttribute("fill")).toMatch(/^#[0-9a-fA-F]{6}$/);
+      // Every mark is painted, one of exactly two ways: filled — a flat brand colour or a reference
+      // to the tile's own gradient — or outlined, the only shape allowed to declare `fill="none"`,
+      // and then the stroke is what carries it. A mark with neither is an invisible tile.
+      const mark = svg!.querySelector("g")!;
+      const fill = mark.getAttribute("fill");
+      if (fill === "none") expect(mark.getAttribute("stroke")).toMatch(/^#[0-9a-fA-F]{6}$/);
+      else expect(fill).toMatch(/^(#[0-9a-fA-F]{6}|url\(#[A-Za-z0-9_-]+\))$/);
       expect(screen.getByRole("img", { name: `${agent} logo` })).toBeInTheDocument();
     },
   );
@@ -24,9 +31,49 @@ describe("AgentIcon", () => {
     ["PI"],
     ["agy-cli"],
     ["antigravity-dev"],
+    ["omp-dev"],
+    ["OMP"],
   ])("resolves label variant '%s' to a brand logo", (variant) => {
     const { container } = render(<AgentIcon agent={variant} />);
     expect(container.querySelector("svg path")).not.toBeNull();
+  });
+
+  // omp's official mark is a three-stop gradient (omp.sh/favicon.svg), and its tile is the only one
+  // AgentIcon paints with `url(#…)`: the gradient must be in the document, and the reference must
+  // resolve to it — a dangling reference paints nothing at all, on every surface at once.
+  it("paints omp's mark with its own gradient, referenced by a resolvable id", () => {
+    const { container } = render(<AgentIcon agent="omp" />);
+    const svg = container.querySelector("svg")!;
+    const ref = svg.querySelector("g")!.getAttribute("fill")!;
+    const id = ref.match(/^url\(#(.+)\)$/)?.[1];
+    expect(id).toBeTruthy();
+    const grad = svg.querySelector("linearGradient")!;
+    expect(grad.getAttribute("id")).toBe(id);
+    expect([...grad.querySelectorAll("stop")].map((s) => s.getAttribute("stop-color"))).toEqual([
+      "#ED4ABF",
+      "#9B4DFF",
+      "#5AD8E6",
+    ]);
+  });
+
+  // Two tiles share one document (the dashboard renders a column of them), so a shared gradient id
+  // would point every mark at whichever tile mounted first.
+  it("gives each mounted gradient tile its own id", () => {
+    const { container } = render(
+      <>
+        <AgentIcon agent="omp" />
+        <AgentIcon agent="omp" />
+      </>,
+    );
+    const ids = [...container.querySelectorAll("linearGradient")].map((g) => g.getAttribute("id"));
+    expect(ids).toHaveLength(2);
+    expect(new Set(ids).size).toBe(2);
+  });
+
+  it("keeps a flat-brand tile free of gradient machinery", () => {
+    const { container } = render(<AgentIcon agent="claude" />);
+    expect(container.querySelector("linearGradient")).toBeNull();
+    expect(container.querySelector("svg g")?.getAttribute("fill")).toBe("#FFFFFF");
   });
 
   it("falls back to an initials tile for unknown agents", () => {

--- a/web/src/components/agent-icon.tsx
+++ b/web/src/components/agent-icon.tsx
@@ -1,3 +1,5 @@
+import { useId } from "react";
+
 import { cn } from "@/lib/utils";
 import { initials } from "@/lib/format";
 import { AGENT_BRANDS } from "@/components/agent-icon-data";
@@ -11,6 +13,9 @@ function brandKey(agent: string): string | undefined {
   if (k.startsWith("codex")) return "codex";
   if (k.startsWith("opencode")) return "opencode";
   if (k === "pi" || k.startsWith("pi-") || k.startsWith("pi.")) return "pi";
+  // Bare prefix, exactly as canonicalAgent folds it (lib/operator-scope.ts): `omp` is its own
+  // prefix, and the `pi` rule above must not claim it — oh-my-pi is not pi.dev.
+  if (k.startsWith("omp")) return "omp";
   if (k === "agy" || k.startsWith("agy-") || k.startsWith("agy.") || k.startsWith("antigravity")) return "agy";
   return undefined;
 }
@@ -29,6 +34,11 @@ export function AgentIcon({
   className?: string;
 }) {
   const brand = agent ? AGENT_BRANDS.get(brandKey(agent) ?? "") : undefined;
+  // One id per mounted tile, sanitised the way collie-mark.tsx does it and for the same two
+  // reasons: an id inside an inline SVG is DOCUMENT-scoped, so a dashboard column of tiles would
+  // otherwise name one gradient and let the first render win; and React's own id carries glyphs a
+  // `url(#…)` reference has no business quoting once a CSS context gets hold of it.
+  const gradId = `agent-icon-${useId().replace(/[^A-Za-z0-9_-]/g, "")}`;
 
   if (!brand) {
     return (
@@ -46,6 +56,10 @@ export function AgentIcon({
   }
 
   const stroke = brand.mode === "stroke";
+  // A local, not `brand.grad` inline: narrowing survives into the map callback, so the stops need no
+  // non-null assertion. omp's official mark is a gradient, so its paint is a fragment reference.
+  const grad = brand.grad;
+  const paint = grad ? `url(#${gradId})` : brand.fg;
   return (
     <svg
       viewBox="0 0 24 24"
@@ -53,12 +67,21 @@ export function AgentIcon({
       role="img"
       aria-label={`${agent} logo`}
     >
+      {grad && (
+        <defs>
+          <linearGradient id={gradId} x1="0" y1="0" x2="1" y2="1">
+            {grad.map((stop, i) => (
+              <stop key={stop + i} offset={i / (grad.length - 1)} stopColor={stop} />
+            ))}
+          </linearGradient>
+        </defs>
+      )}
       <rect width="24" height="24" rx="5.3" fill={brand.bg} />
       {/* Inset the 24×24 mark to ~62% so every logo carries uniform app-icon padding. */}
       <g
         transform="translate(4.6 4.6) scale(0.617)"
-        fill={stroke ? "none" : brand.fg}
-        stroke={stroke ? brand.fg : undefined}
+        fill={stroke ? "none" : paint}
+        stroke={stroke ? paint : undefined}
         strokeWidth={stroke ? 2 : undefined}
         strokeLinecap={stroke ? "square" : undefined}
       >


### PR DESCRIPTION
`AgentIcon` has no `omp` entry, so every oh-my-pi pane falls back to the neutral initials tile. Herdr reports `agent: "omp"` exactly (checked with `herdr pane list`); codex works only because `codex` is in the table — nothing about omp was special except its absence. The fold is a bare `omp` prefix, exactly as `canonicalAgent` already folds it for the slash catalog.

The mark is omp's own path from `omp.sh/favicon.svg`, rescaled ×0.6 and centred so its 64×64 geometry fills 24×24 (the tile adds its own padding) — the same path, not a redrawing. Rasterised against the original: shape IoU 100.0000%, 0 mismatched ink pixels of 320,240.

`grad` is new and optional, because omp's official mark is a three-stop gradient in every asset upstream publishes — the favicon, and the TUI's own welcome logo (`PI_LOGO`'s gradient stops in oh-my-pi's `welcome.ts`). It is **not** a contrast decision: flat `#9B4DFF` on `#0F0A14` measures 4.56:1 and reads fine at every size `AgentIcon` renders, down to the tab strip's `size-3.5`. Flattening would just ship a mark omp never paints, and land it a shade off the `pi` tile it sits beside in the same list.

The field costs one optional key and no new state: two stops minimum by type, so a gradient that paints nothing is unrepresentable; absent is how every existing brand keeps saying "flat"; and the gradient id is sanitised the way `collie-mark.tsx` already sanitises its own, so a column of tiles cannot collide on one id.

Also tightens the shared brand-table assertion, which used to accept `fill="none"` for any brand — a fill-mode mark that had lost its paint entirely still passed.

## Verification

- `bun run build` (root tsc + web tsc + build) green.
- `agent-icon` tests 22/22, 6 of them new. Mutation-checked the tightened assertion: forcing `fill="none"` fails 8 of 22.
- Live UI on this branch against real Herdr panes: every omp row shows the gradient π, 11 tiles with 11 unique gradient ids, every `url(#…)` resolving.

Version files and CHANGELOG deliberately untouched, per the fork rule in CLAUDE.md.