### PR TITLE
fix(web): don't lock the PWA to portrait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ PATH. Details and rollback: [`docs/upgrading.md`](./docs/upgrading.md) → *Upgr
 ### Fixed
 
 - `COLLIE_MUX=tmux collie start` now writes the choice to `.env`, so the next plain `start` and the supervised unit both see it.
+- The installed app no longer locks to portrait, so a tablet can run Collie in landscape, thanks @edwinhu (#162); the pane and history screens sit in a centred column above phone width, like every other screen.
 
 ## [1.5.0] - 2026-09-04
 

--- a/web/src/components/agent-chat.tsx
+++ b/web/src/components/agent-chat.tsx
@@ -1017,15 +1017,32 @@ export function AgentChat({
     // cannot land outside it and end up 16px taller than its neighbours. That is the fault the old
     // per-strip `hideLabel` prop could not prevent, which is why this is a context and not a prop.
     <CompactStripLabels>
-      <div className="flex min-h-0 w-full min-w-0 max-w-[100dvw] flex-1 flex-col overflow-x-hidden">
+      {/* `max-w-[100dvw]` is the phone bound and it stays: a mirror line wider than the screen used
+          to blow the viewport out sideways and let the whole page pan (85f777b, "viewport blowout").
+          `md:max-w-screen-md` caps the same box at 768px from that breakpoint up, where 768px is by
+          definition no more than 100dvw, so the two bounds never contradict each other; `mx-auto`
+          then centres what is left. `overflow-x-hidden`, `min-w-0` and `w-full` are all still doing
+          the phone's job underneath. */}
+      <div className="mx-auto flex min-h-0 w-full min-w-0 max-w-[100dvw] flex-1 flex-col overflow-x-hidden md:max-w-screen-md">
         {/* Header — this route's contribution to the ONE header shell, which is mounted above the
             outlet in RootLayout and is the same element on every screen (so the Collie mark is not
             only identical, it is literally the same drawing, still turning). The pane's own bits are
             portalled into it: the `space › tab` breadcrumb as the center, the ⋮ as the right-cluster
-            lead, and the find bar as the full-row takeover while searching. No `width`: the pane is
-            the edge-to-edge one, which is this component's default. */}
+            lead, and the find bar as the full-row takeover while searching.
+
+            `width="wide"`: the pane is edge to edge below 768px, and from 768px up it is a centred
+            column — which a phone in landscape reaches too, at 844px, giving it 38px each side, the
+            same look the dashboard already has on a portrait iPad. It stops growing because the
+            mirror can never be wider than the mux pane it mirrors.
+            Measured on a 1366px landscape iPad: an 80-column pane renders a ~620px block of text
+            starting at x≈20 and ending near 640px, while the header, both strips, the bottom toolbar
+            and the composer each ran the whole 1366px. One route with two right edges, which is what
+            DESIGN.md §4 forbids — every top-level block "begins and ends on the same x". 768px and
+            not the 640px every other route uses: a 640px column minus its 16px gutters clips an
+            80-column mirror, so the pane pair get their own claim. */}
         <RouteHeader
           onHome={onBack}
+          width="wide"
           // Zen takes the whole row off the screen — the one shell owns the <header> element, so
           // only the shell can stop drawing it, and this is how a route asks. See HeaderClaim.hidden
           // for what survives (the element, its safe-area inset, its reserved rule) and why.

--- a/web/src/components/app-header.test.tsx
+++ b/web/src/components/app-header.test.tsx
@@ -468,6 +468,8 @@ const PaneRoute = () => (
 const SettingsLikeRoute = () => (
   <HoistedRoute name="settings" width="column" override={<button type="button">Back</button>} />
 );
+// The pane's shape, as a fourth type: `width="wide"` rather than the dashboard's `column`.
+const WideRoute = () => <HoistedRoute name="wide" width="wide" onHome={() => {}} />;
 
 function renderHoisted(initialEntry = "/") {
   const router = createMemoryRouter(
@@ -485,6 +487,7 @@ function renderHoisted(initialEntry = "/") {
           { index: true, element: <DashRoute /> },
           { path: "pane", element: <PaneRoute /> },
           { path: "settings", element: <SettingsLikeRoute /> },
+          { path: "wide", element: <WideRoute /> },
         ],
       },
     ],
@@ -622,6 +625,23 @@ describe("the ONE header — hoisted above the outlet", () => {
     expect(header?.className).not.toContain("max-w-screen-sm");
     await go("/settings");
     expect(header?.className).toContain("max-w-screen-sm");
+  });
+
+  it("gives the wide claim the md column, not the sm one the other routes take", async () => {
+    // The third value, added when the PWA stopped locking to portrait. The pane and history screens
+    // were `full`, which on a 1366px landscape iPad spread a header, two strips, a toolbar and a
+    // composer across the whole width above a ~620px mirror. They claim `wide` now: 768px, one
+    // breakpoint out from the 640px the dashboard uses, because a 640px column minus its gutters
+    // clips an 80-column mirror. The two must not collapse into one class.
+    const { container, go } = renderHoisted();
+    const header = container.querySelector("header");
+    await go("/wide");
+    expect(header?.className).toContain("max-w-screen-md");
+    expect(header?.className).not.toContain("max-w-screen-sm");
+    // …and it is still a centred column rather than the full-bleed `full` the pane used to claim.
+    expect(header?.className).toContain("mx-auto");
+    await go("/pane");
+    expect(header?.className).not.toContain("max-w-screen-md");
   });
 
   it("refuses to render a route header with no host above it", () => {

--- a/web/src/components/app-header.tsx
+++ b/web/src/components/app-header.tsx
@@ -36,12 +36,19 @@ import type { Scope } from "@/lib/scope";
 interface HeaderClaim {
   /** Show the stacked identity beside the mark: the "Collie" brand line over the "on <mux>" line. */
   wordmark: boolean;
-  /** `column` = the header is as wide as the route's own `max-w-screen-sm` content column, which is
-   *  what the dashboard, space, Settings and Pack screens have always been; `full` = edge to edge,
-   *  which is what the pane and history screens have always been. Invisible on a phone, where the
-   *  viewport is narrower than the column; on a desktop it is the difference between a 640px rule
-   *  under the header and a 1280px one, so it is a real property of the route and not a default. */
-  width: "column" | "full";
+  /** `column` = the header is as wide as the route's own `max-w-screen-sm` content column (640px),
+   *  which is what the dashboard, space, Settings, Pack and Updates screens have always been;
+   *  `wide` = the same idea one breakpoint out, `max-w-screen-md` (768px), which is what the pane
+   *  and history screens claim — they were `full` until landscape on a tablet showed what that
+   *  costs; `full` = edge to edge, the default, which the unclaimed shell and any route that names
+   *  no width get. Invisible on a portrait phone, where the viewport is narrower than either
+   *  column; on a desktop it is the difference between a 640px rule under the header and a 1280px
+   *  one, so it is a real property of the route and not a default.
+   *
+   *  The pane pair take 768 and not 640 because what sits under them is a terminal mirror: a 640px
+   *  column minus its 16px gutters clips an 80-column mirror. AgentChat's wrapper carries the
+   *  measurement. */
+  width: "column" | "wide" | "full";
   /** The route has taken the whole row (Settings, Pack, and either find bar). The shell then draws
    *  no mark, no caption and no slots — see `RouteHeader`. */
   override: boolean;
@@ -199,6 +206,7 @@ export function AppHeaderHost({ bridge, error, children }: AppHeaderHostProps) {
           // when it comes back.
           claim.hidden ? "border-transparent" : "border-rule",
           claim.width === "column" && "mx-auto w-full max-w-screen-sm",
+          claim.width === "wide" && "mx-auto w-full max-w-screen-md",
         )}
       >
         {/* The row and the prerelease strip leave TOGETHER, and through `Collapse` — DESIGN.md §1's
@@ -380,9 +388,10 @@ interface RouteHeaderProps {
    *  inside a pane: the breadcrumb in `children` carries the context there, and the mark stands alone
    *  to save width. */
   wordmark?: boolean;
-  /** Whether this route's header is as wide as its `max-w-screen-sm` content column or edge to edge.
-   *  See `HeaderClaim.width`. Defaults to `full`, which is the plainer of the two. */
-  width?: "column" | "full";
+  /** Whether this route's header is as wide as its `max-w-screen-sm` content column (`column`), as
+   *  its `max-w-screen-md` one (`wide` — the pane and history screens), or edge to edge (`full`).
+   *  See `HeaderClaim.width`. Defaults to `full`, which is the plainest of the three. */
+  width?: "column" | "wide" | "full";
 
   /** Route-specific center content — the pane's `space › tab` breadcrumb. Rendered in a `flex-1
    *  min-w-0` region so a long breadcrumb truncates instead of pushing the pill off the row. Empty on

--- a/web/src/components/ui/sheet.test.tsx
+++ b/web/src/components/ui/sheet.test.tsx
@@ -236,4 +236,21 @@ describe("BottomSheet: pull-driven peek", () => {
     expect(panel.className).toMatch(/animate-in/);
     expect(panel.className).toMatch(/slide-in-from-bottom/);
   });
+
+  it("caps the panel at the content column while the backdrop stays the whole screen", () => {
+    // The sheet is the app's only floating layer and it holds ordinary rows, so it stops at the same
+    // 640px every route body uses; ui/toast-viewport.tsx already caps its layer there. Uncapped, the
+    // panel spanned the whole viewport — 1366px on a landscape 13-inch iPad — for rows that were
+    // drawn for a phone. The dim is the exception and must not be capped with it.
+    const { container } = render(
+      <BottomSheet open onClose={vi.fn()} title="Switch pane">
+        body
+      </BottomSheet>,
+    );
+    const panel = container.querySelector<HTMLElement>('div[tabindex="-1"]')!;
+    expect(panel.className).toMatch(/\bmx-auto\b/);
+    expect(panel.className).toMatch(/\bmax-w-screen-sm\b/);
+    const backdrop = container.querySelector<HTMLElement>('button[aria-hidden="true"]');
+    expect(backdrop?.className).toMatch(/\babsolute inset-0\b/);
+  });
 });

--- a/web/src/components/ui/sheet.tsx
+++ b/web/src/components/ui/sheet.tsx
@@ -236,7 +236,12 @@ export function BottomSheet({
           // as raised rather than as a hole; --rule (2.06:1 dark) then draws the edge, because this
           // is a cut between two REGIONS and not a component's own outline (DESIGN.md §4). Light
           // gains the same separation for free: white on rgb(245) instead of rgb(245) on rgb(245).
-          "relative z-10 max-h-[82dvh] w-full overflow-y-auto overscroll-contain rounded-t-md border-t border-rule bg-card shadow-2xl",
+          // `mx-auto w-full max-w-screen-sm`: the panel is content, not chrome, so it stops at the
+          // same 640px column every route's body uses and ui/toast-viewport.tsx already caps its
+          // floating layer at. The BACKDROP above stays `absolute inset-0` — the dim is the whole
+          // screen or it is not a dim. Without this the panel spanned the whole viewport, 1366px on
+          // a landscape 13-inch iPad, for rows that were drawn for a phone.
+          "relative z-10 mx-auto max-h-[82dvh] w-full max-w-screen-sm overflow-y-auto overscroll-contain rounded-t-md border-t border-rule bg-card shadow-2xl",
           // The slide-in entrance plays on a fresh open only. A peek has no entrance (it's tracking
           // the finger, not animating), and a drag that continues into an open gets its own 180ms
           // transform transition above rather than restarting from the keyframe's own 100%.

--- a/web/src/routes/history.tsx
+++ b/web/src/routes/history.tsx
@@ -198,9 +198,15 @@ export function HistoryRoute() {
   const matchCursor = matches.indexOf(cursor);
 
   return (
-    <div className="flex min-h-0 flex-1 flex-col">
+    // The same column as the pane this transcript belongs to, because it is the other half of that
+    // screen and one navigation away from it: it keeps the pane's width and its left edge, or the
+    // page jumps sideways on the hop. See AgentChat's wrapper for why the pane stops at 768px.
+    // `max-w-[100dvw]` is the phone bound; `md:max-w-screen-md` only bites from 768px up, where it
+    // is never the wider of the two.
+    <div className="mx-auto flex min-h-0 w-full min-w-0 max-w-[100dvw] flex-1 flex-col md:max-w-screen-md">
       <RouteHeader
         onHome={() => navigate(panePath(paneId, scope))}
+        width="wide"
         override={
           findOpen ? (
             <FindBar

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -166,11 +166,12 @@ export default defineConfig({
         start_url: "/",
         scope: "/",
         display: "standalone",
-        // Not locked to portrait: the manifest is the only thing that was stopping a tablet from
-        // rotating. The shell is fluid (max-w-full / max-w-screen, no phone-width container) and
-        // use-keyboard.ts already re-baselines the visual viewport on a width change so a portrait
-        // baseline doesn't read as "keyboard open" in landscape. A device with rotation lock on
-        // still stays portrait — this defers to the device instead of overriding it.
+        // Not locked to portrait: the manifest was the only thing stopping an installed Collie from
+        // rotating on a tablet. Every route lays out as a centred column rather than a fluid sheet —
+        // 640px on the dashboard, space, Settings, Pack and Updates, 768px on the pane and history
+        // screens above that breakpoint — so a wide viewport gets a real layout and not a stretched
+        // phone. `"any"` defers to the device instead of overriding it, so a tablet held in
+        // landscape with rotation lock on still stays portrait.
         orientation: "any",
         background_color: "#0a0a0a",
         theme_color: "#0a0a0a",

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -166,7 +166,12 @@ export default defineConfig({
         start_url: "/",
         scope: "/",
         display: "standalone",
-        orientation: "portrait",
+        // Not locked to portrait: the manifest is the only thing that was stopping a tablet from
+        // rotating. The shell is fluid (max-w-full / max-w-screen, no phone-width container) and
+        // use-keyboard.ts already re-baselines the visual viewport on a width change so a portrait
+        // baseline doesn't read as "keyboard open" in landscape. A device with rotation lock on
+        // still stays portrait — this defers to the device instead of overriding it.
+        orientation: "any",
         background_color: "#0a0a0a",
         theme_color: "#0a0a0a",
         icons: [


### PR DESCRIPTION
## What

One line in `web/vite.config.ts`: `orientation: "portrait"` → `orientation: "any"`.

## Why

An installed Collie won't rotate on a tablet. The manifest is the only reason. `orientation` is honoured in `display: "standalone"`, so the home-screen app stays portrait however the device is held. Verified against a running bridge, not just the source:

```
$ curl -s http://127.0.0.1:8790/manifest.webmanifest
served orientation: portrait | display: standalone
```

Nothing in the UI actually wants portrait:

- The shell is fluid — `max-w-full` / `max-w-screen` dominate, with no phone-width container. The only `@media` rules in `web/src` are a 640px terminal-background tweak (`index.css:16`) and an 860px breakpoint that belongs to the dev playground (`playground/playground.css:63`), not the app.
- `hooks/use-keyboard.ts:81` already reasons about rotation: *"A width change is an orientation/layout change, not the keyboard — re-baseline so a portrait baseline doesn't read as 'open' in landscape."* The code anticipates landscape; the manifest never allowed it.

`"any"` defers to the device instead of overriding it — a tablet with rotation lock on still stays portrait. Dropping the key entirely would work too; I kept it explicit so the intent reads at the call site. Happy to switch if you'd rather it be absent.

I checked `.adr/` first per CONTRIBUTING. Nothing settles orientation. ADR-0007 arguably points the other way — it describes the idle lock's one appearance as *"A desk, a tablet, a kiosk — almost never a phone"*, which is precisely the long-lived tablet session that can't currently rotate.

## Verification

Built the web bundle and confirmed the emitted manifest:

```
$ cd web && bun run build
$ python3 -c "import json;print(json.load(open('dist/manifest.webmanifest'))['orientation'])"
any
```

Pre-PR checks from CONTRIBUTING:

| Check | Result |
|---|---|
| `bun run typecheck` | pass |
| `cd web && bun run typecheck` | pass |
| `bun run lint` | pass |
| `bun test ./bridge ./cli ./scripts` | pass — 3941 pass, 0 fail |
| `cd web && bun run test` | **18 files / 131 tests fail — pre-existing** |

The web failures are not from this change. I stashed the diff and re-ran on unmodified `main`: identical counts, `18 failed | 163 passed`, `131 failed | 4898 passed | 30 todo`. They're jsdom environment and test-isolation faults (`Cannot read properties of undefined (reading 'setItem')`, `Found multiple elements with the placeholder text`), concentrated in `agent-chat.test.tsx`. A manifest string can't reach them. Flagging in case it's news on your side.

## Version

No version bump or CHANGELOG entry, per the from-a-fork rule. Suggested entry if you want one:

> - Fixed: the installed app no longer locks to portrait, so tablets can run Collie in landscape.

## Not covered

I haven't tested the installed PWA on a physical tablet — this is verified at the manifest level only. Worth noting that Safari's handling of manifest `orientation` for iOS/iPadOS home-screen apps has historically been inconsistent, so an iPad may have been rotating already; the fix is aimed at Chromium-based installs, which do enforce it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YNDSUuuPWJtXq1EsJ6fpuD
