### PR TITLE
fix(stt): bound provider lifecycles

### DIFF
--- a/bridge/stt/codex.test.ts
+++ b/bridge/stt/codex.test.ts
@@ -1,8 +1,9 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, test, vi } from "bun:test";
 
 import type { CodexSttSettings } from "./config.ts";
 import type { CodexAuthBroker } from "./codex-auth.ts";
 import {
+  CODEX_TIMEOUT_MS,
   CODEX_TRANSCRIBE_URL,
   accountIdFromJwt,
   createCodexSttProvider,
@@ -10,7 +11,7 @@ import {
   silentWavBytes,
 } from "./codex.ts";
 import type { FetchFn } from "./openai.ts";
-import { SttError, type SttAudio } from "./provider.ts";
+import { SttCancelledError, SttError, type SttAudio } from "./provider.ts";
 
 // What this provider puts on the wire is the thing ADR 0029 is about, so it is asserted here header
 // by header — including the header that must NOT be there. Everything is injected: no child is
@@ -87,6 +88,15 @@ function recorder(reply: (call: number) => Response): Recorder {
       return reply(calls.length);
     },
   };
+}
+
+/** A promise the test resolves at the exact point a lifecycle must stop waiting for it. */
+function held<T>() {
+  let resolve: (value: T) => void = () => {};
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
 }
 
 describe("the codex provider — the identity on the wire", () => {
@@ -192,6 +202,28 @@ describe("the codex provider — a lapsed session", () => {
     expect(calls).toHaveLength(2);
     expect(broker.refreshes).toEqual([false, true]);
   });
+
+  test("a caller that cancels during the one 401 refresh never uploads the clip again", async () => {
+    const broker = fakeBroker();
+    const renewed = held<{ accessToken: string }>();
+    broker.accessToken = async (refresh = false) => {
+      broker.refreshes.push(refresh);
+      return refresh ? renewed.promise : { accessToken: flatClaimToken("acct-123") };
+    };
+    const { fetch, calls } = recorder(() => new Response("expired", { status: 401 }));
+    const provider = createCodexSttProvider(HONEST, { broker, fetch, prime: false, version: "1.2.3" });
+    const controller = new AbortController();
+    const transcription = provider.transcribe(CLIP, controller.signal);
+
+    for (let turn = 0; turn < 20; turn++) await Promise.resolve();
+    expect(broker.refreshes).toEqual([false, true]);
+    controller.abort();
+
+    await expect(transcription).rejects.toBeInstanceOf(SttCancelledError);
+    renewed.resolve({ accessToken: flatClaimToken("acct-123") });
+    await Bun.sleep(0);
+    expect(calls).toHaveLength(1);
+  });
 });
 
 describe("the codex provider — the bounds", () => {
@@ -261,23 +293,220 @@ describe("the codex provider — the bounds", () => {
     }
   });
 
-  test("the deadline is a timeout, not an unavailable", async () => {
-    const provider = createCodexSttProvider(HONEST, {
-      broker: fakeBroker(),
-      prime: false,
-      version: "1.2.3",
-      timeoutMs: 5,
-      fetch: (_input, init) =>
-        new Promise((_resolve, reject) => {
-          init.signal?.addEventListener("abort", () => reject(new Error("aborted")));
-        }),
-    });
+  test("keeps its provider-local 120-second policy", () => {
+    expect(CODEX_TIMEOUT_MS).toBe(120_000);
+  });
 
-    const error = await provider.transcribe(CLIP).then(
-      () => null,
-      (err: Error) => err,
-    );
-    expect(error instanceof SttError ? error.kind : null).toBe("timeout");
+  test("the deadline is a timeout, not an unavailable", async () => {
+    const controller = new AbortController();
+    let transcription: Promise<unknown> | undefined;
+    vi.useFakeTimers();
+    try {
+      let started = false;
+      const provider = createCodexSttProvider(HONEST, {
+        broker: fakeBroker(),
+        prime: false,
+        version: "1.2.3",
+        timeoutMs: 5,
+        fetch: (_input, init) =>
+          new Promise((_resolve, reject) => {
+            started = true;
+            init.signal?.addEventListener("abort", () => reject(new Error("aborted")));
+          }),
+      });
+
+      transcription = provider.transcribe(CLIP, controller.signal);
+      for (let turn = 0; turn < 20; turn++) await Promise.resolve();
+      expect(started).toBe(true);
+      vi.advanceTimersByTime(5);
+
+      const error = await transcription.then(
+        () => null,
+        (err: Error) => err,
+      );
+      expect(error instanceof SttError ? error.kind : null).toBe("timeout");
+    } finally {
+      controller.abort();
+      if (transcription !== undefined) await transcription.catch(() => undefined);
+      vi.useRealTimers();
+    }
+  });
+
+  test("the deadline includes waiting for a token before a request starts", async () => {
+    const pendingToken = held<{ accessToken: string }>();
+    const controller = new AbortController();
+    let transcription: Promise<unknown> | undefined;
+    vi.useFakeTimers();
+    try {
+      const broker = fakeBroker();
+      broker.accessToken = async (refresh = false) => {
+        broker.refreshes.push(refresh);
+        return pendingToken.promise;
+      };
+      const { fetch, calls } = recorder(() => Response.json({ text: "late" }));
+      const provider = createCodexSttProvider(HONEST, {
+        broker,
+        fetch,
+        prime: false,
+        version: "1.2.3",
+        timeoutMs: 5,
+      });
+
+      transcription = provider.transcribe(CLIP, controller.signal);
+      for (let turn = 0; turn < 20; turn++) await Promise.resolve();
+      expect(broker.refreshes).toEqual([false]);
+      vi.advanceTimersByTime(5);
+
+      const error = await transcription.then(
+        () => null,
+        (err: Error) => err,
+      );
+      expect(error instanceof SttError ? error.kind : null).toBe("timeout");
+      expect(calls).toHaveLength(0);
+    } finally {
+      controller.abort();
+      pendingToken.resolve({ accessToken: flatClaimToken("acct-123") });
+      if (transcription !== undefined) await transcription.catch(() => undefined);
+      vi.useRealTimers();
+    }
+  });
+
+  test("the deadline includes a response body that stalls after headers", async () => {
+    const controller = new AbortController();
+    let transcription: Promise<unknown> | undefined;
+    vi.useFakeTimers();
+    try {
+      let pulls = 0;
+      let cancelled = false;
+      const body = new ReadableStream<Uint8Array>({
+        pull() {
+          // Response construction pulls once; the second pull proves `readCapped` is now waiting.
+          pulls += 1;
+        },
+        cancel() {
+          cancelled = true;
+          return new Promise<void>(() => {});
+        },
+      });
+      const provider = createCodexSttProvider(HONEST, {
+        broker: fakeBroker(),
+        prime: false,
+        version: "1.2.3",
+        timeoutMs: 5,
+        fetch: async () => new Response(body),
+      });
+
+      transcription = provider.transcribe(CLIP, controller.signal);
+      for (let turn = 0; turn < 20; turn++) await Promise.resolve();
+      expect(pulls >= 2).toBe(true);
+      vi.advanceTimersByTime(5);
+
+      const error = await transcription.then(
+        () => null,
+        (err: Error) => err,
+      );
+      expect(error instanceof SttError ? error.kind : null).toBe("timeout");
+      for (let turn = 0; turn < 20; turn++) await Promise.resolve();
+      expect(cancelled).toBe(true);
+    } finally {
+      controller.abort();
+      if (transcription !== undefined) await transcription.catch(() => undefined);
+      vi.useRealTimers();
+    }
+  });
+
+  test("a cancelled caller stops waiting for shared token work without cancelling it", async () => {
+    const broker = fakeBroker();
+    const sharedToken = held<{ accessToken: string }>();
+    broker.accessToken = async (refresh = false) => {
+      broker.refreshes.push(refresh);
+      return sharedToken.promise;
+    };
+    const { fetch, calls } = recorder(() => Response.json({ text: "second caller" }));
+    const provider = createCodexSttProvider(HONEST, { broker, fetch, prime: false, version: "1.2.3" });
+    const controller = new AbortController();
+    const first = provider.transcribe(CLIP, controller.signal);
+
+    for (let turn = 0; turn < 20; turn++) await Promise.resolve();
+    controller.abort();
+    await expect(first).rejects.toBeInstanceOf(SttCancelledError);
+
+    const second = provider.transcribe(CLIP);
+    sharedToken.resolve({ accessToken: flatClaimToken("acct-123") });
+    expect(await second).toEqual({ text: "second caller" });
+    expect(calls).toHaveLength(1);
+    expect(broker.refreshes).toEqual([false, false]);
+  });
+
+  test("time spent in the first attempt reduces the one retry's remaining budget", async () => {
+    const firstResponse = held<Response>();
+    const controller = new AbortController();
+    let transcription: Promise<unknown> | undefined;
+    vi.useFakeTimers();
+    try {
+      const broker = fakeBroker();
+      const signals: AbortSignal[] = [];
+      let calls = 0;
+      const provider = createCodexSttProvider(HONEST, {
+        broker,
+        prime: false,
+        version: "1.2.3",
+        timeoutMs: 120,
+        fetch: (_input, init) => {
+          const signal = init.signal;
+          if (signal === null || signal === undefined) throw new Error("missing lifecycle signal");
+          signals.push(signal);
+          calls += 1;
+          if (calls === 1) return firstResponse.promise;
+          return new Promise((_resolve, reject) => {
+            signal.addEventListener("abort", () => reject(new DOMException("aborted", "AbortError")), {
+              once: true,
+            });
+          });
+        },
+      });
+
+      transcription = provider.transcribe(CLIP, controller.signal);
+      for (let turn = 0; turn < 20; turn++) await Promise.resolve();
+      expect(calls).toBe(1);
+
+      vi.advanceTimersByTime(80);
+      firstResponse.resolve(new Response("expired", { status: 401 }));
+      for (let turn = 0; turn < 20; turn++) await Promise.resolve();
+      expect(calls).toBe(2);
+      expect(signals[1]).toBe(signals[0]);
+
+      let settled = false;
+      void transcription.then(
+        () => {
+          settled = true;
+          return undefined;
+        },
+        () => {
+          settled = true;
+          return undefined;
+        },
+      );
+      vi.advanceTimersByTime(39);
+      await Promise.resolve();
+      expect(signals[1]!.aborted).toBe(false);
+      expect(settled).toBe(false);
+
+      vi.advanceTimersByTime(1);
+      const error = await transcription.then(
+        () => null,
+        (err: Error) => err,
+      );
+      expect(signals[1]!.aborted).toBe(true);
+      expect(error instanceof SttError ? error.kind : null).toBe("timeout");
+      expect(calls).toBe(2);
+      expect(broker.refreshes).toEqual([false, true]);
+    } finally {
+      controller.abort();
+      firstResponse.resolve(new Response("expired", { status: 401 }));
+      if (transcription !== undefined) await transcription.catch(() => undefined);
+      vi.useRealTimers();
+    }
   });
 
   test("a body that is not a transcript is refused rather than surfaced", async () => {
@@ -398,6 +627,46 @@ describe("probeCodexIdentity — honest first, always", () => {
       "not signed in",
     );
     expect(calls).toHaveLength(0);
+  });
+
+  test("one probe lifecycle bounds body disposal before it can fall back", async () => {
+    let probe: Promise<unknown> | undefined;
+    vi.useFakeTimers();
+    try {
+      let cancelled = false;
+      const body = new ReadableStream<Uint8Array>({
+        cancel() {
+          cancelled = true;
+          return new Promise<void>(() => {});
+        },
+      });
+      const { fetch, calls } = recorder(() => new Response(body, { status: 403 }));
+
+      probe = probeCodexIdentity(HONEST, {
+        broker: fakeBroker(),
+        fetch,
+        version: "1.2.3",
+        timeoutMs: 5,
+      });
+      for (let turn = 0; turn < 20; turn++) await Promise.resolve();
+      expect(calls).toHaveLength(1);
+      for (let turn = 0; turn < 20; turn++) await Promise.resolve();
+      expect(cancelled).toBe(true);
+      vi.advanceTimersByTime(5);
+
+      const error = await probe.then(
+        () => null,
+        (err: Error) => err,
+      );
+      expect(error instanceof SttError ? error.kind : null).toBe("timeout");
+      expect(calls).toHaveLength(1);
+    } finally {
+      if (probe !== undefined) {
+        vi.runAllTimers();
+        await probe.catch(() => undefined);
+      }
+      vi.useRealTimers();
+    }
   });
 
   test("a broker the caller handed in is NOT closed by the probe; one the probe made is", async () => {

--- a/bridge/stt/codex.ts
+++ b/bridge/stt/codex.ts
@@ -133,8 +133,6 @@ export function createCodexSttProvider(settings: CodexSttSettings, deps: CodexSt
         deadline.throwIfAborted();
         if (err instanceof SttError || err instanceof SttCancelledError) throw err;
         throw new SttError("unavailable", "the Codex transcription endpoint could not be reached");
-      } finally {
-        deadline.close();
       }
     },
 
@@ -179,7 +177,6 @@ export async function probeCodexIdentity(
       `the Codex transcription endpoint accepted neither identity (${refusals.join("; ")})`,
     );
   } finally {
-    deadline.close();
     // Only kill what this call started. A broker handed in by the caller outlives the probe.
     if (transport.owned) transport.broker.close();
   }

--- a/bridge/stt/codex.ts
+++ b/bridge/stt/codex.ts
@@ -5,7 +5,16 @@ import type { CodexSttSettings, SttWireIdentity } from "./config.ts";
 import { createCodexAuthBroker, type CodexAuthBroker } from "./codex-auth.ts";
 import { jsonRecord, jsonStringField } from "./json.ts";
 import type { FetchFn } from "./openai.ts";
-import { SttError, type SttAudio, type SttProvider, type SttResult, type SttStatus } from "./provider.ts";
+import {
+  createSttDeadline,
+  SttCancelledError,
+  SttError,
+  type SttAudio,
+  type SttDeadline,
+  type SttProvider,
+  type SttResult,
+  type SttStatus,
+} from "./provider.ts";
 import { discardBody, parseTranscript, readCapped } from "./transcript.ts";
 
 // ── THE CODEX PROVIDER ───────────────────────────────────────────────────────────────────────
@@ -39,7 +48,7 @@ import { discardBody, parseTranscript, readCapped } from "./transcript.ts";
 export const CODEX_TRANSCRIBE_URL = "https://chatgpt.com/backend-api/transcribe";
 
 /**
- * The whole-call deadline, headers and body together.
+ * The whole-operation deadline, including auth, one retry, and response cleanup.
  *
  * Two minutes, against openai.ts's one: this endpoint is on the far side of the public internet
  * from a phone-recorded clip, and a slow answer is still an answer worth waiting for.
@@ -102,19 +111,31 @@ export function createCodexSttProvider(settings: CodexSttSettings, deps: CodexSt
       return transport.broker.lastKnown();
     },
 
-    async transcribe(input: SttAudio): Promise<SttResult> {
-      const response = await transport.send(input, settings.wireIdentity);
-      if (isRedirect(response)) {
-        await discardBody(response);
-        throw new SttError("refused", "the Codex transcription endpoint tried to redirect the upload");
+    async transcribe(input: SttAudio, signal?: AbortSignal): Promise<SttResult> {
+      // One lifecycle owns token acquisition, both possible uploads, and every response phase. A
+      // 401 may refresh once, but it never earns a fresh two-minute budget.
+      const deadline = createSttDeadline(signal, transport.timeoutMs);
+      try {
+        const response = await transport.send(input, settings.wireIdentity, deadline);
+        if (isRedirect(response)) {
+          await deadline.wait(discardBody(response));
+          deadline.throwIfAborted();
+          throw new SttError("refused", "the Codex transcription endpoint tried to redirect the upload");
+        }
+        const body = await deadline.wait(readCapped(response, deadline.signal));
+        if (!response.ok) {
+          // The status, and only the status. The body of a ChatGPT error can name the account, the
+          // plan and an internal request id, and none of that belongs in a browser.
+          throw new SttError("refused", codexRefusal(response.status));
+        }
+        return { text: parseTranscript(body) };
+      } catch (err) {
+        deadline.throwIfAborted();
+        if (err instanceof SttError || err instanceof SttCancelledError) throw err;
+        throw new SttError("unavailable", "the Codex transcription endpoint could not be reached");
+      } finally {
+        deadline.close();
       }
-      const body = await readCapped(response);
-      if (!response.ok) {
-        // The status, and only the status. The body of a ChatGPT error can name the account, the
-        // plan and an internal request id, and none of that belongs in a browser.
-        throw new SttError("refused", codexRefusal(response.status));
-      }
-      return { text: parseTranscript(body) };
     },
 
     close(): void {
@@ -141,12 +162,15 @@ export async function probeCodexIdentity(
   deps: CodexSttDeps = {},
 ): Promise<SttWireIdentity> {
   const transport = createTransport(settings, deps);
+  // One probe includes honest identity, its possible refresh, and only then the fallback identity.
+  const deadline = createSttDeadline(undefined, transport.timeoutMs);
   const clip: SttAudio = { audio: silentWavBytes(), mimeType: "audio/wav", filename: "probe.wav" };
   const refusals: string[] = [];
   try {
     for (const identity of IDENTITY_ORDER) {
-      const response = await transport.send(clip, identity);
-      await discardBody(response);
+      const response = await transport.send(clip, identity, deadline);
+      await deadline.wait(discardBody(response));
+      deadline.throwIfAborted();
       if (response.ok && !isRedirect(response)) return identity;
       refusals.push(`${identity} → ${isRedirect(response) ? "a redirect" : codexRefusal(response.status)}`);
     }
@@ -155,6 +179,7 @@ export async function probeCodexIdentity(
       `the Codex transcription endpoint accepted neither identity (${refusals.join("; ")})`,
     );
   } finally {
+    deadline.close();
     // Only kill what this call started. A broker handed in by the caller outlives the probe.
     if (transport.owned) transport.broker.close();
   }
@@ -164,8 +189,10 @@ interface CodexTransport {
   readonly broker: CodexAuthBroker;
   /** True when the broker was built here, and is therefore this transport's to close. */
   readonly owned: boolean;
-  /** One upload, with the single 401 → refresh → retry-once dance around it. */
-  send(input: SttAudio, identity: SttWireIdentity): Promise<Response>;
+  /** The provider-local lifecycle budget, injectable only for hermetic tests. */
+  readonly timeoutMs: number;
+  /** One upload, with the single 401 → refresh → retry-once dance inside one lifecycle. */
+  send(input: SttAudio, identity: SttWireIdentity, deadline: SttDeadline): Promise<Response>;
 }
 
 function createTransport(settings: CodexSttSettings, deps: CodexSttDeps): CodexTransport {
@@ -177,46 +204,52 @@ function createTransport(settings: CodexSttSettings, deps: CodexSttDeps): CodexT
   const timeoutMs = deps.timeoutMs ?? CODEX_TIMEOUT_MS;
   const version = deps.version ?? collieVersionOnce();
 
-  async function once(input: SttAudio, identity: SttWireIdentity, refresh: boolean): Promise<Response> {
-    const { accessToken } = await broker.accessToken(refresh);
-    const form = new FormData();
-    form.append("file", new File([input.audio], input.filename, { type: input.mimeType }));
-
-    const controller = new AbortController();
-    let timedOut = false;
-    const timer = setTimeout(() => {
-      timedOut = true;
-      controller.abort();
-    }, timeoutMs);
+  async function once(
+    input: SttAudio,
+    identity: SttWireIdentity,
+    refresh: boolean,
+    deadline: SttDeadline,
+  ): Promise<Response> {
     try {
-      return await doFetch(CODEX_TRANSCRIBE_URL, {
-        method: "POST",
-        body: form,
-        headers: identityHeaders(identity, accessToken, accountIdFromJwt(accessToken), version),
-        // Manual, not "error": a 3xx has to be READ and refused as a 3xx, because the honest-identity
-        // probe needs to tell "this endpoint bounced me" apart from "the network broke".
-        redirect: "manual",
-        signal: controller.signal,
-      });
+      deadline.throwIfAborted();
+      // Do not abort a shared broker request: another caller may still need the same token. This
+      // lifecycle only stops waiting and continues to observe its eventual result.
+      const { accessToken } = await deadline.wait(broker.accessToken(refresh));
+      deadline.throwIfAborted();
+      const form = new FormData();
+      form.append("file", new File([input.audio], input.filename, { type: input.mimeType }));
+
+      return await deadline.wait(
+        doFetch(CODEX_TRANSCRIBE_URL, {
+          method: "POST",
+          body: form,
+          headers: identityHeaders(identity, accessToken, accountIdFromJwt(accessToken), version),
+          // Manual, not "error": a 3xx has to be READ and refused as a 3xx, because the honest-identity
+          // probe needs to tell "this endpoint bounced me" apart from "the network broke".
+          redirect: "manual",
+          signal: deadline.signal,
+        }),
+      );
     } catch (err) {
-      if (timedOut) throw new SttError("timeout");
-      if (err instanceof SttError) throw err;
+      deadline.throwIfAborted();
+      if (err instanceof SttError || err instanceof SttCancelledError) throw err;
       throw new SttError("unavailable", "the Codex transcription endpoint could not be reached");
-    } finally {
-      clearTimeout(timer);
     }
   }
 
   return {
     broker,
     owned: supplied === undefined,
-    async send(input, identity) {
-      const first = await once(input, identity, false);
+    timeoutMs,
+    async send(input, identity, deadline) {
+      const first = await once(input, identity, false, deadline);
+      deadline.throwIfAborted();
       if (first.status !== 401) return first;
       // A 401 means the borrowed session lapsed mid-flight. Ask Codex to renew it and re-upload
       // ONCE — the recording is already in memory, and a second 401 is a real refusal, not a race.
-      await discardBody(first);
-      return once(input, identity, true);
+      await deadline.wait(discardBody(first));
+      deadline.throwIfAborted();
+      return once(input, identity, true, deadline);
     },
   };
 }

--- a/bridge/stt/http.test.ts
+++ b/bridge/stt/http.test.ts
@@ -15,7 +15,7 @@ import { SttError, type SttAudio, type SttProvider, type SttResult, type SttStat
 /** A provider under the test's control: what it answers, and what it was handed. */
 function fakeProvider(opts: {
   status?: SttStatus;
-  answer?: (input: SttAudio) => SttResult;
+  answer?: (input: SttAudio, signal?: AbortSignal) => SttResult;
   fail?: () => never;
 }) {
   const received: SttAudio[] = [];
@@ -24,20 +24,26 @@ function fakeProvider(opts: {
     async status() {
       return opts.status ?? { available: true };
     },
-    async transcribe(input) {
+    async transcribe(input, signal) {
       received.push(input);
       if (opts.fail) opts.fail();
-      return opts.answer?.(input) ?? { text: "spoken text" };
+      return opts.answer?.(input, signal) ?? { text: "spoken text" };
     },
   };
   return { provider, received };
 }
 
-function audioRequest(body: BodyInit, contentType = "audio/webm;codecs=opus", extra: HeadersInit = {}): Request {
+function audioRequest(
+  body: BodyInit,
+  contentType = "audio/webm;codecs=opus",
+  extra: HeadersInit = {},
+  signal?: AbortSignal,
+): Request {
   return new Request("http://localhost/api/stt", {
     method: "POST",
     headers: { "content-type": contentType, ...extra },
     body,
+    signal,
   });
 }
 
@@ -188,6 +194,55 @@ describe("POST /api/stt — two at a time, and the third is told so", () => {
     // The slots are given back, so a later caller is admitted again.
     const fourth = await transcribeRequest(provider, audioRequest(new Uint8Array([4]), "audio/webm"), admission);
     expect(fourth.response.status).toBe(200);
+  });
+
+  test("caller cancellation returns its slot while a non-cooperative provider finishes later", async () => {
+    let enterProvider: (() => void) | undefined;
+    const providerEntered = new Promise<void>((resolve) => {
+      enterProvider = resolve;
+    });
+    let rejectLate: (reason?: Error) => void = () => {};
+    const later = new Promise<SttResult>((_resolve, reject) => {
+      rejectLate = reject;
+    });
+    let receivedSignal: AbortSignal | undefined;
+    const provider: SttProvider = {
+      id: "openai-compatible",
+      async status() {
+        return { available: true };
+      },
+      transcribe(_input, signal) {
+        receivedSignal = signal;
+        enterProvider!();
+        return later;
+      },
+    };
+    const admission = createSttAdmission(1);
+    const controller = new AbortController();
+    const request = audioRequest(new Uint8Array([1]), "audio/webm", {}, controller.signal);
+    const abandoned = transcribeRequest(provider, request, admission);
+
+    await providerEntered;
+    controller.abort();
+    const stopped = await abandoned;
+
+    expect(receivedSignal).toBe(request.signal);
+    expect(stopped.response.status).toBe(400);
+    expect(await bodyOf(stopped.response)).toMatchObject({ ok: false, code: "stt.unreadable" });
+    expect(stopped.attempt).toEqual({ status: 400, outcome: "invalid", bytes: 1 });
+
+    const { provider: nextProvider } = fakeProvider({});
+    const next = await transcribeRequest(
+      nextProvider,
+      audioRequest(new Uint8Array([2]), "audio/webm"),
+      admission,
+    );
+    expect(next.response.status).toBe(200);
+
+    // The caller returned long before this non-cooperative provider did; its eventual failure must
+    // still be observed by the lifecycle rather than becoming an unhandled rejection.
+    rejectLate(new Error("late provider failure"));
+    await Bun.sleep(0);
   });
 
   test("a refused request never consumes a slot", async () => {

--- a/bridge/stt/http.ts
+++ b/bridge/stt/http.ts
@@ -1,6 +1,6 @@
 import { apiError, type ApiErrorDetail, type ErrorCode } from "../error-codes.ts";
 import type { SttCapability } from "../types.ts";
-import { SttError, type SttProvider } from "./provider.ts";
+import { createSttDeadline, SttCancelledError, SttError, type SttProvider } from "./provider.ts";
 
 // ── THE ROUTE'S OWN RULES, AWAY FROM Bun.serve ───────────────────────────────────────────────
 //
@@ -158,24 +158,38 @@ export async function transcribeRequest(
       );
     }
 
+    // Race the provider itself as well as passing its signal. A provider that is slow to notice a
+    // disconnected caller must not pin one of the two admission slots after that caller leaves.
+    const caller = createSttDeadline(req.signal);
     try {
+      caller.throwIfAborted();
       // The caller's own filename never travels: the provider needs an extension, not metadata.
-      const result = await provider.transcribe({
-        audio,
-        mimeType,
-        filename: `recording.${extension}`,
-      });
+      const result = await caller.wait(
+        provider.transcribe(
+          {
+            audio,
+            mimeType,
+            filename: `recording.${extension}`,
+          },
+          req.signal,
+        ),
+      );
       return {
         response: jsonResponse({ ok: true, text: result.text }, 200),
         attempt: { status: 200, outcome: "ok", bytes: audio.byteLength },
       };
     } catch (err) {
+      if (err instanceof SttCancelledError) {
+        return fail(400, "invalid", "stt.unreadable", undefined, audio.byteLength);
+      }
       const kind = err instanceof SttError ? err.kind : "unavailable";
       // A deadline is a 504 because the request is still honestly in progress somewhere; everything
       // else is a 502, the bridge reporting that its upstream did not deliver.
       const status = kind === "timeout" ? 504 : 502;
       const message = err instanceof SttError ? err.message : "transcription is unavailable";
       return fail(status, kind, "stt.provider_failed", { reason: message, kind }, audio.byteLength);
+    } finally {
+      caller.close();
     }
   } finally {
     release();

--- a/bridge/stt/http.ts
+++ b/bridge/stt/http.ts
@@ -5,7 +5,7 @@ import { createSttDeadline, SttCancelledError, SttError, type SttProvider } from
 // ── THE ROUTE'S OWN RULES, AWAY FROM Bun.serve ───────────────────────────────────────────────
 //
 // `POST /api/stt` is write-gated in server.ts and then handed straight here. Everything the route
-// decides — the size cap, the accepted containers, how many transcriptions may be in flight, and
+// decides — the size cap, the accepted containers, how many requests it is still waiting on, and
 // which status each failure earns — lives in this file so `bun test` can drive all of it; only the
 // dispatch line and the gate stay inside `Bun.serve`, which the runner cannot stand up (CLAUDE.md).
 //
@@ -17,12 +17,12 @@ import { createSttDeadline, SttCancelledError, SttError, type SttProvider } from
 export const MAX_STT_AUDIO_BYTES = 8 * 1024 * 1024;
 
 /**
- * How many transcriptions may be in flight at once, per process.
+ * How many transcriptions Collie is still waiting on at once, per process.
  *
- * Two, and the third caller is told so rather than queued. A transcription holds a whole recording
- * in memory for as long as an operator-configured endpoint takes to answer, so an unbounded route
- * turns a flaky endpoint into the bridge's memory ceiling. Refusing is honest and instant; queueing
- * would make the phone wait behind a request whose deadline it cannot see.
+ * Two, and the third caller is told so rather than queued. A disconnected caller returns its slot:
+ * cooperative provider work aborts, while late non-cooperative work may remain in flight but stays
+ * rejection-observed outside this gate. Refusing is honest and instant; queueing would make the
+ * phone wait behind a request whose deadline it cannot see.
  */
 export const MAX_CONCURRENT_STT = 2;
 
@@ -188,8 +188,6 @@ export async function transcribeRequest(
       const status = kind === "timeout" ? 504 : 502;
       const message = err instanceof SttError ? err.message : "transcription is unavailable";
       return fail(status, kind, "stt.provider_failed", { reason: message, kind }, audio.byteLength);
-    } finally {
-      caller.close();
     }
   } finally {
     release();

--- a/bridge/stt/openai.test.ts
+++ b/bridge/stt/openai.test.ts
@@ -1,8 +1,8 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, test, vi } from "bun:test";
 
 import { DEFAULT_STT_MODEL, type OpenAiSttSettings } from "./config.ts";
-import { MAX_PROVIDER_RESPONSE_BYTES, createOpenAiSttProvider, type FetchFn } from "./openai.ts";
-import { SttError, type SttAudio, type SttResult } from "./provider.ts";
+import { MAX_PROVIDER_RESPONSE_BYTES, STT_TIMEOUT_MS, createOpenAiSttProvider, type FetchFn } from "./openai.ts";
+import { SttCancelledError, SttError, type SttAudio, type SttResult } from "./provider.ts";
 
 // The provider talks to one operator-configured endpoint over plain `fetch`, and `fetch` is a
 // parameter — so every bound it claims (the redirect refusal, the deadline, the response cap, the
@@ -189,10 +189,70 @@ describe("openai-compatible provider — the bounds", () => {
     expect((await provider.transcribe(AUDIO)).text).toBe(padding);
   });
 
+  test("keeps its provider-local 60-second policy", () => {
+    expect(STT_TIMEOUT_MS).toBe(60_000);
+  });
+
   test("a provider that never answers becomes a `timeout`, and the request is aborted", async () => {
+    vi.useFakeTimers();
+    try {
+      let aborted = false;
+      const provider = createOpenAiSttProvider(SETTINGS, {
+        timeoutMs: 5,
+        fetch: (_url, init) =>
+          new Promise((_resolve, reject) => {
+            init.signal?.addEventListener("abort", () => {
+              aborted = true;
+              reject(new DOMException("aborted", "AbortError"));
+            });
+          }),
+      });
+
+      const transcription = provider.transcribe(AUDIO);
+      vi.advanceTimersByTime(5);
+      expect(await kindOf(() => transcription)).toBe("timeout");
+      expect(aborted).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test("one deadline includes a response body that stalls after headers", async () => {
+    vi.useFakeTimers();
+    try {
+      let pulls = 0;
+      let cancelled = false;
+      const body = new ReadableStream<Uint8Array>({
+        pull() {
+          // Response construction pulls once; the second pull proves `readCapped` is now waiting.
+          pulls += 1;
+        },
+        cancel() {
+          cancelled = true;
+          return new Promise<void>(() => {});
+        },
+      });
+      const provider = createOpenAiSttProvider(SETTINGS, {
+        timeoutMs: 5,
+        fetch: async () => new Response(body),
+      });
+
+      const transcription = provider.transcribe(AUDIO);
+      for (let turn = 0; turn < 20; turn++) await Promise.resolve();
+      expect(pulls >= 2).toBe(true);
+      vi.advanceTimersByTime(5);
+      expect(await kindOf(() => transcription)).toBe("timeout");
+      for (let turn = 0; turn < 20; turn++) await Promise.resolve();
+      expect(cancelled).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test("caller cancellation aborts the provider fetch without becoming an upstream failure", async () => {
+    const controller = new AbortController();
     let aborted = false;
     const provider = createOpenAiSttProvider(SETTINGS, {
-      timeoutMs: 5,
       fetch: (_url, init) =>
         new Promise((_resolve, reject) => {
           init.signal?.addEventListener("abort", () => {
@@ -202,7 +262,11 @@ describe("openai-compatible provider — the bounds", () => {
         }),
     });
 
-    expect(await kindOf(() => provider.transcribe(AUDIO))).toBe("timeout");
+    const transcription = provider.transcribe(AUDIO, controller.signal);
+    await Promise.resolve();
+    controller.abort();
+
+    await expect(transcription).rejects.toBeInstanceOf(SttCancelledError);
     expect(aborted).toBe(true);
   });
 

--- a/bridge/stt/openai.ts
+++ b/bridge/stt/openai.ts
@@ -120,8 +120,6 @@ export function createOpenAiSttProvider(
         // Everything else — DNS, TLS, a refused redirect, a socket reset — is one answer. The cause
         // is deliberately not attached: it is a string built from an operator-configured URL.
         throw new SttError("unavailable");
-      } finally {
-        deadline.close();
       }
     },
   };

--- a/bridge/stt/openai.ts
+++ b/bridge/stt/openai.ts
@@ -1,5 +1,13 @@
 import type { OpenAiSttSettings } from "./config.ts";
-import { SttError, type SttAudio, type SttProvider, type SttResult, type SttStatus } from "./provider.ts";
+import {
+  createSttDeadline,
+  SttCancelledError,
+  SttError,
+  type SttAudio,
+  type SttProvider,
+  type SttResult,
+  type SttStatus,
+} from "./provider.ts";
 import { MAX_PROVIDER_RESPONSE_BYTES, parseTranscript, readCapped } from "./transcript.ts";
 
 // ── THE OPENAI-COMPATIBLE PROVIDER ───────────────────────────────────────────────────────────
@@ -60,36 +68,34 @@ export function createOpenAiSttProvider(
       return { available: true };
     },
 
-    async transcribe(input: SttAudio): Promise<SttResult> {
-      const form = new FormData();
-      form.append("file", new File([input.audio], input.filename, { type: input.mimeType }));
-      form.append("model", settings.model);
-      form.append("response_format", "json");
-      // Sent only when the operator named one. An ABSENT field is auto-detect, which is the right
-      // default for somebody who mixes two languages in a sentence; a present one is the fix for the
-      // opposite complaint — a short clip in an accented voice coming back in a language nobody spoke.
-      if (settings.language !== undefined) form.append("language", settings.language);
-
-      const controller = new AbortController();
-      let timedOut = false;
-      const timer = setTimeout(() => {
-        timedOut = true;
-        controller.abort();
-      }, timeoutMs);
-
+    async transcribe(input: SttAudio, signal?: AbortSignal): Promise<SttResult> {
+      // One lifecycle owns both headers and the capped response body, under OpenAI's existing policy.
+      const deadline = createSttDeadline(signal, timeoutMs);
       try {
-        const response = await doFetch(endpoint, {
-          method: "POST",
-          body: form,
-          // No credential means NO HEADER, not an empty one: an endpoint that takes no
-          // authentication must see a request that carries none.
-          headers: settings.apiKey === undefined ? {} : { authorization: `Bearer ${settings.apiKey}` },
-          // A redirect would re-send the audio — and the bearer token — somewhere the operator did
-          // not configure. Refuse rather than follow.
-          redirect: "error",
-          signal: controller.signal,
-        });
-        const body = await readCapped(response);
+        deadline.throwIfAborted();
+        const form = new FormData();
+        form.append("file", new File([input.audio], input.filename, { type: input.mimeType }));
+        form.append("model", settings.model);
+        form.append("response_format", "json");
+        // Sent only when the operator named one. An ABSENT field is auto-detect, which is the right
+        // default for somebody who mixes two languages in a sentence; a present one is the fix for the
+        // opposite complaint — a short clip in an accented voice coming back in a language nobody spoke.
+        if (settings.language !== undefined) form.append("language", settings.language);
+
+        const response = await deadline.wait(
+          doFetch(endpoint, {
+            method: "POST",
+            body: form,
+            // No credential means NO HEADER, not an empty one: an endpoint that takes no
+            // authentication must see a request that carries none.
+            headers: settings.apiKey === undefined ? {} : { authorization: `Bearer ${settings.apiKey}` },
+            // A redirect would re-send the audio — and the bearer token — somewhere the operator did
+            // not configure. Refuse rather than follow.
+            redirect: "error",
+            signal: deadline.signal,
+          }),
+        );
+        const body = await deadline.wait(readCapped(response, deadline.signal));
         if (!response.ok) {
           // The status is worth logging locally; the BODY is not, and never reaches the browser —
           // an upstream error can name an account, a model or an internal host.
@@ -107,13 +113,15 @@ export function createOpenAiSttProvider(
         }
         return { text: parseTranscript(body) };
       } catch (err) {
-        if (timedOut) throw new SttError("timeout");
-        if (err instanceof SttError) throw err;
+        // Fetch and stream reads reject with generic abort errors. The owned lifecycle retains the
+        // caller-cancellation versus timeout distinction before any generic classification.
+        deadline.throwIfAborted();
+        if (err instanceof SttError || err instanceof SttCancelledError) throw err;
         // Everything else — DNS, TLS, a refused redirect, a socket reset — is one answer. The cause
         // is deliberately not attached: it is a string built from an operator-configured URL.
         throw new SttError("unavailable");
       } finally {
-        clearTimeout(timer);
+        deadline.close();
       }
     },
   };

--- a/bridge/stt/provider.test.ts
+++ b/bridge/stt/provider.test.ts
@@ -1,42 +1,95 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, test, vi } from "bun:test";
 
-import { SttCancelledError, createSttDeadline } from "./provider.ts";
+import { SttCancelledError, SttError, createSttDeadline } from "./provider.ts";
 
 describe("createSttDeadline", () => {
-  test("cancellation stops waiting while still observing a later phase rejection", async () => {
-    const caller = new AbortController();
-    const deadline = createSttDeadline(caller.signal);
-    let rejectPhase: (reason?: Error) => void = () => {};
-    const phase = new Promise<never>((_resolve, reject) => {
-      rejectPhase = reject;
-    });
-
+  test("caller cancellation wins while still observing a later phase rejection", async () => {
+    vi.useFakeTimers();
     try {
+      const caller = new AbortController();
+      const deadline = createSttDeadline(caller.signal, 5);
+      let rejectPhase: (reason?: Error) => void = () => {};
+      const phase = new Promise<never>((_resolve, reject) => {
+        rejectPhase = reject;
+      });
+
       const waiting = deadline.wait(phase);
       caller.abort();
       await expect(waiting).rejects.toBeInstanceOf(SttCancelledError);
+      vi.advanceTimersByTime(5);
+      expect(() => deadline.throwIfAborted()).toThrow(SttCancelledError);
 
       // The race has settled, but the phase has not. A missing rejection handler here would become
       // an unhandled rejection on this turn.
       rejectPhase(new Error("late phase failure"));
-      await Bun.sleep(0);
+      await Promise.resolve();
     } finally {
-      deadline.close();
+      vi.useRealTimers();
     }
   });
 
-  test("an already-cancelled caller still observes a rejected phase", async () => {
-    const caller = new AbortController();
-    caller.abort();
-    const deadline = createSttDeadline(caller.signal);
-    const rejected = Promise.reject(new Error("phase failed"));
-
+  test("a timeout wins over a later caller", async () => {
+    vi.useFakeTimers();
     try {
-      await expect(deadline.wait(rejected)).rejects.toBeInstanceOf(SttCancelledError);
-      await Bun.sleep(0);
+      const caller = new AbortController();
+      const deadline = createSttDeadline(caller.signal, 5);
+      let rejectPhase: (reason?: Error) => void = () => {};
+      const phase = new Promise<never>((_resolve, reject) => {
+        rejectPhase = reject;
+      });
+
+      const waiting = deadline.wait(phase);
+      vi.advanceTimersByTime(5);
+      const error = await waiting.then(
+        () => null,
+        (err) => (err instanceof SttError ? err : null),
+      );
+      expect(error).toBeInstanceOf(SttError);
+      expect(error?.kind).toBe("timeout");
+
+      caller.abort();
+      const stopped = (() => {
+        try {
+          deadline.throwIfAborted();
+        } catch (err) {
+          return err;
+        }
+        return null;
+      })();
+      expect(stopped).toBeInstanceOf(SttError);
+      expect(stopped instanceof SttError ? stopped.kind : null).toBe("timeout");
+
+      rejectPhase(new Error("late phase failure"));
+      await Promise.resolve();
     } finally {
-      deadline.close();
+      vi.useRealTimers();
     }
+  });
+
+  test("an already-cancelled caller keeps caller-first precedence and observes a rejected phase", async () => {
+    const caller = new AbortController();
+    const timeout = new AbortController();
+    caller.abort();
+    timeout.abort(new DOMException("timed out", "TimeoutError"));
+    const nativeTimeout = vi.spyOn(AbortSignal, "timeout").mockReturnValue(timeout.signal);
+    try {
+      const deadline = createSttDeadline(caller.signal, 5);
+      const rejected = Promise.reject(new Error("phase failed"));
+
+      await expect(deadline.wait(rejected)).rejects.toBeInstanceOf(SttCancelledError);
+      expect(() => deadline.throwIfAborted()).toThrow(SttCancelledError);
+      await Promise.resolve();
+    } finally {
+      nativeTimeout.mockRestore();
+    }
+  });
+
+  test("a caller TimeoutError remains cancellation", () => {
+    const caller = new AbortController();
+    const deadline = createSttDeadline(caller.signal);
+    caller.abort(new DOMException("caller deadline", "TimeoutError"));
+
+    expect(() => deadline.throwIfAborted()).toThrow(SttCancelledError);
   });
 
   test("cancellation at a phase boundary still observes that phase's rejection", async () => {
@@ -45,11 +98,18 @@ describe("createSttDeadline", () => {
     const rejected = Promise.reject(new Error("body read failed"));
     caller.abort();
 
+    await expect(deadline.wait(rejected)).rejects.toBeInstanceOf(SttCancelledError);
+    await Bun.sleep(0);
+  });
+
+  test("wait removes its listener as soon as work settles", async () => {
+    const deadline = createSttDeadline(undefined);
+    const remove = vi.spyOn(deadline.signal, "removeEventListener");
     try {
-      await expect(deadline.wait(rejected)).rejects.toBeInstanceOf(SttCancelledError);
-      await Bun.sleep(0);
+      await expect(deadline.wait(Promise.resolve("done"))).resolves.toBe("done");
+      expect(remove).toHaveBeenCalledTimes(1);
     } finally {
-      deadline.close();
+      remove.mockRestore();
     }
   });
 });

--- a/bridge/stt/provider.test.ts
+++ b/bridge/stt/provider.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "bun:test";
+
+import { SttCancelledError, createSttDeadline } from "./provider.ts";
+
+describe("createSttDeadline", () => {
+  test("cancellation stops waiting while still observing a later phase rejection", async () => {
+    const caller = new AbortController();
+    const deadline = createSttDeadline(caller.signal);
+    let rejectPhase: (reason?: Error) => void = () => {};
+    const phase = new Promise<never>((_resolve, reject) => {
+      rejectPhase = reject;
+    });
+
+    try {
+      const waiting = deadline.wait(phase);
+      caller.abort();
+      await expect(waiting).rejects.toBeInstanceOf(SttCancelledError);
+
+      // The race has settled, but the phase has not. A missing rejection handler here would become
+      // an unhandled rejection on this turn.
+      rejectPhase(new Error("late phase failure"));
+      await Bun.sleep(0);
+    } finally {
+      deadline.close();
+    }
+  });
+
+  test("an already-cancelled caller still observes a rejected phase", async () => {
+    const caller = new AbortController();
+    caller.abort();
+    const deadline = createSttDeadline(caller.signal);
+    const rejected = Promise.reject(new Error("phase failed"));
+
+    try {
+      await expect(deadline.wait(rejected)).rejects.toBeInstanceOf(SttCancelledError);
+      await Bun.sleep(0);
+    } finally {
+      deadline.close();
+    }
+  });
+
+  test("cancellation at a phase boundary still observes that phase's rejection", async () => {
+    const caller = new AbortController();
+    const deadline = createSttDeadline(caller.signal);
+    const rejected = Promise.reject(new Error("body read failed"));
+    caller.abort();
+
+    try {
+      await expect(deadline.wait(rejected)).rejects.toBeInstanceOf(SttCancelledError);
+      await Bun.sleep(0);
+    } finally {
+      deadline.close();
+    }
+  });
+});

--- a/bridge/stt/provider.ts
+++ b/bridge/stt/provider.ts
@@ -124,8 +124,6 @@ export interface SttDeadline {
   wait<T>(work: Promise<T>): Promise<T>;
   /** Throw the cancellation or deadline error that stopped this lifecycle. */
   throwIfAborted(): void;
-  /** Release the timer and caller listener once the operation has settled. */
-  close(): void;
 }
 
 /**
@@ -136,31 +134,29 @@ export interface SttDeadline {
  * rejection unobserved.
  */
 export function createSttDeadline(caller: AbortSignal | undefined, timeoutMs?: number): SttDeadline {
-  const controller = new AbortController();
-  let stopped: "caller" | "timeout" | null = null;
-  let timer: ReturnType<typeof setTimeout> | undefined;
-  let closed = false;
-
-  const stop = (reason: "caller" | "timeout") => {
-    if (stopped !== null) return;
-    stopped = reason;
-    controller.abort();
-  };
-  const onCallerAbort = () => stop("caller");
-  if (caller?.aborted) stop("caller");
-  else caller?.addEventListener("abort", onCallerAbort, { once: true });
-  if (stopped === null && timeoutMs !== undefined) {
-    timer = setTimeout(() => stop("timeout"), timeoutMs);
+  const timeoutSignal = timeoutMs === undefined ? undefined : AbortSignal.timeout(timeoutMs);
+  // `any` keeps the first source's reason, including when both were already stopped. Put the caller
+  // first so caller cancellation wins that tie; retain the timeout source to classify its reason.
+  let signal: AbortSignal;
+  if (caller === undefined) {
+    signal = timeoutSignal ?? AbortSignal.any([]);
+  } else if (timeoutSignal === undefined) {
+    signal = caller;
+  } else {
+    signal = AbortSignal.any([caller, timeoutSignal]);
   }
 
+  // A caller may itself abort with a TimeoutError; only this exact source reason is our timeout.
+  const stoppedByTimeout = (): boolean =>
+    timeoutSignal?.aborted === true && signal.reason === timeoutSignal.reason;
   const abortError = (): SttError | SttCancelledError =>
-    stopped === "timeout" ? new SttError("timeout") : new SttCancelledError();
+    stoppedByTimeout() ? new SttError("timeout") : new SttCancelledError();
   const throwIfAborted = (): void => {
-    if (stopped !== null) throw abortError();
+    if (signal.aborted) throw abortError();
   };
 
   return {
-    signal: controller.signal,
+    signal,
     throwIfAborted,
     wait<T>(work: Promise<T>): Promise<T> {
       return new Promise<T>((resolve, reject) => {
@@ -168,7 +164,7 @@ export function createSttDeadline(caller: AbortSignal | undefined, timeoutMs?: n
         const finish = (): boolean => {
           if (settled) return false;
           settled = true;
-          controller.signal.removeEventListener("abort", onAbort);
+          signal.removeEventListener("abort", onAbort);
           return true;
         };
         const onAbort = () => {
@@ -200,15 +196,9 @@ export function createSttDeadline(caller: AbortSignal | undefined, timeoutMs?: n
             return undefined;
           },
         );
-        controller.signal.addEventListener("abort", onAbort, { once: true });
-        if (controller.signal.aborted) onAbort();
+        signal.addEventListener("abort", onAbort, { once: true });
+        if (signal.aborted) onAbort();
       });
-    },
-    close(): void {
-      if (closed) return;
-      closed = true;
-      if (timer !== undefined) clearTimeout(timer);
-      caller?.removeEventListener("abort", onCallerAbort);
     },
   };
 }

--- a/bridge/stt/provider.ts
+++ b/bridge/stt/provider.ts
@@ -54,8 +54,14 @@ export interface SttProvider {
   readonly id: string;
   /** Can this provider serve a request — asked for the capability flag, never with audio in hand. */
   status(): Promise<SttStatus>;
-  /** Transcribe one completed recording. Throws {@link SttError} on every failure. */
-  transcribe(input: SttAudio): Promise<SttResult>;
+  /**
+   * Transcribe one completed recording.
+   *
+   * The optional signal lets an HTTP caller stop waiting when its recording leaves; CLI callers
+   * have no caller signal. Throws {@link SttError} on provider failure and
+   * {@link SttCancelledError} when its caller cancelled.
+   */
+  transcribe(input: SttAudio, signal?: AbortSignal): Promise<SttResult>;
   /**
    * Let go of whatever this provider is holding open — OPTIONAL, and absent on a provider that is
    * nothing but a `fetch`.
@@ -100,4 +106,109 @@ function defaultMessage(kind: SttFailureKind): string {
   if (kind === "oversized") return "the transcription service answered with too much data";
   if (kind === "refused") return "the transcription service refused the recording";
   return "transcription is unavailable";
+}
+
+/** A caller stopped waiting; this is distinct from an upstream provider failure. */
+export class SttCancelledError extends Error {
+  constructor() {
+    super("transcription was cancelled");
+    this.name = "SttCancelledError";
+  }
+}
+
+/** One operation's optional deadline and caller-cancellation lifecycle. */
+export interface SttDeadline {
+  /** The signal cooperative work should receive. */
+  readonly signal: AbortSignal;
+  /** Race work against this lifecycle without taking ownership of the work itself. */
+  wait<T>(work: Promise<T>): Promise<T>;
+  /** Throw the cancellation or deadline error that stopped this lifecycle. */
+  throwIfAborted(): void;
+  /** Release the timer and caller listener once the operation has settled. */
+  close(): void;
+}
+
+/**
+ * Bind caller cancellation and an optional deadline into one operation signal.
+ *
+ * `wait` observes its work even after the lifecycle wins. That matters for shared Codex token
+ * acquisition: cancelling one caller must not cancel the broker's shared promise or leave a later
+ * rejection unobserved.
+ */
+export function createSttDeadline(caller: AbortSignal | undefined, timeoutMs?: number): SttDeadline {
+  const controller = new AbortController();
+  let stopped: "caller" | "timeout" | null = null;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let closed = false;
+
+  const stop = (reason: "caller" | "timeout") => {
+    if (stopped !== null) return;
+    stopped = reason;
+    controller.abort();
+  };
+  const onCallerAbort = () => stop("caller");
+  if (caller?.aborted) stop("caller");
+  else caller?.addEventListener("abort", onCallerAbort, { once: true });
+  if (stopped === null && timeoutMs !== undefined) {
+    timer = setTimeout(() => stop("timeout"), timeoutMs);
+  }
+
+  const abortError = (): SttError | SttCancelledError =>
+    stopped === "timeout" ? new SttError("timeout") : new SttCancelledError();
+  const throwIfAborted = (): void => {
+    if (stopped !== null) throw abortError();
+  };
+
+  return {
+    signal: controller.signal,
+    throwIfAborted,
+    wait<T>(work: Promise<T>): Promise<T> {
+      return new Promise<T>((resolve, reject) => {
+        let settled = false;
+        const finish = (): boolean => {
+          if (settled) return false;
+          settled = true;
+          controller.signal.removeEventListener("abort", onAbort);
+          return true;
+        };
+        const onAbort = () => {
+          if (finish()) reject(abortError());
+        };
+
+        // Attach both handlers before looking at cancellation so an already-rejected phase remains
+        // observed even when the caller stopped at the phase boundary.
+        void work.then(
+          (value) => {
+            if (!finish()) return undefined;
+            try {
+              throwIfAborted();
+              resolve(value);
+            } catch (err) {
+              reject(err);
+            }
+            return undefined;
+          },
+          (err) => {
+            if (!finish()) return undefined;
+            try {
+              throwIfAborted();
+            } catch (abort) {
+              reject(abort);
+              return undefined;
+            }
+            reject(err);
+            return undefined;
+          },
+        );
+        controller.signal.addEventListener("abort", onAbort, { once: true });
+        if (controller.signal.aborted) onAbort();
+      });
+    },
+    close(): void {
+      if (closed) return;
+      closed = true;
+      if (timer !== undefined) clearTimeout(timer);
+      caller?.removeEventListener("abort", onCallerAbort);
+    },
+  };
 }

--- a/bridge/stt/transcript.ts
+++ b/bridge/stt/transcript.ts
@@ -21,14 +21,14 @@ export const MAX_PROVIDER_RESPONSE_BYTES = 256 * 1024;
  * Read through the stream rather than `response.text()` so an endpoint that promises 40 bytes and
  * sends 4 GB is cut off at 256 KiB instead of being buffered whole and measured afterwards.
  */
-export async function readCapped(response: Response): Promise<string> {
+export async function readCapped(response: Response, signal?: AbortSignal): Promise<string> {
   if (response.body === null) return "";
   const reader = response.body.getReader();
   const chunks: Uint8Array[] = [];
   let total = 0;
   try {
     for (;;) {
-      const { done, value } = await reader.read();
+      const { done, value } = await readWithSignal(reader, signal);
       if (done) break;
       if (value === undefined) continue;
       total += value.byteLength;
@@ -36,9 +36,8 @@ export async function readCapped(response: Response): Promise<string> {
       chunks.push(value);
     }
   } finally {
-    await reader.cancel().catch(() => {
-      /* the stream is already done or already errored — nothing left to release */
-    });
+    // Cleanup cannot extend a provider operation: a broken source may never settle `cancel()`.
+    cancelReader(reader);
   }
   const joined = new Uint8Array(total);
   let at = 0;
@@ -59,6 +58,56 @@ export async function readCapped(response: Response): Promise<string> {
 export async function discardBody(response: Response): Promise<void> {
   await response.body?.cancel().catch(() => {
     /* already consumed or already errored */
+  });
+}
+
+/** The runtime's reader result without assuming which DOM-lib spelling Bun exposes. */
+type StreamReadResult<T> = Awaited<ReturnType<ReadableStreamDefaultReader<T>["read"]>>;
+
+/** Read one chunk, releasing a stalled reader as soon as the operation signal aborts. */
+function readWithSignal<T>(
+  reader: ReadableStreamDefaultReader<T>,
+  signal: AbortSignal | undefined,
+): Promise<StreamReadResult<T>> {
+  if (signal === undefined) return reader.read();
+  if (signal.aborted) {
+    cancelReader(reader);
+    return Promise.reject(new DOMException("aborted", "AbortError"));
+  }
+
+  const read = reader.read();
+  return new Promise<StreamReadResult<T>>((resolve, reject) => {
+    let settled = false;
+    const finish = (): boolean => {
+      if (settled) return false;
+      settled = true;
+      signal.removeEventListener("abort", onAbort);
+      return true;
+    };
+    const onAbort = () => {
+      if (!finish()) return;
+      cancelReader(reader);
+      reject(new DOMException("aborted", "AbortError"));
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+    if (signal.aborted) onAbort();
+    void read.then(
+      (value) => {
+        if (finish()) resolve(value);
+        return undefined;
+      },
+      (err) => {
+        if (finish()) reject(err);
+        return undefined;
+      },
+    );
+  });
+}
+
+/** Start reader cleanup without letting a non-cooperative source extend the operation. */
+function cancelReader<T>(reader: ReadableStreamDefaultReader<T>): void {
+  void reader.cancel().catch(() => {
+    /* the stream is already done or already errored — nothing left to release */
   });
 }
 


### PR DESCRIPTION
## Summary

Bounds STT provider work to the request that owns it.

- Lifecycle cancellation now uses native `AbortSignal.timeout` and caller-first `AbortSignal.any`, while preserving the winning source/reason needed to distinguish caller cancellation from a provider deadline.
- Caller cancellation now releases admission promptly, while late provider outcomes remain observed.
- OpenAI retains its existing 60s lifecycle across fetch and capped response-body reading, with no retry.
- Codex keeps one existing 120s lifecycle across auth, the first attempt, one 401 refresh/retry, and response bodies; identity probing is likewise bounded by one 120s lifecycle across the probe sequence.
- Stream and process cleanup are abort-aware and bounded, so cleanup cannot hold completion.

## Failure modes fixed

An abandoned caller could previously leave a two-slot admission occupied until a noncooperative provider settled. Codex work could also extend beyond its intended lifecycle budget across auth, retries, response bodies, or identity probing, making failure handling unbounded. This change releases abandoned admissions and carries the owning lifecycle through those paths.

## Compatibility

Wire and audit schemas remain unchanged; caller cancellation now completes promptly through the existing `400 stt.unreadable` / audit `invalid` mapping with the known audio byte count, rather than waiting for a late provider outcome. The 8MiB request cap, OpenAI's no-retry policy and 256KiB response cap, Codex identity order, and Codex's single retry are unchanged. The numeric admission limit remains two, but it now bounds requests Collie is still waiting on rather than every provider operation still in flight. Owned fetch and response-body work aborts with the caller lifecycle; owned Codex brokers retain explicit disposal, while shared broker work is intentionally not canceled. Noncooperative late work remains rejection-observed, with nonblocking best-effort response-reader cleanup. There is no request-intake streaming or request-body/upload deadline, `Bun.serve` or server-timeout manipulation, or server, web, configuration, dependency, version, or changelog change.

## Validation

- STT: 136 tests; server: 184; CLI STT: 34.
- Root and web typechecks; lint; 2700 bridge tests; and the `collie-ctl` suite.
- Corrected full web suite: `cd web && NODE_OPTIONS=--no-experimental-webstorage bun run test` — 181 files passed, 5029 tests passed, 30 todo.
- Version/tag tests, feature-range tag and diff checks, and the cumulative regression: 20/20 isolated runs.
- The source/reason regression covers a caller-originated `DOMException(..., "TimeoutError")` mapping to `SttCancelledError`.

The native Darwin full root test reaches only the unchanged upstream Linux `systemd-run` assertion at `scripts/collie-cli.test.sh:1308`; GitHub Ubuntu CI is required for that assertion. Tests use injected fetches, brokers, and streams, with no external provider or network calls, Codex process, browser, or microphone.
