### PR TITLE
A table in the mirror pans instead of wrapping, and the prose around it still wraps

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -317,6 +317,12 @@ lint guard or the pack-wire guard.
   `terminal session observe`/`control`: a stale mirror is a transport problem, cursor position is an
   upstream ask, and `control` resizes the *shared* PTY
   ([ADR 0008](./.adr/0008-collie-does-not-run-a-terminal-emulator.md)).
+- **A table pans; the mirror around it keeps wrapping** — `lib/table-run.ts` groups a table's rows
+  into a single scroller inside the wrapping `<pre>` (`ansi-output.tsx`). One scroller per table,
+  never one per row. Each grammar anchors on a row nothing else prints — a markdown delimiter row,
+  a `+---+` rule, a frame row carrying a **cross** — and then grows by agreement, so a menu, a
+  chrome box or a rule beside a table is never claimed. `table-run.test.ts` gates it against every
+  capture in `fixtures/panes`; the argument sits in `table-run.ts`'s header.
 - **Never use a `dark:` variant inside the mirror `<pre>`** — it tracks the root theme, which is
   backwards in a surface that renders dark under every theme and inverts in light
   ([ADR 0002](./.adr/0002-invert-the-light-terminal-mirror.md)). Fails silently;

--- a/web/src/components/ansi-output.test.tsx
+++ b/web/src/components/ansi-output.test.tsx
@@ -75,7 +75,8 @@ describe("mirror line wrapping", () => {
     const text = `ordinary prose\n${ESC}[41m${border.slice(0, 12)}${ESC}[44m${border.slice(12)}${ESC}[0m\nsee https://herdr.dev/docs\n`;
     const { container } = render(<AnsiOutput text={text} query="───" />);
     const pre = container.querySelector("pre")!;
-    const clipped = pre.querySelector("span.inline-block")!;
+    // `span.overflow-hidden`, not `span.inline-block`: the table-run scroller is an inline-block too.
+    const clipped = pre.querySelector("span.overflow-hidden")!;
 
     expect(clipped.className).toContain("max-w-full");
     expect(clipped.className).toContain("overflow-hidden");
@@ -101,18 +102,143 @@ describe("mirror line wrapping", () => {
   it("clips a plain border only while wrapping, leaving ordinary output and wrap-off panning alone", () => {
     const border = `  ${"─".repeat(20)}  `;
     const { container: plain } = render(<AnsiOutput text={`${border}\n`} />);
-    expect(plain.querySelector("span.inline-block")?.textContent).toBe(border);
+    expect(plain.querySelector("span.overflow-hidden")?.textContent).toBe(border);
 
     const { container: wrapped } = render(<AnsiOutput text={`unbroken-${"x".repeat(40)}\n`} />);
     const wrappedPre = wrapped.querySelector("pre")!;
     expect(wrappedPre.className).toContain("break-words");
-    expect(wrappedPre.querySelector("span.inline-block")).toBeNull();
+    expect(wrappedPre.querySelector("span.overflow-hidden")).toBeNull();
 
     const { container: panned } = render(<AnsiOutput text={`${border}\n`} wrap={false} />);
     const pannedPre = panned.querySelector("pre")!;
     expect(pannedPre.className).toContain("overflow-x-auto");
-    expect(pannedPre.querySelector("span.inline-block")).toBeNull();
+    expect(pannedPre.querySelector("span.overflow-hidden")).toBeNull();
     expect(pannedPre.textContent).toBe(`${border}\n`);
+  });
+});
+
+// Wrap is right for prose and wrong for a table, whose meaning is the column a character sits in
+// (lib/table-run.ts). So a table run pans inside its own scroller while everything around it keeps
+// wrapping. What a refactor would break silently is not the scroller — it is the mirror text around
+// it: the run is grouped by moving line nodes under one span, and the find offsets, the link
+// offsets and a clipboard copy are all defined by the "\n" text nodes those lines sit between.
+describe("a table pans while the mirror around it wraps", () => {
+  const TABLE = ["| Option | Cost |", "| --- | --- |", "| A | low |", "| B | high |"].join("\n");
+  const TEXT = `here is the comparison:\n\n${TABLE}\n\nsee https://herdr.dev/docs\n`;
+
+  function mirror(props: Partial<ComponentProps<typeof AnsiOutput>> = {}) {
+    const { container } = render(<AnsiOutput text={TEXT} {...props} />);
+    return container.querySelector("pre")!;
+  }
+
+  it("puts the whole table in ONE scroller, so its rows pan together and stay aligned", () => {
+    const pre = mirror();
+    const runs = [...pre.querySelectorAll("span.overflow-x-auto")];
+
+    expect(runs).toHaveLength(1);
+    expect(runs[0]!.textContent).toBe(TABLE);
+    // Per-line scrollers would let two rows sit at different scrollLeft — the columns would come
+    // apart under the thumb, which is the exact failure wrapping already causes.
+    expect(runs[0]!.className).toContain("whitespace-pre");
+    expect(runs[0]!.className).toContain("inline-block");
+  });
+
+  it("pins overflow-y, so a link's em-padding cannot make the run a second vertical scroller", () => {
+    expect(mirror().querySelector("span.overflow-x-auto")!.className).toContain("overflow-y-hidden");
+  });
+
+  it("leaves the mirror text, the find offsets and the autolink exactly where they were", () => {
+    const pre = mirror({ query: "high" });
+
+    // Byte-identical to the input: grouping moved nodes, it did not add or drop a separator.
+    expect(pre.textContent).toBe(TEXT);
+    expect(pre.querySelector("[data-find-match]")!.textContent).toBe("high");
+    expect(pre.querySelector("span.overflow-x-auto")!.querySelector("[data-find-match]")).not.toBeNull();
+    expect(pre.querySelector("a")!.textContent).toBe("https://herdr.dev/docs");
+  });
+
+  it("does not nest a scroller inside the wrap-off pan, which is already column-faithful", () => {
+    expect(mirror({ wrap: false }).querySelector("span.overflow-x-auto")).toBeNull();
+  });
+
+  it("leaves the border clip alone: a rule beside a table stays clipped and outside the run", () => {
+    // The two features cannot meet. A clipped line is 20+ IDENTICAL rule glyphs, and every grammar
+    // demands its own separator at each member row's column offsets, which such a line has nowhere.
+    // So the run ends at the rule, and the rule keeps the single-row clip it has always had.
+    const rule = "─".repeat(20);
+    const table = ["┌──────┬──────┐", "│ a    │ b    │", "├──────┼──────┤", "│ 1    │ 2    │", "└──────┴──────┘"].join("\n");
+    const text = `${table}\n${rule}\n`;
+    const { container } = render(<AnsiOutput text={text} />);
+    const run = container.querySelector("span.overflow-x-auto")!;
+
+    expect(run.textContent).toBe(table);
+    expect(container.querySelector("span.overflow-hidden")!.textContent).toBe(rule);
+    expect(container.querySelector("pre")!.textContent).toBe(text);
+  });
+
+  // The grouping moves line nodes under a span and hoists one "\n" out of it, so the arrangements
+  // worth testing are the ones where that newline is decisive: a run with nothing before it, two
+  // runs in one block, and two runs with no gap. TEXT above always has prose first, so on its own it
+  // never renders the branch where the hoisted newline would be wrong.
+  describe("the arrangements where the hoisted newline decides", () => {
+    const A = ["| a | b |", "| --- | --- |", "| 1 | 2 |"].join("\n");
+    const B = ["| c | d |", "| --- | --- |", "| 3 | 4 |"].join("\n");
+
+    function offsetsOf(pre: HTMLElement, selector: string): number[] {
+      const walker = document.createTreeWalker(pre, NodeFilter.SHOW_TEXT);
+      const at: number[] = [];
+      let seen = 0;
+      for (let node = walker.nextNode(); node; node = walker.nextNode()) {
+        const owner = node.parentElement?.closest(selector);
+        if (owner && !at.includes(seen)) at.push(seen);
+        seen += node.textContent!.length;
+      }
+      return at;
+    }
+
+    it.each([
+      ["a run that starts the mirror", `${A}\nafter\n`],
+      ["a run that ends the mirror, no trailing newline", `before\n${A}`],
+      ["two runs with prose between them", `${A}\nbetween\n${B}\n`],
+      ["two runs with no gap at all", `${A}\n${B}\n`],
+      ["the whole mirror being one run", A],
+    ])("keeps the mirror text byte-identical: %s", (_name, text) => {
+      const { container } = render(<AnsiOutput text={text} />);
+      expect(container.querySelector("pre")!.textContent).toBe(text);
+    });
+
+    it("keeps find offsets true when a match sits after a run that starts the mirror", () => {
+      const text = `${A}\nbetween\n${B}\n`;
+      const { container } = render(<AnsiOutput text={text} query="3" />);
+      const pre = container.querySelector("pre")!;
+
+      // The highlighted node must start at the same index in the DOM text as in the input string.
+      expect(offsetsOf(pre, "[data-find-match]")).toEqual([text.indexOf("3")]);
+      expect(pre.textContent).toBe(text);
+    });
+
+    it("anchors a URL at its true offset inside a run", () => {
+      const table = ["| doc | note |", "| --- | --- |", "| https://herdr.dev/docs | read |"].join("\n");
+      const text = `before\n${table}\n`;
+      const { container } = render(<AnsiOutput text={text} />);
+      const pre = container.querySelector("pre")!;
+
+      expect(offsetsOf(pre, "a")).toEqual([text.indexOf("https://")]);
+      expect(pre.querySelector("span.overflow-x-auto")!.querySelector("a")).not.toBeNull();
+    });
+  });
+
+  it("survives a poll that shifts the table's line index, so the reader's pan is not thrown away", () => {
+    // The mirror is a rendered grid: one new line of output moves every line index. Keyed by index,
+    // the scroller would unmount on that poll and scrollLeft would snap back to zero under the
+    // thumb, with the table still sitting in the same place on screen.
+    const table = ["| a | b |", "| --- | --- |", "| 1 | 2 |"].join("\n");
+    const { container, rerender } = render(<AnsiOutput text={`one\n\n${table}\n`} />);
+    const before = container.querySelector("span.overflow-x-auto")!;
+
+    rerender(<AnsiOutput text={`one\ntwo\n\n${table}\n`} />);
+
+    expect(container.querySelector("span.overflow-x-auto")).toBe(before);
   });
 });
 

--- a/web/src/components/ansi-output.tsx
+++ b/web/src/components/ansi-output.tsx
@@ -12,8 +12,10 @@ import {
   type MultiSelectModel,
   type PreviewSelectModel,
   type PromptModel,
+  type StyledLine,
   type WizardModel,
 } from "@/lib/blocks";
+import { tableRuns, type TableRun } from "@/lib/table-run";
 import { MIRROR_SPACE, MIRROR_INVERT, styleFor } from "@/components/mirror-space";
 import { findMatches, splitSegment, type FindMatch } from "@/lib/find";
 import { findLinks } from "@/lib/links";
@@ -46,8 +48,9 @@ export interface AnsiOutputProps {
   className?: string;
   /** true = wrap; the block breaks at the viewport width instead of scrolling horizontally. Default
    *  true — the mirror is mostly agent prose, and a phone shows far fewer columns than the desktop
-   *  width panes are spawned at, so panning was the common case. Disable Wrap in View for
-   *  column-faithful TUI tables. */
+   *  width panes are spawned at, so panning was the common case. Tables are the exception and are
+   *  handled inside that default (lib/table-run.ts): each one pans in its own scroller, so turning
+   *  Wrap off is now only for output whose columns matter EVERYWHERE, such as a full-screen TUI. */
   wrap?: boolean;
   /** Monospace font size in px. Default 11. */
   fontSize?: number;
@@ -86,6 +89,11 @@ export interface AnsiOutputProps {
 // Stable empty result so the "not searching" path keeps the same `matches` reference across polls
 // (no needless effect re-runs / parent count updates while find is closed).
 const NO_MATCHES: FindMatch[] = [];
+/** The grammar's own frozen empty result, so "this block has no table" is one identity everywhere.
+ *  `NO_BLOCK_RUNS` is the wrap-off answer for EVERY block at once: that path computes nothing, and
+ *  the lookup below falls through to NO_RUNS for each block it asks about. */
+const NO_RUNS = tableRuns([]);
+const NO_BLOCK_RUNS: readonly (readonly TableRun[])[] = Object.freeze([]);
 
 // The mirror's dark colour space and its light-theme inversion live in mirror-space.ts — the
 // statusline strip renders the same terminal segments and the two must not drift.
@@ -126,6 +134,35 @@ function preClass(wrap: boolean, className?: string): string {
     className,
   );
 }
+
+// A table run (lib/table-run.ts) is the one thing Wrap must not reflow, so it pans in its own
+// scroller while the mirror around it keeps wrapping. Five details are load-bearing:
+//
+//   · `inline-block`, not `block`. The run sits between the same "\n" text nodes as every other
+//     line, and the mirror's find offsets, its link offsets and a clipboard copy are all defined by
+//     those nodes. A block box would need them deleted either side of every run — three coordinate
+//     spaces perturbed for a line break the inline-block already gets from the newline it follows.
+//     Same in-flow shape as the single-row border clip below, which is not the same class string.
+//     `align-bottom` keeps its rows on the mirror's own 1.25em grid: `baseline` would add the
+//     strut's descent under the table. `w-full` makes the box fill the line instead of shrinking to
+//     fit, so a table narrower than the mirror still scrolls from the same left edge as the prose.
+//   · `overscroll-x-contain` and `[touch-action:pan-x_pan-y]`, for the same reason preClass carries
+//     them: a pan that reaches the end of the table must not become a page-level swipe, and the
+//     vertical gesture must still reach the message list underneath.
+//   · `overflow-y-hidden`, explicitly. `overflow-x-auto` alone computes `overflow-y` to `auto` (the
+//     CSS quirk preClass documents), and LINK_CLASS's em-padding deliberately overflows its line box
+//     — so an autolinked URL in a cell would make the run a second, stray vertical scroller. What y
+//     clipping costs is one pixel: measured at every size the A+/A- control offers, the first row's
+//     ink starts 1.0px above the run's border box, so the very top of a tall glyph is cut. The last
+//     row and a link's underline are inside the box at every size.
+//   · No scrollbar of its own. A classic (non-overlay) scrollbar is laid INSIDE an auto-height box,
+//     so it would cover about 15px at the foot of the run — a whole 13.75px row at fontSize 11 —
+//     and `overflow-y-hidden` leaves no way to reach what it covers. Overlay scrollbars, i.e. every
+//     phone, never showed one anyway. Same spelling the strips use.
+//   · `whitespace-pre` beats the <pre>'s `pre-wrap` for its subtree, which is the whole point, and
+//     it also means a run narrower than the phone simply does not scroll.
+const TABLE_RUN_CLASS =
+  "inline-block w-full max-w-full align-bottom whitespace-pre break-normal overflow-x-auto overflow-y-hidden overscroll-x-contain [touch-action:pan-x_pan-y] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden";
 
 // Faithful, colored mirror of a pane's recent terminal output. Rendering flows through the Block AST
 // (blocks.ts): parseAnsi → styled lines → typed blocks → React. Text is always rendered as React
@@ -196,6 +233,14 @@ export const AnsiOutput = memo(function AnsiOutput({
   const autoBlock = useMemo(
     () => blocks.find((b): b is AutoBlock => b.kind === "autocomplete") ?? null,
     [blocks],
+  );
+
+  // The table runs of each raw block, by block index. Only while wrapping: with Wrap off the whole
+  // <pre> already pans column-faithfully, and a nested scroller would just trap the gesture — so
+  // that branch computes nothing at all and every block falls through to NO_RUNS below.
+  const runsByBlock = useMemo(
+    () => (wrap ? rawBlocks.map((b) => tableRuns(b.lines)) : NO_BLOCK_RUNS),
+    [rawBlocks, wrap],
   );
 
   // Find offsets live over the *raw* mirror text (raw blocks joined by "\n", lines joined by "\n").
@@ -329,34 +374,72 @@ export const AnsiOutput = memo(function AnsiOutput({
     });
   };
 
+  // One mirror line. `lead` says whether this line emits the "\n" that separates it from the one
+  // before: the first line of a table run does NOT, because that newline is hoisted out to sit
+  // before the run's scroller (inside it, it would open the table with a blank row). The offset is
+  // advanced either way — the separator exists in the find/link coordinate space regardless of which
+  // element holds its text node.
+  const renderLine = (line: StyledLine, li: number, lead: boolean): ReactNode => {
+    if (li > 0) offset += 1; // the "\n" separating this line from the previous
+    const segNodes = line.segments.map((s, si) => {
+      const segStart = offset;
+      offset += s.text.length;
+      return (
+        <span key={si} style={styleFor(s)}>
+          {renderSegment(s.text, segStart)}
+        </span>
+      );
+    });
+    // No interaction with the border clip below: a `noWrap` line is 20+ IDENTICAL rule glyphs, and
+    // every grammar demands a separator of its own on each member row, so a clipped border can
+    // never be inside a run.
+    const content = line.noWrap && wrap ? (
+      <span className="inline-block max-w-full overflow-hidden align-bottom whitespace-pre break-normal">{segNodes}</span>
+    ) : (
+      segNodes
+    );
+    return (
+      <Fragment key={li}>
+        {li > 0 && lead ? "\n" : null}
+        {content}
+      </Fragment>
+    );
+  };
+
   const renderBlock = (block: RawBlock, bi: number) => {
     if (bi > 0) offset += 1; // the "\n" separating this block from the previous
+    const runs = runsByBlock[bi] ?? NO_RUNS;
+    const nodes: ReactNode[] = [];
+    let ri = 0;
+    for (let li = 0; li < block.lines.length; ) {
+      const run: TableRun | undefined = runs[ri];
+      if (!run || run.start !== li) {
+        nodes.push(renderLine(block.lines[li]!, li, true));
+        li++;
+        continue;
+      }
+      ri++;
+      const rows: ReactNode[] = [];
+      for (let k = run.start; k <= run.end; k++) {
+        rows.push(renderLine(block.lines[k]!, k, k > run.start));
+      }
+      // Keyed by the table's own first row and height, NEVER by its line index. The mirror is a
+      // rendered grid: one new line of output shifts every index by one, and an index key would
+      // unmount the scroller on that poll and snap the reader's pan back to column zero — while the
+      // table on screen had not moved at all. React reuses the element while the key holds, and
+      // scrollLeft lives on the element.
+      nodes.push(
+        <Fragment key={`run:${run.end - run.start}:${lineText(block.lines[run.start]!)}`}>
+          {li > 0 ? "\n" : null}
+          <span className={TABLE_RUN_CLASS}>{rows}</span>
+        </Fragment>,
+      );
+      li = run.end + 1;
+    }
     return (
       <Fragment key={bi}>
         {bi > 0 ? "\n" : null}
-        {block.lines.map((line, li) => {
-          if (li > 0) offset += 1; // the "\n" separating this line from the previous
-          const segNodes = line.segments.map((s, si) => {
-            const segStart = offset;
-            offset += s.text.length;
-            return (
-              <span key={si} style={styleFor(s)}>
-                {renderSegment(s.text, segStart)}
-              </span>
-            );
-          });
-          const content = line.noWrap && wrap ? (
-            <span className="inline-block max-w-full overflow-hidden align-bottom whitespace-pre break-normal">{segNodes}</span>
-          ) : (
-            segNodes
-          );
-          return (
-            <Fragment key={li}>
-              {li > 0 ? "\n" : null}
-              {content}
-            </Fragment>
-          );
-        })}
+        {nodes}
       </Fragment>
     );
   };

--- a/web/src/hooks/use-display-prefs.ts
+++ b/web/src/hooks/use-display-prefs.ts
@@ -8,8 +8,9 @@ import { asJsonBoolean, asJsonNumber, asJsonString, parseJsonObject } from "@/li
 export interface DisplayPrefs {
   /** Whether the mirror wraps long lines (default: true). The mirror is mostly agent prose, and a
    *  phone shows ~45-50 columns against panes herdr spawns at desktop width (190 in one reporter's
-   *  session), so panning was the common case, not the exception. Column-faithful no-wrap for TUI
-   *  tables stays one tap away in View. */
+   *  session), so panning was the common case, not the exception. A table pans in its own scroller
+   *  INSIDE the wrap (lib/table-run.ts), so no-wrap is now only for output whose columns matter
+   *  everywhere, such as a full-screen TUI. */
   wrap: boolean;
   /** Font size in px for the mirror pre (default: 10, range: 9–16). */
   fontSize: number;

--- a/web/src/lib/i18n/messages/de.ts
+++ b/web/src/lib/i18n/messages/de.ts
@@ -169,7 +169,7 @@ export const de: Dictionary = {
   // --- settings.display (mirror display prefs, behind the composer's ⚙ dock) ---
   "settings.display.wrap.label": "Zeilenumbruch",
   "settings.display.wrap.hint":
-    "Deaktiviert: Spaltentreue Darstellung für TUI-Tabellen mit horizontalem Scrollen.",
+    "Deaktiviert: Das ganze Pane bleibt spaltentreu und wird horizontal gescrollt. Für eine Tabelle ist das nicht mehr nötig: Bei aktivem Zeilenumbruch scrollt eine Tabelle für sich.",
   "settings.display.tapToType.label": "Tippen zum Schreiben",
   "settings.display.tapToType.hint":
     "Aktiv: Antippen des Spiegels öffnet überall die Tastatur. Deaktiviert: Spiegel bleibt Textanzeige, Tastatur öffnet nur im Eingabefeld.",

--- a/web/src/lib/i18n/messages/en.ts
+++ b/web/src/lib/i18n/messages/en.ts
@@ -181,7 +181,7 @@ export const en = {
   // --- settings.display (mirror display prefs, behind the composer's ⚙ dock) ---
   "settings.display.wrap.label": "Wrap lines",
   "settings.display.wrap.hint":
-    "Off shows column-faithful output for TUI tables — you pan instead.",
+    "Off pans the whole pane, column-faithful. You no longer need it for a table — a table pans by itself while Wrap is on.",
   "settings.display.tapToType.label": "Tap to type",
   "settings.display.tapToType.hint":
     "On, tapping the mirror anywhere opens the keyboard. Off, the mirror behaves like a document — taps land on the text and only the composer opens the keyboard.",

--- a/web/src/lib/i18n/messages/es.ts
+++ b/web/src/lib/i18n/messages/es.ts
@@ -168,7 +168,7 @@ export const es: Dictionary = {
   // --- settings.display (mirror display prefs, behind the composer's ⚙ dock) ---
   "settings.display.wrap.label": "Ajuste de línea",
   "settings.display.wrap.hint":
-    "Desactivado mantiene la salida exacta por columnas para interfaces TUI mediante desplazamiento.",
+    "Desactivado desplaza todo el panel manteniendo las columnas. Ya no hace falta para una tabla: con el ajuste activo, una tabla se desplaza por su cuenta.",
   "settings.display.tapToType.label": "Tocar para escribir",
   "settings.display.tapToType.hint":
     "Si esta activo, pulsar en cualquier parte abre el teclado. Si no, funciona como documento de texto y solo el editor abre el teclado.",

--- a/web/src/lib/i18n/messages/ja.ts
+++ b/web/src/lib/i18n/messages/ja.ts
@@ -164,7 +164,8 @@ export const ja: Dictionary = {
 
   // --- settings.display (mirror display prefs, behind the composer's ⚙ dock) ---
   "settings.display.wrap.label": "行の折り返し",
-  "settings.display.wrap.hint": "無効化するとTUIの表などの列構造を維持します。表示範囲外は水平スクロールで確認します。",
+  "settings.display.wrap.hint":
+    "無効化するとペイン全体が列構造を維持し、水平スクロールになります。表のために無効化する必要はありません。折り返しが有効なままでも、表は単独でスクロールします。",
   "settings.display.tapToType.label": "タップで入力開始",
   "settings.display.tapToType.hint":
     "有効時はターミナル領域のタップでキーボードが開きます。無効時はテキスト選択が優先され、キーボードは入力欄タップ時のみ開きます。",

--- a/web/src/lib/i18n/messages/ko.ts
+++ b/web/src/lib/i18n/messages/ko.ts
@@ -163,7 +163,8 @@ export const ko: Dictionary = {
 
   // --- settings.display (mirror display prefs, behind the composer's ⚙ dock) ---
   "settings.display.wrap.label": "자동 줄바꿈",
-  "settings.display.wrap.hint": "비활성화 시 TUI 표를 열 기준 그대로 출력합니다. 화면은 가로로 이동합니다.",
+  "settings.display.wrap.hint":
+    "비활성화 시 창 전체가 열 기준을 유지하며 가로로 스크롤됩니다. 표 때문에 끌 필요는 없습니다. 자동 줄바꿈이 켜져 있어도 표는 스스로 스크롤됩니다.",
   "settings.display.tapToType.label": "탭하여 입력",
   "settings.display.tapToType.hint":
     "활성화하면 미러 영역 어디를 눌러도 키보드가 열립니다. 끄면 일반 문서처럼 동작하며 입력기를 눌러야 키보드가 표시됩니다.",

--- a/web/src/lib/i18n/messages/zh.ts
+++ b/web/src/lib/i18n/messages/zh.ts
@@ -155,7 +155,8 @@ export const zh: Dictionary = {
 
   // --- settings.display (mirror display prefs, behind the composer's ⚙ dock) ---
   "settings.display.wrap.label": "自动换行",
-  "settings.display.wrap.hint": "关闭以按原始列宽渲染 TUI 表格，通过水平平移查看。",
+  "settings.display.wrap.hint":
+    "关闭后整个窗格按原始列宽渲染，通过水平平移查看。表格无需关闭此项：开启自动换行时，表格会单独平移。",
   "settings.display.tapToType.label": "点击唤起键盘",
   "settings.display.tapToType.hint":
     "开启后点击镜像任意位置均弹出键盘。关闭后镜像以文档模式交互，仅点击输入框时调出键盘。",

--- a/web/src/lib/rule-glyphs.ts
+++ b/web/src/lib/rule-glyphs.ts
@@ -2,9 +2,9 @@
 // box-drawing contract; visual clipping narrows that to glyphs that are themselves horizontal, so
 // a repeated corner/junction can never be mistaken for a terminal-width border.
 //
-// THIS FILE IS THE WHOLE SHARED SURFACE, AND IT IS MEANT TO STAY THAT WAY. Two things in this
-// codebase decide whether a line is a border, and the obvious tidy-up — one predicate, one
-// threshold — is the change to refuse:
+// THIS FILE IS THE WHOLE SHARED SURFACE, AND IT IS MEANT TO STAY THAT WAY. Several tests in this
+// codebase decide whether a line is a border; three of them share this file, and the obvious
+// tidy-up — one predicate, one threshold — is the change to refuse:
 //
 //   · `markers.ts` (isBoxBorder / isInputBoxTopBorder) asks whether this is CLAUDE'S INPUT BOX, to
 //     decide whether the reply guard may press Enter. Its false positive types a message into a
@@ -13,6 +13,10 @@
 //   · `blocks.ts` (PURE_HORIZONTAL_BORDER) asks whether this row is TOO WIDE TO WRAP NICELY, to
 //     decide whether to clip it. Its false positive crops a short rule. It can afford a broad glyph
 //     set and a plain repetition count.
+//   · `table-run.ts` (tableRuns) asks whether this row belongs to a TABLE, to decide whether to pan
+//     it instead of wrapping it. Its false positive pans readable prose, or worse, a menu. It reads
+//     the three classes at the foot of this file plus BOX_DRAWING_RULE_GLYPH_CLASS above, and its
+//     predicates and counts are its own.
 //
 // Same word, different question, and the costs of being wrong are not comparable. markers.ts:86–103
 // records what happened the last time one of these tests was reused for the other job — a spaced-out
@@ -37,3 +41,27 @@ const HORIZONTAL_BOX_RULE_GLYPH_CLASS = "─━┄┅┈┉╌╍═╴╶╸╺
 /** Glyphs safe to classify as a repeated, standalone horizontal terminal border. */
 export const PURE_HORIZONTAL_RULE_GLYPH_CLASS =
   HORIZONTAL_BOX_RULE_GLYPH_CLASS + BLOCK_EIGHTH_RULE_GLYPH_CLASS + UNICODE_DASH_RULE_GLYPH_CLASS;
+
+// A THIRD question, asked by table-run.ts: is this row part of a TABLE, so the mirror should pan it
+// instead of wrapping it? Its false positive pans prose, or worse a menu, but it never types
+// anything — which is exactly why it must not borrow either predicate above. It shares only these
+// alphabets, and BOX_DRAWING_RULE_GLYPH_CLASS at the head of the file.
+
+/** Box-drawing CROSSES: single, heavy, and double. A cross is one column boundary crossing a row
+ *  boundary, which only a table draws — it is the anchor table-run.ts is allowed to trust.
+ *
+ *  The T-pieces below are deliberately absent, and this is the line that matters. A `┬` sits
+ *  wherever ANY two-pane box's divider meets its top border and a `┴` where it meets the bottom, so
+ *  anchoring on those claimed omp's splash screen and the whole of its `/model` picker — 18 of the
+ *  121 committed pane fixtures — which is the class of screen ADR 0009 exists to keep hands off. */
+export const BOX_CROSS_GLYPH_CLASS = "┼-╋╪-╬";
+
+/** Every junction that carries a COLUMN boundary: the crosses above plus the T-pieces. Only ever
+ *  used to READ a frame row's column offsets off the anchor, or to recognise one on a member row;
+ *  never to decide that a run exists. `├ ┤ ╞ ╡` stay out — they end a frame row without dividing
+ *  it, so a single-column chrome box has no column boundary anywhere. */
+export const BOX_COLUMN_JUNCTION_GLYPH_CLASS = "┬-╋╤-╬";
+
+/** Vertical strokes that can stand at a column boundary on a content row: solid, heavy, both
+ *  dashed weights of each, and double. */
+export const BOX_VERTICAL_GLYPH_CLASS = "│┃┆┇┊┋╎╏║";

--- a/web/src/lib/table-run.test.ts
+++ b/web/src/lib/table-run.test.ts
@@ -1,0 +1,260 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { parseAnsi } from "./ansi";
+import { splitLines } from "./blocks";
+import { buildBlocks } from "./harness";
+import { tableRuns, type TableRun } from "./table-run";
+
+// The grammar's only real risk is a false positive: a run pans instead of wrapping, so anything it
+// claims by mistake becomes a strip of prose the reader has to scroll sideways. These tests are
+// therefore weighted toward what it must REFUSE — chrome, prose with pipes, a lone delimiter, and a
+// table the terminal already wrapped past the pane's width, which cannot be repaired by panning.
+
+const runs = (text: string) => tableRuns(splitLines(parseAnsi(text)));
+
+describe("tableRuns — markdown", () => {
+  it("claims a pipe table, delimiter row included, and stops at the blank line", () => {
+    const text = [
+      "here is the comparison:",
+      "",
+      "| Option | Cost | Notes |",
+      "| --- | --- | --- |",
+      "| A | low | fine |",
+      "| B | high | avoid |",
+      "",
+      "that is all.",
+    ].join("\n");
+
+    expect(runs(text)).toEqual([{ start: 2, end: 5 }]);
+  });
+
+  it("claims a table written without outer pipes", () => {
+    const text = ["Option | Cost", "--- | ---", "A | low"].join("\n");
+    expect(runs(text)).toEqual([{ start: 0, end: 2 }]);
+  });
+
+  it("claims two tables separately rather than swallowing the prose between them", () => {
+    const text = [
+      "| a | b |",
+      "|---|---|",
+      "| 1 | 2 |",
+      "",
+      "and then",
+      "",
+      "| c | d |",
+      "|---|---|",
+      "| 3 | 4 |",
+    ].join("\n");
+
+    expect(runs(text)).toEqual([
+      { start: 0, end: 2 },
+      { start: 6, end: 8 },
+    ]);
+  });
+
+  it("drops a row the terminal already wrapped, because its cell count no longer matches", () => {
+    // The pane rendered `| B | high | a very long note …` at its own width and broke the tail onto
+    // its own row. Neither half now carries the table's four pipes, so BOTH stay outside the run:
+    // the intact rows pan, and the wreckage keeps wrapping, which is the only readable thing left
+    // to do with it. Panning cannot put those two rows back together — the terminal split them
+    // before Collie saw the grid.
+    const text = [
+      "| Option | Cost | Notes |",
+      "| --- | --- | --- |",
+      "| A | low | fine |",
+      "| B | high | a very long note that ran",
+      "past the pane's last column |",
+    ].join("\n");
+
+    expect(runs(text)).toEqual([{ start: 0, end: 2 }]);
+  });
+
+  it("refuses prose that merely contains a pipe, and a delimiter row with no table under it", () => {
+    expect(runs("run `a | b` to pipe it\nthen read the output")).toEqual([]);
+    expect(runs("| --- | --- |")).toEqual([]);
+    expect(runs("--------------------")).toEqual([]);
+  });
+});
+
+describe("tableRuns — box drawing", () => {
+  it("claims a junction-divided table, frame rows and all", () => {
+    const text = [
+      "┌────────┬───────┐",
+      "│ Option │ Cost  │",
+      "├────────┼───────┤",
+      "│ A      │ low   │",
+      "└────────┴───────┘",
+    ].join("\n");
+
+    expect(runs(text)).toEqual([{ start: 0, end: 4 }]);
+  });
+
+  it("refuses Claude's input box: a single-column frame has no column junction anywhere", () => {
+    const text = [
+      "╭──────────────────────────────╮",
+      "│ > write the migration        │",
+      "╰──────────────────────────────╯",
+    ].join("\n");
+
+    expect(runs(text)).toEqual([]);
+  });
+
+  it("refuses a single-column frame divided by ├ ┤, which ends a row without splitting it", () => {
+    const text = ["╭────────────╮", "│ heading    │", "├────────────┤", "│ body       │", "╰────────────╯"].join("\n");
+    expect(runs(text)).toEqual([]);
+  });
+
+  it("refuses a two-pane chrome box, whose ┬ and ┴ are border joins and not a table", () => {
+    // The shape that made omp's splash screen and its whole /model picker pan: a divider between two
+    // panes meets the lid at ┬ and the floor at ┴, and neither is a cross. 18 of the 121 committed
+    // pane fixtures were claimed this way. Only a ┼ anchors a run.
+    const text = [
+      "╭───────────────┬──────────────╮",
+      "│ omp 18.1.2    │ opus-5       │",
+      "│ /model        │ /resume      │",
+      "╰───────────────┴──────────────╯",
+    ].join("\n");
+
+    expect(runs(text)).toEqual([]);
+  });
+
+  it("keeps a titled lid in the run, though its letters stop it being a pure frame row", () => {
+    const text = [
+      "┌─ Results ──┬─────────┐",
+      "│ id         │ name    │",
+      "├────────────┼─────────┤",
+      "│ 1          │ alice   │",
+      "└────────────┴─────────┘",
+    ].join("\n");
+
+    expect(runs(text)).toEqual([{ start: 0, end: 4 }]);
+  });
+
+  it("keeps the aligned head of a terminal-wrapped row and stops the run at the remainder", () => {
+    // The pane broke `│ A │ a very long note …` across two rows. The head still carries the table's
+    // wall at the anchor's offset, so it is a member and pans with the rows above it. The remainder
+    // carries nothing there, so the run ends — and the table's closing frame, no longer contiguous,
+    // wraps below it. That is the honest outcome: panning cannot rejoin two rows the terminal split
+    // before Collie saw the grid, so the run keeps exactly the part that is still a table.
+    const text = [
+      "┌────────┬───────┐",
+      "│ Option │ Cost  │",
+      "├────────┼───────┤",
+      "│ A      │ a very long note that ran",
+      "past the pane's last column │",
+      "└────────┴───────┘",
+    ].join("\n");
+
+    expect(runs(text)).toEqual([{ start: 0, end: 3 }]);
+  });
+
+  it("refuses a neighbouring box whose walls stand somewhere else", () => {
+    const text = [
+      "┌────┬────┬────┐",
+      "│ a  │ b  │ c  │",
+      "├────┼────┼────┤",
+      "│ 1  │ 2  │ 3  │",
+      "└────┴────┴────┘",
+      "│ x │ y │ z │",
+    ].join("\n");
+
+    expect(runs(text)).toEqual([{ start: 0, end: 4 }]);
+  });
+});
+
+describe("tableRuns — line coordinates", () => {
+  it("reports indices into the lines it was given, so the renderer can group in place", () => {
+    const lines = splitLines(parseAnsi(["intro", "| a | b |", "|---|---|", "| 1 | 2 |", "outro"].join("\n")));
+    const [run] = tableRuns(lines);
+
+    expect(run).toEqual({ start: 1, end: 3 });
+    expect(lines.slice(run!.start, run!.end + 1)).toHaveLength(3);
+  });
+
+  it("returns the same empty array for output with no table (one identity across polls)", () => {
+    expect(runs("nothing to see")).toBe(runs("nothing else either"));
+  });
+});
+
+describe("tableRuns — ASCII tables", () => {
+  it("claims the +---+ table every shell tool prints", () => {
+    const text = [
+      "+----+-------+",
+      "| id | name  |",
+      "+----+-------+",
+      "|  1 | alice |",
+      "|  2 | bob   |",
+      "+----+-------+",
+    ].join("\n");
+
+    expect(tableRuns(splitLines(parseAnsi(text)))).toEqual([{ start: 0, end: 5 }]);
+  });
+});
+
+describe("tableRuns — what a run may not grow into", () => {
+  it("stops at a chrome box below the table, blank line or no blank line", () => {
+    // A single-column box has walls only at its own two edges, never at the table's column offsets,
+    // so the anchor cannot reach it. Before the offset rule this claimed all eight lines.
+    const text = [
+      "┌────────┬───────┐",
+      "│ Option │ Cost  │",
+      "├────────┼───────┤",
+      "│ A      │ low   │",
+      "└────────┴───────┘",
+      "╭──────────────────────────────╮",
+      "│ > write the migration        │",
+      "╰──────────────────────────────╯",
+    ].join("\n");
+
+    expect(runs(text)).toEqual([{ start: 0, end: 4 }]);
+  });
+
+  it("stops at a plain rule beside the table rather than panning and un-clipping it", () => {
+    const rule = "─".repeat(30);
+    const text = [rule, "┌────────┬───────┐", "│ a      │ b     │", "├────────┼───────┤", "│ 1      │ 2     │", "└────────┴───────┘", rule].join("\n");
+
+    expect(runs(text)).toEqual([{ start: 1, end: 5 }]);
+  });
+});
+
+describe("tableRuns — the empty result", () => {
+  it("is frozen, so a caller cannot poison every later table-free mirror", () => {
+    const empty = tableRuns([]);
+
+    expect(empty).toEqual([]);
+    // SAFETY: the cast strips `readonly` on purpose — it is the whole test. A caller in plain JS,
+    // or one that widens the type exactly like this, must hit the freeze rather than mutate the
+    // singleton that every later table-free mirror is handed.
+    expect(() => (empty as TableRun[]).push({ start: 999, end: 1000 })).toThrow();
+    expect(runs("nothing to see")).toEqual([]);
+  });
+});
+
+// The corpus gate. Every other grammar in this repo is developed against the byte-faithful captures
+// in fixtures/panes (harness/claude/prompt-select.test.ts, harness/conformance.ts), and this one
+// needs it more than most: an earlier anchor alphabet that accepted a `┬` claimed omp's welcome
+// splash and the WHOLE of its /model picker across 18 of these files, and every hand-written test
+// above still passed. Globbing rather than listing means a newly captured screen is covered the day
+// it lands.
+describe("tableRuns — the whole pane corpus", () => {
+  const DIR = join(import.meta.dirname, "..", "fixtures", "panes");
+
+  it("claims real tables and nothing else across every committed capture", () => {
+    const claimed: string[] = [];
+    for (const file of readdirSync(DIR).filter((f) => f.endsWith(".txt"))) {
+      const agent = file.split("--")[0]!;
+      const lines = splitLines(parseAnsi(readFileSync(join(DIR, file), "utf8")));
+      for (const block of buildBlocks(lines, { agent })) {
+        if (block.kind !== "raw") continue;
+        for (const run of tableRuns(block.lines)) claimed.push(`${file} ${run.start}..${run.end}`);
+      }
+    }
+
+    // The one real table in the corpus: the Bluefin motd's `Command │ Description` two-column list,
+    // 200 columns wide, sitting in the scrollback above Claude's trust prompt. Everything else here
+    // is chrome — splashes, pickers, permission dialogs, wizards — and must keep wrapping.
+    expect(claimed).toEqual(["claude--trust-prompt.txt 5..10"]);
+  });
+});

--- a/web/src/lib/table-run.ts
+++ b/web/src/lib/table-run.ts
@@ -1,0 +1,163 @@
+// Which rows of the mirror are a TABLE — the one shape that Wrap lines gets wrong.
+//
+// Wrap is right for almost everything: the pane was rendered at the desktop's column count and a
+// phone shows far fewer, so prose has to reflow ([ADR 0008](../../../.adr/0008-collie-does-not-run-a-terminal-emulator.md),
+// issue #53). A table is the exception, and it is the exception for a structural reason rather than
+// an aesthetic one: its meaning is carried by the COLUMN a character sits in, and wrapping destroys
+// exactly that. Reflowed, row three's second cell lands under row two's third — the rows are all
+// still there and the table is unreadable. So a table run is panned inside its own scroller while
+// the mirror around it keeps wrapping (components/ansi-output.tsx).
+//
+// This can only recover the columns between the phone's width and the PANE'S width. A table already
+// too wide for the pane was hard-wrapped by the terminal before Collie ever saw it — `pane.read`
+// returns a rendered grid, not logical lines — and no amount of CSS gets those rows back. Neither
+// half of such a row carries the table's own separator count, so both fall out of the run and keep
+// wrapping rather than dragging a broken table into a scroller.
+//
+// TWO GRAMMARS, EACH ANCHORED ON A ROW THAT CANNOT BE ANYTHING ELSE, THEN GROWN BY COUNT. The two
+// halves are the whole safety argument. A row is never claimed for being pipe-ish or box-ish on its
+// own: it must sit in the contiguous neighbourhood of a delimiter no other construct prints, AND
+// divide into the same number of columns as that delimiter.
+//
+//   · Markdown — the anchor is the delimiter row (`| --- | --- |`, or the same without outer pipes),
+//     and the count is its pipes. Prose that happens to contain a pipe cannot match a count it never
+//     had.
+//   · Box drawing — the anchor is a frame row carrying a CROSS (`├───┼───┤`), and the count is its
+//     crosses. A T-piece is not enough and the reason is load-bearing: see BOX_CROSS_GLYPH_CLASS.
+//     Claude's input box has neither, being a single-column frame (`╭───╮`, `│ > … │`, `╰───╯`).
+//     Neighbours join as frame rows spending that count on junctions, or as content rows spending it
+//     on verticals — plus two more when the table is drawn with outer borders.
+//
+// A blank line always ends a run, in both grammars — it is the one separator every harness prints
+// around a table, and it stops an anchor reaching across unrelated output.
+
+import { isBlank, lineText, type StyledLine } from "./blocks";
+import {
+  BOX_COLUMN_JUNCTION_GLYPH_CLASS,
+  BOX_CROSS_GLYPH_CLASS,
+  BOX_DRAWING_RULE_GLYPH_CLASS,
+  BOX_VERTICAL_GLYPH_CLASS,
+} from "./rule-glyphs";
+
+/** A contiguous, inclusive range of line indices to pan as one unit. */
+export interface TableRun {
+  readonly start: number;
+  readonly end: number;
+}
+
+/** Stable empty result, frozen: it is shared by every table-free call, so a caller that pushed into
+ *  it would corrupt every later one. */
+const NO_RUNS: readonly TableRun[] = Object.freeze([]);
+
+// A GFM delimiter row: two or more dash cells, optional alignment colons, optional outer pipes. The
+// interior pipe is what the `+` demands, so a bare rule (`------`) is not a table and neither is a
+// single pipe-less cell.
+const MD_DELIMITER = /^\|?\s*:?-+:?\s*(?:\|\s*:?-+:?\s*)+\|?$/;
+const PIPE = /\|/g;
+
+// The `+---+---+` rule of mysql, sqlite3 -table, psql, docker, tabulate and comfy-table — the most
+// common table an agent pastes out of a shell tool, after markdown.
+const ASCII_DELIMITER = /^\+(?:-+\+)+$/;
+const PLUS = /\+/g;
+const ASCII_SEPARATOR = /^[|+]$/;
+
+// A row whose every printable character is box drawing: a frame row, top, bottom or divider.
+const BOX_FRAME_ROW = new RegExp(`^[${BOX_DRAWING_RULE_GLYPH_CLASS}\\s]+$`);
+// The anchor is a CROSS and never a T-piece. A `┬` sits wherever ANY two-pane box's divider meets
+// its top border and a `┴` where it meets the bottom, so a T-piece anchor claimed omp's splash
+// screen and the whole of its /model picker — 18 of the 121 committed pane fixtures. A cross is a
+// column boundary crossing a ROW boundary, which only a table draws. The trade is a headerless box
+// table, with no interior divider row, which is now left to wrap; that is the cheap failure.
+const BOX_CROSS = new RegExp(`[${BOX_CROSS_GLYPH_CLASS}]`);
+// Interior junctions carry the anchor's column offsets. Corners and side tees (`┌ ┐ ├ ┤`) are not
+// here: they mark where the FRAME is, and a lid draws a corner where a content row draws a border,
+// so an offset taken from one would never match the other.
+const BOX_JUNCTION = new RegExp(`[${BOX_COLUMN_JUNCTION_GLYPH_CLASS}]`, "g");
+// What may stand at a column offset on a member row: a cell wall, or another row's junction.
+const BOX_SEPARATOR = new RegExp(`^[${BOX_VERTICAL_GLYPH_CLASS}${BOX_COLUMN_JUNCTION_GLYPH_CLASS}]$`);
+
+/**
+ * The table runs in a block's lines, in order, non-overlapping, each at least two lines long.
+ *
+ * Pure, and cheap enough to run on every unique poll text: up to three regex tests per line to find
+ * an anchor, plus one membership probe per line an anchor tries to grow over. The renderer memoises
+ * it anyway, because the mirror re-renders far more often than its text changes.
+ */
+export function tableRuns(lines: StyledLine[]): readonly TableRun[] {
+  // Two views of each line. `grid` keeps the left padding, because the box and ASCII grammars agree
+  // on column OFFSETS and those only line up in the terminal's own coordinates. `text` is fully
+  // trimmed, which is what lets an indented markdown table anchor at all.
+  const grid = lines.map((line) => lineText(line).trimEnd());
+  const runs: TableRun[] = [];
+  // The first line of the next run may not reach back into the previous one.
+  let floor = 0;
+
+  for (let i = 0; i < lines.length; i++) {
+    if (i < floor) continue;
+    const row = grid[i]!;
+    if (isBlank(row)) continue;
+    const text = row.trimStart();
+
+    const member = MD_DELIMITER.test(text)
+      ? markdownMember(text.match(PIPE)?.length ?? 0)
+      : ASCII_DELIMITER.test(text)
+        ? offsetMember(offsetsOf(row, PLUS), ASCII_SEPARATOR)
+        : BOX_FRAME_ROW.test(text) && BOX_CROSS.test(text)
+          ? offsetMember(offsetsOf(row, BOX_JUNCTION), BOX_SEPARATOR)
+          : null;
+    if (!member) continue;
+
+    let start = i;
+    while (start > floor && member(grid[start - 1]!)) start--;
+    let end = i;
+    while (end + 1 < lines.length && member(grid[end + 1]!)) end++;
+    floor = end + 1;
+    // One row is a delimiter with nothing to delimit — leave it to the ordinary wrap.
+    if (end === start) continue;
+    runs.push({ start, end });
+  }
+
+  return runs.length > 0 ? runs : NO_RUNS;
+}
+
+/** Where the anchor's separators stand, in terminal columns. */
+function offsetsOf(row: string, separator: RegExp): number[] {
+  const at: number[] = [];
+  separator.lastIndex = 0;
+  for (let m = separator.exec(row); m; m = separator.exec(row)) at.push(m.index);
+  return at;
+}
+
+/** A markdown row of the anchor's shape. The count includes the outer pipes, so it also pins
+ *  whether the table is written with them — a delimiter row that omits the outer pipes its data
+ *  rows carry is refused, which is the deliberate strict half of this rule. Markdown alone is
+ *  matched by COUNT rather than by offset, because a model routinely prints a table whose columns
+ *  do not line up; a grid-drawn one always does. */
+function markdownMember(pipes: number): (text: string) => boolean {
+  return (row) => {
+    const text = row.trimStart();
+    return !isBlank(text) && (text.match(PIPE)?.length ?? 0) === pipes;
+  };
+}
+
+/**
+ * A row that carries a separator at every one of the anchor's column offsets — the grid grammars'
+ * agreement rule, and it is what four otherwise separate refusals all reduce to.
+ *
+ *   · A row the terminal already wrapped keeps no separator at those offsets, so neither half joins
+ *     and the wreckage is left to wrap instead of being dragged into the scroller half-panned.
+ *   · A TITLED lid (`┌─ Results ──┬───┐`) DOES carry one, so the run keeps its own top border even
+ *     though the letters in it stop it being a frame row.
+ *   · A plain rule drawn next to a table carries `─` there, not a wall, so the run stops at it.
+ *   · A single-column chrome box below a table — Claude's input box — has walls only at its own two
+ *     edges, so a multi-column anchor cannot grow into it even with no blank line between them.
+ *
+ * The cost is a table whose cells hold double-width characters: the terminal's columns and the
+ * string's indices stop agreeing, no offset matches, and the table wraps as it did before.
+ */
+function offsetMember(offsets: number[], separator: RegExp): (row: string) => boolean {
+  return (row) => {
+    if (isBlank(row)) return false;
+    return offsets.every((at) => separator.test(row.charAt(at)));
+  };
+}


### PR DESCRIPTION
Wrap lines is right for almost everything the mirror shows and wrong for one shape. A table's meaning is the column a character sits in, so reflowing it at phone width puts row three's second cell under row two's third: every row is still there and the table is unreadable. Turning Wrap off to read one table then costs column-faithful panning on all the prose too. This is the road issue #5 originally asked for ("no-wrap + horizontal scroll inside the mirror") and that #53 correctly overruled as a global default.

`lib/table-run.ts` groups a table's rows into one scroller inside the wrapping `<pre>`. Wrap stays on and there is no new setting.

### Before and after

Same idle pane, same 191-column table an agent printed, 390px viewport: shipped 1.2.0 on the left column of the description below, this branch on the right. On 1.2.0 the header row breaks so that `Channel` and `Evidence` share a line and `Current meaning` sits alone on the next, with the borders sprayed across six rows. On this branch the table keeps its columns and clips at the viewport edge, ready to pan; the prose above and below it still wraps. I can attach the two PNGs to a comment if you would like them in the thread.

Measured on the live pane: the run reports `scrollWidth 1128` in `clientWidth 374`, the outer `<pre>` reports `scrollWidth === clientWidth` (so the page itself never pans), and one `scrollLeft` moves every row of the table by the same amount.

### How it decides

One scroller per table, never one per row — two rows at different `scrollLeft` come apart exactly the way wrapping already breaks them.

Three grammars, each anchored on a row nothing else prints:

- a markdown delimiter row (`| --- | --- |`, with or without outer pipes),
- a `+---+---+` rule (mysql, sqlite3 `-table`, psql, docker, tabulate),
- a box frame row carrying a **cross**.

A T-piece is deliberately not enough, and that exclusion is load-bearing: a `┬` sits wherever any two-pane box's divider meets its lid, so an earlier revision that accepted one claimed omp's welcome splash and the whole of its `/model` picker across 18 of the 121 committed pane captures. The cost is a headerless box table, which keeps wrapping.

The anchor alone never claims a row. Markdown grows by pipe count; the two grid grammars grow by **column offset** — a member must carry a separator at each offset the anchor spends one on. That single rule is why a titled lid stays in the run, why a plain rule beside a table does not, why a chrome box below a table cannot be swallowed even with no blank line between them, and why the remains of a row the terminal already wrapped are left to wrap instead of being dragged in half-panned.

### Scope of the fix

Only the columns between the phone and the **pane** are recoverable. `pane.read` returns a rendered grid, so a table already too wide for the pane was broken by the terminal before Collie saw it, and no CSS gets those rows back (ADR 0008). Codex is worth noting here: its own TUI reflows a markdown table into stacked field lists at the pane's width, so there is never a table on the grid to claim, and a live codex pane correctly yields zero runs.

### Rendering details

The run is an `inline-block` sitting between the same `"\n"` text nodes as every other line, so find offsets, link offsets and a clipboard copy are untouched — a selection dragged across a run boundary serialises character-identically to `pre.textContent`. `overflow-y` is pinned explicitly, because `overflow-x-auto` alone computes it to `auto` and `LINK_CLASS`'s em-padding would then make the run a second vertical scroller. The run hides its own scrollbar: a classic non-overlay scrollbar is laid inside an auto-height box and would cover the last row with y pinned. It is keyed by its own first row rather than by a line index, so a poll that shifts the grid does not remount the scroller and throw away the reader's pan (verified live: a 200px pan survives across polls).

### Tests

`table-run.test.ts` gates the grammar against **every** capture in `fixtures/panes` through each harness's own adapter, the way `prompt-select.test.ts` and `conformance.ts` do. That gate is what found the T-piece false positive; every hand-written case passed while 18 fixtures were being claimed. Result now: claude 50 captures / 1 claim, and that one is a real 200-column table in the scrollback of `claude--trust-prompt.txt`; codex 16 / 0; omp 22 / 0; grok 25 / 0; agy 8 / 0.

`ansi-output.test.tsx` adds the arrangements where the hoisted newline decides — a run that starts the mirror, one that ends it with no trailing newline, two runs, two adjacent runs — with find and link offsets asserted by position rather than by text, plus a guard that the scroller survives a poll.

`cd web && bunx vitest run src/lib/table-run.test.ts src/components/ansi-output.test.tsx` gives 47 passing; `bunx tsc --noEmit` is clean.

### Fork PR housekeeping

Version files and CHANGELOG deliberately untouched; `scripts/check-version.sh` prints its ok line at 1.2.0. Proposed CHANGELOG entry, in your hands:

> **Added** — A table in the mirror pans in its own scroller while the prose around it keeps wrapping, so Wrap no longer has to be turned off to read one (#5).

The Wrap hint changed in all six locales, because it told the operator to turn Wrap off for a table. The stale copy of that rationale in `use-display-prefs.ts` is corrected too.

### An ADR, if you want one

I have left `.adr/` alone — a number claimed in a fork collides with your next one the same way a guessed version bump collides with the release commit, and I cannot accept my own. But I think one is warranted, as an **amendment in scope to 0008**, not a supersede: 0008 stays entirely correct, Collie still runs no emulator, but its Decision says a column-faithful grid "reopens the pan-vs-wrap question 0.21.0 settled toward wrap", and the code now says "except for a detected table". Two of the roads this closes have no line to attach a comment to, because their subject is code that does not exist: a user-facing toggle (the point is that the operator is not asked) and detect-by-width (there is no width test). Draft:

- **Context** — #5 asked for a per-table scroller and got a global no-wrap default; #53 argued the other way and flipped that default in 0.21.0; part 2 of #53 was closed by measurement; 0008 refused the emulator.
- **Decision** — Wrap stays the default. A detected table gets one horizontal scroller, never one per row. Detection is by anchor grammar, never by width. The recoverable range is phone-width to pane-width only, because `pane.read` returns a rendered grid.
- **Consequences** — A false positive pans readable prose, so the anchor alphabet is narrow and the corpus gates it. A table the terminal already broke is split rather than repaired.

If you would rather not, the fallback is to cut the CLAUDE.md bullet to the rule plus a pointer and leave the argument in `table-run.ts`'s header, which is where it already lives.