### PR TITLE
feat: list live omp skills in the Agent-commands sheet

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -102,7 +102,8 @@
     {
       // Agent beacons (M11/01): a beacon is a JSON file in a state directory, written by a process Collie does not control and possibly not by Collie at all — a torn write, a newer schema, a foreign tool's file. `bridge/beacon/parse.ts` is the ONE file under bridge/beacon/ that reads an unvalidated field, exactly so this override stays a single file rather than a directory; every `typeof` in it sits inside its own field readers and IS the parse. Validation is not trust: a `path` ref that survives it is still confined by journal/files.ts (.adr/0024).
       "files": [
-        "**/bridge/beacon/parse.ts"
+        "**/bridge/beacon/parse.ts",
+        "**/bridge/slash-catalog.ts"
       ],
       "rules": {
         "anti-slop/no-runtime-typeof": "off"

--- a/bridge/server.ts
+++ b/bridge/server.ts
@@ -15,6 +15,7 @@ import { createOperatorCommands } from "./operator-commands.ts";
 import { createOperatorKeys } from "./operator-keys.ts";
 import { createOperatorQuickReplies } from "./operator-quick-replies.ts";
 import { createOperatorFonts, resolveOperatorFont } from "./operator-fonts.ts";
+import { createSlashCatalogReader } from "./slash-catalog.ts";
 import {
   DEFAULT_PROMPT_TAIL_LINES,
   verifyExpectedPrompt,
@@ -539,6 +540,7 @@ export function startServer(opts: {
   const operatorQuickReplies = createOperatorQuickReplies(cfg.quickRepliesFile);
   // The fourth on that contract: the operator's own UI typefaces, theme.toml off the hot path.
   const operatorFonts = createOperatorFonts(cfg.themeFile);
+  const slashCatalogs = createSlashCatalogReader(join(cfg.stateDir, "slash-catalog"));
   const journals = cfg.transcript ? buildJournalRegistry(cfg.journalRoots) : null;
   const transcripts = cfg.transcript ? new TranscriptStore() : null;
   /** Does this agent have a journal at all — the snapshot's History-affordance gate. */
@@ -588,9 +590,12 @@ export function startServer(opts: {
     // are read at serialise time, i.e. as fresh as the request. The ledger is keyed by SESSION, so
     // the runtime whose panes are being serialised is the one that has to be asked — which is why
     // this takes the runtime rather than closing over the ambient one.
+    const catalogByPane = slashCatalogs();
     const withActivity = (from: SessionRuntime, p: AgentView): AgentView => {
       const a = activity.get(from.name, p.paneId);
-      return a ? { ...p, lastActiveAt: a.activeAt, lastSeenAt: a.seenAt } : p;
+      const live = catalogByPane.get(p.paneId);
+      const stamped = a ? { ...p, lastActiveAt: a.activeAt, lastSeenAt: a.seenAt } : p;
+      return live && live.length > 0 ? { ...stamped, liveCommands: live } : stamped;
     };
     // The one place a pane leaves the bridge: the session ref is stripped to a presence flag here,
     // so an agent-reported filesystem path never reaches a browser (see toPaneWire). The flag is

--- a/bridge/slash-catalog.test.ts
+++ b/bridge/slash-catalog.test.ts
@@ -1,0 +1,71 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, test } from "bun:test";
+
+import { createSlashCatalogReader, readSlashCatalogs } from "./slash-catalog.ts";
+
+interface Dump {
+  schemaVersion: number;
+  harness: string;
+  hint: boolean;
+  herdrPaneId: string;
+  paneKey: string;
+  commands: { name: string; description: string }[];
+}
+
+function dump(over: Partial<Dump> = {}): Dump {
+  return {
+    schemaVersion: 1,
+    harness: "omp",
+    hint: true,
+    herdrPaneId: "w5:p2",
+    paneKey: "herdr-w5:p2",
+    commands: [
+      { name: "green", description: "Iterate on CI until green" },
+      { name: "collie-catalog", description: "debug" },
+      { name: "review", description: "Launch interactive code review" },
+    ],
+    ...over,
+  };
+}
+
+describe("readSlashCatalogs", () => {
+  test("maps a herdr dump to its pane id and drops the debug command", () => {
+    const dir = mkdtempSync(join(tmpdir(), "collie-slash-"));
+    writeFileSync(join(dir, "herdr-w5:p2.json"), JSON.stringify(dump()));
+    writeFileSync(join(dir, "latest.json"), JSON.stringify(dump()));
+    const rows = readSlashCatalogs(dir);
+    expect([...rows.keys()]).toEqual(["w5:p2"]);
+    expect(rows.get("w5:p2")?.map((c) => c.command)).toEqual(["/green", "/review"]);
+  });
+
+  test("ignores a missing directory, a broken file, and a non-omp harness", () => {
+    expect(readSlashCatalogs(join(tmpdir(), "no-such-collie-slash"))).toEqual(new Map());
+    const dir = mkdtempSync(join(tmpdir(), "collie-slash-"));
+    writeFileSync(join(dir, "herdr-w1:p1.json"), "{");
+    writeFileSync(join(dir, "herdr-w1:p2.json"), JSON.stringify(dump({ harness: "claude", herdrPaneId: "w1:p2" })));
+    expect(readSlashCatalogs(dir).size).toBe(0);
+  });
+
+  test("keys off herdrPaneId when the filename is latest-shaped but not latest.json", () => {
+    const dir = mkdtempSync(join(tmpdir(), "collie-slash-"));
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, "herdr-w9:p1.json"),
+      JSON.stringify(dump({ herdrPaneId: "w9:p1", paneKey: "herdr-w9:p1" })),
+    );
+    expect(readSlashCatalogs(dir).get("w9:p1")?.[0]?.command).toBe("/green");
+  });
+});
+
+describe("createSlashCatalogReader", () => {
+  test("re-reads after a new file appears", () => {
+    const dir = mkdtempSync(join(tmpdir(), "collie-slash-"));
+    const read = createSlashCatalogReader(dir);
+    expect(read().size).toBe(0);
+    writeFileSync(join(dir, "herdr-w5:p2.json"), JSON.stringify(dump()));
+    expect(read().get("w5:p2")?.map((c) => c.command)).toEqual(["/green", "/review"]);
+  });
+});

--- a/bridge/slash-catalog.ts
+++ b/bridge/slash-catalog.ts
@@ -1,0 +1,155 @@
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+import type { JsonObject, JsonValue } from "./json.ts";
+import type { LiveSlashCommand } from "./types.ts";
+
+// Live slash-command dumps written by the omp extension (contrib/omp/collie-slash-catalog.ts).
+// Same posture as a beacon (ADR 0024): a hint file the running agent wrote, never a control
+// channel and never a reason to spawn `omp --mode rpc`. The phone merges these into the palette;
+// Collie still types `/name` into the PTY.
+//
+// This file is the parse boundary: every `typeof` below sits inside a field reader, which is why
+// `anti-slop/no-runtime-typeof` is off for this ONE file in `.oxlintrc.json`.
+
+const SCHEMA_VERSION = 1;
+const HARNESS = "omp";
+const SKIP_NAMES = new Set(["collie-catalog"]);
+const MAX_COMMANDS = 200;
+const DESCRIPTION_MAX = 140;
+
+/** Directory under the Collie state dir. The extension writes the same path. */
+export function slashCatalogDir(stateDir: string): string {
+  return join(stateDir, "slash-catalog");
+}
+
+function readObject(value: JsonValue | undefined): JsonObject | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return null;
+  return value;
+}
+
+function readText(row: JsonObject, key: string): string | null {
+  const value = row[key];
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed === "" ? null : trimmed;
+}
+
+function slashName(raw: string): string | undefined {
+  const trimmed = raw.trim().replace(/^\//, "");
+  if (!trimmed || SKIP_NAMES.has(trimmed)) return undefined;
+  return `/${trimmed}`;
+}
+
+function oneLine(value: string): string {
+  const text = value.replace(/\s+/g, " ").trim();
+  if (!text) return "";
+  return text.length > DESCRIPTION_MAX ? `${text.slice(0, DESCRIPTION_MAX - 1)}…` : text;
+}
+
+function paneIdOf(file: string, row: JsonObject): string | undefined {
+  const herdrPaneId = readText(row, "herdrPaneId");
+  if (herdrPaneId) return herdrPaneId;
+  const paneKey = readText(row, "paneKey");
+  if (paneKey?.startsWith("herdr-")) {
+    const id = paneKey.slice("herdr-".length).trim();
+    return id || undefined;
+  }
+  const base = file.replace(/\.json$/u, "");
+  if (base.startsWith("herdr-")) {
+    const id = base.slice("herdr-".length);
+    return id || undefined;
+  }
+  return undefined;
+}
+
+function parseRecord(file: string, text: string): { paneId: string; commands: LiveSlashCommand[] } | undefined {
+  let parsed: JsonValue;
+  try {
+    parsed = JSON.parse(text);
+
+  } catch {
+    return undefined;
+  }
+  const rec = readObject(parsed);
+  if (rec === null) return undefined;
+  if (rec.schemaVersion !== SCHEMA_VERSION) return undefined;
+  if (rec.harness !== HARNESS) return undefined;
+  const paneId = paneIdOf(file, rec);
+  if (!paneId) return undefined;
+  const listed = rec.commands;
+  const rows = Array.isArray(listed) ? listed : [];
+  const seen = new Set<string>();
+  const commands: LiveSlashCommand[] = [];
+  for (const entry of rows) {
+    const row = readObject(entry);
+    if (row === null) continue;
+    const name = readText(row, "name");
+    if (name === null) continue;
+    const command = slashName(name);
+    if (!command || seen.has(command)) continue;
+    seen.add(command);
+    const description = readText(row, "description");
+    commands.push({ command, description: description ? oneLine(description) : "" });
+    if (commands.length >= MAX_COMMANDS) break;
+  }
+  return { paneId, commands };
+}
+
+/**
+ * Read every per-pane dump. `latest.json` is a convenience copy for operators and is ignored.
+ * Fail-closed: a missing dir, a broken file, or a record without a Herdr pane id is skipped.
+ */
+export function readSlashCatalogs(dir: string): Map<string, LiveSlashCommand[]> {
+  const out = new Map<string, LiveSlashCommand[]>();
+  let files: string[];
+  try {
+    files = readdirSync(dir);
+  } catch {
+    return out;
+  }
+  for (const file of files) {
+    if (file === "latest.json" || !file.endsWith(".json")) continue;
+    let text: string;
+    try {
+      text = readFileSync(join(dir, file), "utf8");
+    } catch {
+      continue;
+    }
+    const parsed = parseRecord(file, text);
+    if (!parsed) continue;
+    out.set(parsed.paneId, parsed.commands);
+  }
+  return out;
+}
+
+/** Snapshot-path cache: readdir is cheap; skip it when the directory has not changed. */
+export function createSlashCatalogReader(dir: string): () => Map<string, LiveSlashCommand[]> {
+  let stamp = "";
+  let rows = new Map<string, LiveSlashCommand[]>();
+  return () => {
+    let files: string[];
+    try {
+      files = readdirSync(dir);
+    } catch {
+      stamp = "";
+      rows = new Map();
+      return rows;
+    }
+    const next = files
+      .filter((f) => f.endsWith(".json"))
+      .toSorted()
+      .map((file) => {
+        try {
+          return `${file}:${statSync(join(dir, file)).mtimeMs}`;
+        } catch {
+          return file;
+        }
+      })
+      .join("\0");
+    if (next === stamp) return rows;
+    stamp = next;
+    rows = readSlashCatalogs(dir);
+    return rows;
+  };
+}

--- a/bridge/solo-baseline.test.ts
+++ b/bridge/solo-baseline.test.ts
@@ -298,8 +298,9 @@ const PANE_WIRE_KEYS = {
   // and then on every pane in the body. Nothing in this baseline asks, so it is absent on every
   // pane here and no golden byte moved — which is the claim, not an aside.
   session: true,
+  // Optional hint-file extras from omp (slash-catalog). Absent when none; not a pack dimension.
+  liveCommands: true,
 } satisfies Record<keyof PaneWire, true>;
-
 const DEVICE_AUTH_KEYS = {
   enforced: true,
   device: true,
@@ -391,6 +392,7 @@ describe("solo zero-tax — wire shapes carry no pack dimension", () => {
       "kind",
       "lastActiveAt",
       "lastSeenAt",
+      "liveCommands",
       "paneId",
       "paneLabel",
       "readableLines",
@@ -741,6 +743,8 @@ const STATE_DIR_ENTRIES = [
   "paired-devices.json",
   "pairing-pending.json",
   "push-subscriptions.json",
+  // omp slash-command dumps (hint files). A directory the bridge only READS; the omp extension writes it.
+  "slash-catalog",
   "snooze.json",
   // Speech-to-text settings. Absent until the operator runs `collie stt setup`, and READ ONLY by
   // the bridge — `bridge/stt/config.ts` names this path and never writes it.

--- a/bridge/types.ts
+++ b/bridge/types.ts
@@ -11,6 +11,12 @@ export type { TranscriptEntry, TranscriptPart } from "./journal/types.ts";
 
 export type AgentStatus = "idle" | "working" | "blocked" | "done" | "unknown";
 
+/** One row from an omp slash-catalog hint file. Hint only: Collie still types the command into the PTY. */
+export interface LiveSlashCommand {
+  command: string;
+  description: string;
+}
+
 /**
  * A single pane the user might want to monitor or drive. Usually an agent-bearing pane (the
  * triage home), but also a bare **shell** pane (`kind:"shell"`, `agent:"shell"`) once we surface
@@ -109,6 +115,12 @@ export interface AgentView {
    * `done` agent IS the "finished while you weren't looking" state — there is no stored seen flag.
    */
   lastSeenAt?: number;
+  /**
+   * Slash commands the live omp session dumped into `<stateDir>/slash-catalog/`. A hint file,
+   * never a control channel (ADR 0024). Omitted when none. The shipped catalog stays the first
+   * screen; these are session extras (skills, extensions) the corpus cannot ship.
+   */
+  liveCommands?: LiveSlashCommand[];
 }
 
 /**

--- a/contrib/omp/README.md
+++ b/contrib/omp/README.md
@@ -1,0 +1,10 @@
+# omp slash-command catalog
+
+The running omp session writes a **hint file** (not a control channel — same rule as Collie beacons)
+so the phone palette can list skills and extension commands without spawning `omp --mode rpc`.
+
+Install: copy `collie-slash-catalog.ts` to `~/.omp/agent/extensions/` and **restart omp**.
+
+Dumps land in `~/.local/state/collie/slash-catalog/herdr-<paneId>.json`.
+Collie's bridge reads those files on each snapshot and merges them into the Agent-commands sheet
+(search-only; the shipped omp catalog stays the first screen).

--- a/contrib/omp/collie-slash-catalog.ts
+++ b/contrib/omp/collie-slash-catalog.ts
@@ -1,0 +1,185 @@
+// collie slash-command catalog — writes a hint file; never a control channel.
+// Install: drop this in ~/.omp/agent/extensions/ and restart omp.
+// Restart is required: OMP does not reload extensions in a running session.
+// @ts-nocheck
+
+import { mkdirSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+const SCHEMA_VERSION = 1;
+const DESCRIPTION_MAX = 140;
+
+function collieStateDir(): string {
+	const explicit = process.env.COLLIE_STATE_DIR?.trim();
+	if (explicit) return explicit;
+	const instance = process.env.COLLIE_INSTANCE?.trim();
+	const name = instance ? `collie-${instance}` : "collie";
+	return join(homedir(), ".local/state", name);
+}
+
+function catalogDir(): string {
+	return join(collieStateDir(), "slash-catalog");
+}
+
+function paneKey(): string {
+	const herdr = process.env.HERDR_PANE_ID?.trim();
+	if (herdr) return `herdr-${safeKey(herdr)}`;
+	const tmux = process.env.TMUX_PANE?.trim();
+	if (tmux) return `tmux-${safeKey(tmux)}`;
+	const zellij = process.env.ZELLIJ_PANE_ID?.trim();
+	if (zellij) {
+		const session = process.env.ZELLIJ_SESSION_NAME?.trim() || "unknown";
+		return `zellij-${safeKey(session)}-${safeKey(zellij)}`;
+	}
+	return `pid-${process.pid}`;
+}
+
+function safeKey(value: string): string {
+	return value.replace(/[^A-Za-z0-9._:-]+/g, "_").slice(0, 96);
+}
+
+function trimDescription(value: unknown): string | undefined {
+	if (typeof value !== "string") return undefined;
+	const oneLine = value.replace(/\s+/g, " ").trim();
+	if (!oneLine) return undefined;
+	return oneLine.length > DESCRIPTION_MAX ? `${oneLine.slice(0, DESCRIPTION_MAX - 1)}…` : oneLine;
+}
+
+function sessionRef(ctx: any): { sessionId?: string; sessionFile?: string; cwd?: string } {
+	const out: { sessionId?: string; sessionFile?: string; cwd?: string } = {};
+	try {
+		const file = ctx?.sessionManager?.getSessionFile?.();
+		if (typeof file === "string" && file.length > 0) out.sessionFile = file;
+	} catch {
+		/* ignore */
+	}
+	try {
+		const id = ctx?.sessionManager?.getSessionId?.();
+		if (typeof id === "string" && id.length > 0) out.sessionId = id;
+	} catch {
+		/* ignore */
+	}
+	try {
+		const cwd = ctx?.sessionManager?.getCwd?.() ?? ctx?.cwd;
+		if (typeof cwd === "string" && cwd.length > 0) out.cwd = cwd;
+	} catch {
+		/* ignore */
+	}
+	return out;
+}
+
+function atomicWrite(path: string, text: string): void {
+	const temp = `${path}.${process.pid}.tmp`;
+	writeFileSync(temp, text, { encoding: "utf8", mode: 0o600 });
+	try {
+		renameSync(temp, path);
+	} catch (error) {
+		try {
+			unlinkSync(temp);
+		} catch {
+			/* ignore */
+		}
+		throw error;
+	}
+}
+
+export default function collieSlashCatalog(pi) {
+	pi.setLabel("Collie slash catalog");
+
+	const dumpTimers = new Set<ReturnType<typeof setTimeout>>();
+	let lastFingerprint = "";
+	let lastCtx: any;
+
+	function collect(piApi: typeof pi): Array<{
+		name: string;
+		description?: string;
+		source?: string;
+		location?: string;
+	}> {
+		const commands = typeof piApi.getCommands === "function" ? piApi.getCommands() : [];
+		const seen = new Set<string>();
+		const out = [];
+		for (const command of Array.isArray(commands) ? commands : []) {
+			const name = typeof command?.name === "string" ? command.name.trim() : "";
+			if (!name || seen.has(name)) continue;
+			seen.add(name);
+			out.push({
+				name,
+				description: trimDescription(command.description),
+				source: typeof command.source === "string" ? command.source : undefined,
+				location: typeof command.location === "string" ? command.location : undefined,
+			});
+		}
+		out.sort((a, b) => a.name.localeCompare(b.name));
+		return out;
+	}
+
+	function dump(ctx: any, reason: string): { path: string; count: number } | undefined {
+		if (ctx) lastCtx = ctx;
+		const commands = collect(pi);
+		const fingerprint = commands.map((c) => `${c.source ?? ""}:${c.name}`).join("\n");
+		if (fingerprint === lastFingerprint && reason !== "load") {
+			return undefined;
+		}
+		lastFingerprint = fingerprint;
+
+		const dir = catalogDir();
+		mkdirSync(dir, { recursive: true, mode: 0o700 });
+		const key = paneKey();
+		const record = {
+			schemaVersion: SCHEMA_VERSION,
+			harness: "omp",
+			hint: true,
+			reason,
+			pid: process.pid,
+			paneKey: key,
+			herdrPaneId: process.env.HERDR_PANE_ID ?? null,
+			writtenAt: new Date().toISOString(),
+			...sessionRef(ctx),
+			commands,
+			note: "getCommands() omits OMP builtins; Collie should keep its shipped omp catalog for those and merge this list.",
+		};
+		const json = `${JSON.stringify(record, null, 2)}\n`;
+		const panePath = join(dir, `${key}.json`);
+		atomicWrite(panePath, json);
+		atomicWrite(join(dir, "latest.json"), json);
+		return { path: panePath, count: commands.length };
+	}
+
+	function scheduleDump(ctx: any, reason: string, delayMs = 250): void {
+		const timer = setTimeout(() => {
+			dumpTimers.delete(timer);
+			try {
+				dump(ctx ?? lastCtx, reason);
+			} catch {
+				/* never wedge the session */
+			}
+		}, delayMs);
+		timer.unref?.();
+		dumpTimers.add(timer);
+	}
+
+	function dumpOnLifecycle(ctx: any, reason: string): void {
+		scheduleDump(ctx, reason, 0);
+		// Skills and MCP prompts often register after session_start.
+		scheduleDump(ctx, `${reason}_settled`, 800);
+		scheduleDump(ctx, `${reason}_late`, 3000);
+	}
+
+	pi.on("session_start", (_event, ctx) => dumpOnLifecycle(ctx, "session_start"));
+	pi.on("session_switch", (_event, ctx) => dumpOnLifecycle(ctx, "session_switch"));
+	pi.on("agent_end", (_event, ctx) => scheduleDump(ctx, "agent_end", 200));
+
+	pi.on("session_shutdown", () => {
+		for (const timer of dumpTimers) clearTimeout(timer);
+		dumpTimers.clear();
+	});
+
+	// Write as soon as the extension loads. Restart omp once; after that no slash command.
+	try {
+		dump(undefined, "load");
+	} catch {
+		/* ignore */
+	}
+}

--- a/web/src/components/agent-chat.tsx
+++ b/web/src/components/agent-chat.tsx
@@ -1758,6 +1758,7 @@ export function AgentChat({
                   paneId={paneId}
                   scope={scope}
                   agent={agent?.agent}
+                  liveCommands={agent?.liveCommands}
                   isShell={isShell}
                   // The state, as the WORD on the composer's status strip. It used to be the pane
                   // header's caption line; the dot badged onto the agent's tile up there stays, because

--- a/web/src/components/command-palette.test.tsx
+++ b/web/src/components/command-palette.test.tsx
@@ -4,7 +4,7 @@ import userEvent from "@testing-library/user-event";
 import { CommandPalette } from "./command-palette";
 import type { OperatorCommand } from "@/lib/types";
 
-function setup(overrides?: { agent?: string | null; mine?: OperatorCommand[] }) {
+function setup(overrides?: { agent?: string | null; mine?: OperatorCommand[]; live?: { command: string; description: string }[] }) {
   // Widened at the binding, not asserted at the literal: the overrides below hand `null` and
   // `undefined` for the same prop, so the base value has to carry the whole domain.
   const agentProp: string | null | undefined = "claude";
@@ -26,6 +26,17 @@ describe("CommandPalette", () => {
     // /status is common; /doctor is not.
     expect(screen.getByText("/status")).toBeInTheDocument();
     expect(screen.queryByText("/doctor")).toBeNull();
+  });
+
+  it("keeps live omp extras off the first screen until you search", async () => {
+    const user = userEvent.setup();
+    setup({
+      agent: "omp",
+      live: [{ command: "/green", description: "Iterate on CI until green" }],
+    });
+    expect(screen.queryByText("/green")).toBeNull();
+    await user.type(screen.getByPlaceholderText(/Search \d+ commands/), "green");
+    expect(screen.getByText("/green")).toBeInTheDocument();
   });
 
   it("filters across the full catalog as you type", async () => {

--- a/web/src/components/command-palette.tsx
+++ b/web/src/components/command-palette.tsx
@@ -16,6 +16,8 @@ interface CommandPaletteProps {
   agent: string | undefined | null;
   /** The operator's own rows (`commands.toml`); they replace the catalog on panes they address. */
   mine?: readonly OperatorCommand[];
+  /** Live omp extras from the slash-catalog hint file. Search-only; never replace the catalog. */
+  live?: readonly { command: string; description: string }[];
   /** Insert "/cmd " into the composer for the user to complete (arg-taking commands). */
   onInsert: (text: string) => void;
   /** Send "/cmd" immediately and submit (no-arg commands). */
@@ -27,11 +29,12 @@ export function CommandPalette({
   onClose,
   agent,
   mine,
+  live,
   onInsert,
   onSubmit,
 }: CommandPaletteProps) {
   useLocale();
-  const all = commandsFor(agent, mine);
+  const all = commandsFor(agent, mine, live);
   const [query, setQuery] = useState("");
   const { pending, confirm, reset } = usePendingConfirm();
 

--- a/web/src/components/composer.tsx
+++ b/web/src/components/composer.tsx
@@ -55,6 +55,8 @@ interface ComposerProps {
   scope?: Scope;
   /** The pane's agent name — drives the slash-command palette and the reply-vs-shell placeholder. */
   agent: string | undefined | null;
+  /** Live omp extras from the snapshot (`liveCommands`). */
+  liveCommands?: readonly { command: string; description: string }[];
   /** True for a bare shell pane (tweaks the placeholder copy, and is its own status word). */
   isShell: boolean;
   /**
@@ -225,7 +227,7 @@ function ComposerDock({
 }
 
 export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Composer(
-  { paneId, scope, agent, isShell, status, stale, gone, readOnly, hostBlock, composing, dialogPresent, text, terminalDraft, rawTerminalDraft, prefs, setWrap, stepFontSize, setRawTerminal, setTapToFocus, onSent },
+  { paneId, scope, agent, liveCommands, isShell, status, stale, gone, readOnly, hostBlock, composing, dialogPresent, text, terminalDraft, rawTerminalDraft, prefs, setWrap, stepFontSize, setRawTerminal, setTapToFocus, onSent },
   ref,
 ) {
   const revalidator = useRevalidator();
@@ -662,7 +664,7 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
   // The operator's own palette rows, resolved against the shipped catalog for both the button's
   // visibility test here and the palette's own list below (same call, same arguments).
   const operatorCommands = useOperatorCommands();
-  const commands = commandsFor(agent, operatorCommands);
+  const commands = commandsFor(agent, operatorCommands, liveCommands);
   // The Keys tray's preset row, resolved the same way from the same one-shot read of /api/config.
   const keyPresets = ctrlPresetsFor(agent, useOperatorKeys());
   // Empty on every adapter that refuses nothing, and empty for Herdr's six as far as this tray is
@@ -1579,6 +1581,7 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
         onClose={closeDrawer}
         agent={agent}
         mine={operatorCommands}
+        live={liveCommands}
         onInsert={insertCommand}
         onSubmit={(t) => send(t, false)}
       />

--- a/web/src/lib/agent-commands.test.ts
+++ b/web/src/lib/agent-commands.test.ts
@@ -312,3 +312,25 @@ describe("commandsFor with the operator's own rows", () => {
     expect(commandsFor("omp", [mine]).some((c) => c.command === "/mine")).toBe(false);
   });
 });
+
+describe("commandsFor with live omp extras", () => {
+  it("appends live rows after the shipped catalog and keeps them out of the first screen", () => {
+    const cmds = commandsFor("omp", [], [
+      { command: "/green", description: "Iterate on CI until green" },
+      { command: "/new", description: "should not duplicate" },
+    ]);
+    expect(cmds.some((c) => c.command === "/new" && c.common)).toBe(true);
+    const green = cmds.find((c) => c.command === "/green");
+    expect(green).toMatchObject({ description: "Iterate on CI until green", common: false, dangerous: false });
+    expect(cmds.filter((c) => c.command === "/new")).toHaveLength(1);
+  });
+
+  it("still appends live extras when commands.toml replaced the catalog", () => {
+    const mine = [
+      { agent: "omp", command: "/fork-in-herdr", description: "Fork", takesArg: false, argHint: "" },
+    ];
+    const cmds = commandsFor("omp", mine, [{ command: "/review", description: "Launch review" }]);
+    expect(cmds.map((c) => c.command)).toEqual(["/fork-in-herdr", "/review"]);
+    expect(cmds.find((c) => c.command === "/review")?.common).toBe(false);
+  });
+});

--- a/web/src/lib/agent-commands.ts
+++ b/web/src/lib/agent-commands.ts
@@ -299,8 +299,10 @@ const CATALOG = new Map<string, readonly AgentCommand[]>([
  * 1. YOUR LIST IS THE PALETTE. A pane addressed by even one of your rows shows your rows for that
  *    pane and nothing else. This surface is a handful of one-thumb shortcuts, and the value of the
  *    shipped catalog is that someone chose those ten; a list half-chosen by you and half-guessed
- *    for you is worse than either. Discovery is not lost by this — the agent's own `/` completion
- *    renders in the mirrored pane, complete and live, which no copy here could stay.
+ *    for you is worse than either.
+ *    Live omp extras (`live`) are a separate source: the running session dumped them. They APPEND
+ *    after the chosen list, never replace it, and they are never `common` — the first screen stays
+ *    the handful someone chose. ADR 0018 still forbids merging commands.toml with the shipped catalog.
  * 2. DANGER IS INHERITED, NOT RESET. A row naming a shipped command keeps that row's `dangerous`
  *    classification, so re-describing a session wipe cannot turn a two-tap command into a one-tap
  *    one. A row that names nothing shipped is not dangerous — nothing out here knows otherwise.
@@ -308,23 +310,46 @@ const CATALOG = new Map<string, readonly AgentCommand[]>([
 export function commandsFor(
   agent: string | undefined | null,
   mine: readonly OperatorCommand[] = [],
+  live: readonly { command: string; description: string }[] = [],
 ): readonly AgentCommand[] {
   const shipped = catalogFor(agent);
   const aimed = rowsFor(mine, agent, (row) => row.command);
   // Rule 2: nothing of yours points here, so this pane was never part of what you were choosing.
-  if (aimed.length === 0) return shipped;
-  const byName = new Map(shipped.map((c) => [c.command, c] as const));
-  return aimed.map((row) => ({
-    command: row.command,
-    description: row.description,
-    takesArg: row.takesArg,
-    argHint: row.argHint,
-    // A row you typed into your own config is by definition one you want on the first screen.
-    common: true,
-    // Inheriting is a FLOOR, never a default: `confirm = false` on a row that names a shipped
-    // dangerous command still confirms, so the only direction this field moves is up.
-    dangerous: (byName.get(row.command)?.dangerous ?? false) || row.confirm === true,
-  }));
+  const base: readonly AgentCommand[] =
+    aimed.length === 0
+      ? shipped
+      : aimed.map((row) => ({
+          command: row.command,
+          description: row.description,
+          takesArg: row.takesArg,
+          argHint: row.argHint,
+          // A row you typed into your own config is by definition one you want on the first screen.
+          common: true,
+          // Inheriting is a FLOOR, never a default: `confirm = false` on a row that names a shipped
+          // dangerous command still confirms, so the only direction this field moves is up.
+          dangerous: (byNameFor(shipped).get(row.command)?.dangerous ?? false) || row.confirm === true,
+        }));
+  if (live.length === 0) return base;
+  const seen = new Set(base.map((c) => c.command));
+  const extras: AgentCommand[] = [];
+  for (const row of live) {
+    const command = row.command.startsWith("/") ? row.command : `/${row.command}`;
+    if (seen.has(command)) continue;
+    seen.add(command);
+    extras.push({
+      command,
+      description: row.description || command,
+      takesArg: false,
+      argHint: "",
+      common: false,
+      dangerous: false,
+    });
+  }
+  return extras.length === 0 ? base : [...base, ...extras];
+}
+
+function byNameFor(shipped: readonly AgentCommand[]): Map<string, AgentCommand> {
+  return new Map(shipped.map((c) => [c.command, c] as const));
 }
 
 /** The agent names the shipped catalog is filed under — pinned against AGENT_FAMILIES in the tests. */

--- a/web/src/lib/solo-baseline.test.ts
+++ b/web/src/lib/solo-baseline.test.ts
@@ -106,6 +106,8 @@ const AGENT_VIEW_KEYS = {
   // present exactly when the snapshot was widened (`?sessions=all`, the "All sessions" view), absent
   // on every other read — which is every read the app made before that view existed.
   session: true,
+  // Optional omp slash-catalog extras. Absent when none; not a pack dimension.
+  liveCommands: true,
 } satisfies Record<keyof AgentView, true>;
 
 const DEVICE_AUTH_KEYS = {
@@ -173,6 +175,7 @@ describe("solo zero-tax — the client's mirror types carry no pack dimension", 
       "kind",
       "lastActiveAt",
       "lastSeenAt",
+      "liveCommands",
       "paneId",
       "paneLabel",
       "readableLines",

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -6,6 +6,11 @@ import { t } from "@/lib/i18n";
 
 export type AgentStatus = "idle" | "working" | "blocked" | "done" | "unknown";
 
+export interface LiveSlashCommand {
+  command: string;
+  description: string;
+}
+
 export interface AgentView {
   paneId: string;
   workspaceId: string;
@@ -117,6 +122,10 @@ export interface AgentView {
    * rather than with the ambient one.
    */
   session?: string;
+  /**
+   * Live omp extras from `<stateDir>/slash-catalog/`. Hint only. Omitted when none.
+   */
+  liveCommands?: LiveSlashCommand[];
 }
 
 /**


### PR DESCRIPTION
## Why

The phone palette only shipped a static omp catalog. Per-project skills and extension commands (`/skill:…`, `/green`, `/review`) live on the running session, so they never showed up unless you spawned `omp --mode rpc` per pane — which discussion #117 sketched for pi, but is the wrong layer for omp.

## What

The **running omp** writes a hint file (not a control channel — ADR 0024, same as beacons). Collie reads it on each snapshot and **appends** those rows to the Agent-commands sheet.

- Shipped `/new` `/compact` stay on the first screen.
- Live extras are search-only (`common: false`).
- `commands.toml` still **replaces** the shipped catalog (ADR 0018); live extras still append after that list.
- Collie still types `/name` into the PTY. The dump is never obeyed as a control channel.

Install: copy `contrib/omp/collie-slash-catalog.ts` to `~/.omp/agent/extensions/` and **restart omp**. Dumps land in `~/.local/state/collie/slash-catalog/herdr-<paneId>.json`.

## Out of scope

Full TUI autocomplete (subcommands, `@file`, ghost accept). That still lives in omp's overlay.

## Version

From a fork: no version bump / CHANGELOG, per CONTRIBUTING.