### PR TITLE
fix: keep release tag checks and fetches on HTTPS

### DIFF
--- a/cli/update-check.test.ts
+++ b/cli/update-check.test.ts
@@ -23,7 +23,6 @@ import type { RemoteResult, RemoteRunner } from "./remote.ts";
 import type { Net } from "./sys.ts";
 import { unitFilePath } from "./unit.ts";
 import {
-  anonymousTagUrl,
   bunCheck,
   checkLine,
   classifyTagFailure,
@@ -418,17 +417,8 @@ describe("preflight — the upstream check", () => {
     });
     await preflight(h.deps);
     const listing = h.exec.calls.find((c) => c.includes("ls-remote"))!;
-    expect(listing).toBe(`${GIT} ls-remote --tags https://github.com/AltanS/collie.git`);
+    expect(listing).toBe(`${GIT} ls-remote --tags https::https://github.com/AltanS/collie.git`);
     expect(h.exec.timeouts.find((t) => t.call.includes("ls-remote"))?.ms).toBe(15_000);
-  });
-
-  test("anonymousTagUrl maps the GitHub ssh spellings to https and leaves everything else alone", () => {
-    expect(anonymousTagUrl("git@github.com:a/b.git")).toBe("https://github.com/a/b.git");
-    expect(anonymousTagUrl("git@github.com:a/b")).toBe("https://github.com/a/b.git");
-    expect(anonymousTagUrl("ssh://git@github.com/a/b.git")).toBe("https://github.com/a/b.git");
-    expect(anonymousTagUrl("https://github.com/a/b.git")).toBe("https://github.com/a/b.git");
-    expect(anonymousTagUrl("git@git.example.com:a/b.git")).toBe("git@git.example.com:a/b.git");
-    expect(anonymousTagUrl("/srv/mirrors/collie.git")).toBe("/srv/mirrors/collie.git");
   });
 
   test("the failure classifier tells a dead network from a credential", () => {

--- a/cli/update-check.ts
+++ b/cli/update-check.ts
@@ -31,6 +31,7 @@ import {
   sshRunner,
 } from "./remote.ts";
 import { realExec, realFiles, realNet, type Exec, type Files, type Net } from "./sys.ts";
+import { tagRemote } from "./update-remote.ts";
 import {
   MAJOR_ACTION,
   parseApiTags,
@@ -367,7 +368,7 @@ export async function upstreamCheck(
   // `--to-tag` asks a different question of the same listing: not "what would an update take" but
   // "does THIS release resolve here, and may this install take it". It is what a peer following its
   // lead asks before it spawns anything (M16/04), and it is answered by the same `listTags()`
-  // through the same `anonymousTagUrl()` — no second listing, no credential, no new mechanism.
+  // through the same `tagRemote()` — no second listing, no credential, no new mechanism.
   if (toTag !== null) {
     const pinned = planToTag({ tags: listed.tags, installed, wanted: toTag });
     return pinned.kind === "refused"
@@ -424,33 +425,6 @@ type TagListing =
 const LS_REMOTE_TIMEOUT_MS = 15_000;
 
 /**
- * The URL a READ-ONLY tag listing should use for `origin`.
- *
- * Listing the tags of a public repository must not depend on a credential. The bridge runs as a
- * systemd user service with no access to the operator's SSH agent, so `git ls-remote origin` on a
- * checkout whose origin is `git@github.com:AltanS/collie.git` fails with "Permission denied
- * (publickey)" — a red preflight that has nothing to do with whether an update could succeed.
- * A GitHub SSH remote is therefore listed over anonymous HTTPS instead. Every other URL is used
- * exactly as git reports it: a self-hosted mirror or a local path is not ours to rewrite.
- */
-export function anonymousTagUrl(url: string): string {
-  const raw = url.trim();
-  const scp = /^git@github\.com:(.+)$/i.exec(raw);
-  const ssh = /^ssh:\/\/git@github\.com\/(.+)$/i.exec(raw);
-  const path = scp?.[1] ?? ssh?.[1];
-  if (path === undefined) return raw;
-  const repo = path.replace(/\/+$/, "").replace(/\.git$/, "");
-  return repo === "" ? raw : `https://github.com/${repo}.git`;
-}
-
-/** What `origin` is called on the wire for a read-only listing — the URL, or the name as a fallback. */
-function tagRemote(deps: UpdateCheckDeps): string {
-  const r = deps.exec.capture("git", gitArgs(deps.ctx.root, ["remote", "get-url", "origin"]));
-  const url = r.found && r.code === 0 ? r.stdout.trim() : "";
-  return url === "" ? "origin" : anonymousTagUrl(url);
-}
-
-/**
  * Why a `git ls-remote` failed, in the only two families a remedy can differ on.
  *
  * `network` is the one the operator fixes by getting the machine online; everything else is the
@@ -482,7 +456,7 @@ const TAG_REMEDY = {
  */
 async function listTags(deps: UpdateCheckDeps, install: InstallKind, repo: string): Promise<TagListing> {
   if (isCheckout(install)) {
-    const remote = tagRemote(deps);
+    const remote = tagRemote(deps.exec, deps.ctx.root);
     const ls = deps.exec.capture(
       "git",
       gitArgs(deps.ctx.root, ["ls-remote", "--tags", remote]),

--- a/cli/update-remote.test.ts
+++ b/cli/update-remote.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { fakeExec, ROOT } from "./fakes.ts";
+import { realExec } from "./sys.ts";
+import { anonymousTagUrl, tagRemote } from "./update-remote.ts";
+
+const HTTPS = "https://github.com/AltanS/collie.git";
+const REMOTE = `https::${HTTPS}`;
+
+describe("release tag transport", () => {
+  test("GitHub spellings select the HTTPS helper; mirrors and paths are unchanged", () => {
+    for (const url of [HTTPS, "git@github.com:AltanS/collie.git", "ssh://git@github.com/AltanS/collie.git"]) {
+      expect(anonymousTagUrl(url)).toBe(REMOTE);
+    }
+    expect(anonymousTagUrl(" git@GitHub.com:a/b/ ")).toBe("https::https://github.com/a/b.git");
+    for (const url of ["git@git.example.com:a/b.git", "https://git.example.com/a/b.git", "/srv/mirrors/collie.git"]) {
+      expect(anonymousTagUrl(url)).toBe(url);
+    }
+  });
+
+  test("a mirror retains its named-remote settings", () => {
+    const exec = fakeExec({ answers: [[`git -C ${ROOT} remote get-url origin`, { stdout: "https://mirror.example/collie.git\n" }]] });
+    expect(tagRemote(exec, ROOT)).toBe("origin");
+  });
+
+  test("an unreadable origin retains the named-remote fallback", () => {
+    const exec = fakeExec({ answers: [[`git -C ${ROOT} remote get-url origin`, { code: 2 }]] });
+    expect(tagRemote(exec, ROOT)).toBe("origin");
+  });
+
+  test("real git lists AND fetches over HTTPS despite global and local SSH rewrites, without editing config", () => {
+    const root = mkdtempSync(join(tmpdir(), "collie-update-https-"));
+    try {
+      const repo = join(root, "source");
+      const checkout = join(root, "checkout");
+      const helpers = join(root, "helpers");
+      const log = join(root, "transport.log");
+      const global = join(root, "gitconfig");
+      mkdirSync(helpers);
+      writeFileSync(global, '[url "git@github.com:"]\n\tinsteadOf = https://github.com/\n');
+      // Only this private HTTPS helper can supply refs. It records the address Git actually hands
+      // it, then serves a local fixture via upload-pack: no network and no operator credentials.
+      writeFileSync(join(helpers, "git-remote-https"), `#!/bin/sh
+printf '%s\\n' "$2" >> "$TRANSPORT_LOG"
+while IFS= read -r line; do
+  case "$line" in
+    capabilities) printf 'connect\\n\\n' ;;
+    'connect git-upload-pack') printf '\\n'; exec git upload-pack "$FIXTURE_REPO" ;;
+    *) printf 'unsupported\\n' ;;
+  esac
+done
+`, { mode: 0o755 });
+      const noSsh = join(root, "no-ssh");
+      writeFileSync(noSsh, '#!/bin/sh\necho "SSH must not be used" >&2\nexit 97\n', { mode: 0o755 });
+      const env = {
+        PATH: process.env.PATH,
+        HOME: root,
+        GIT_CONFIG_NOSYSTEM: "1",
+        GIT_CONFIG_GLOBAL: global,
+        GIT_EXEC_PATH: helpers,
+        GIT_SSH_COMMAND: noSsh,
+        GIT_TERMINAL_PROMPT: "0",
+        TRANSPORT_LOG: log,
+        FIXTURE_REPO: repo,
+      };
+      const exec = realExec(env, root);
+      const git = (args: string[]): string => {
+        const r = exec.capture("git", args, 5_000);
+        if (!r.found || r.code !== 0) throw new Error(`git ${args.join(" ")}: ${r.stderr}`);
+        return r.stdout.trim();
+      };
+      git(["init", "-q", repo]);
+      git(["-C", repo, "-c", "user.name=Test", "-c", "user.email=test@example.invalid", "commit", "-q", "--allow-empty", "-m", "release"]);
+      git(["-C", repo, "tag", "v1.0.0"]);
+      const commit = git(["-C", repo, "rev-parse", "HEAD"]);
+      git(["init", "-q", checkout]);
+      git(["-C", checkout, "remote", "add", "origin", HTTPS]);
+      git(["-C", checkout, "config", "url.ssh://git@github.com/AltanS/.insteadOf", "https://github.com/AltanS/"]);
+      const localConfig = join(checkout, ".git", "config");
+      const before = readFileSync(localConfig, "utf8");
+      const beforeGlobal = readFileSync(global, "utf8");
+
+      // Negative control: a plain HTTPS URL is still rewritten to SSH by real Git.
+      expect(git(["-C", checkout, "ls-remote", "--get-url", HTTPS])).toBe("ssh://git@github.com/AltanS/collie.git");
+      expect(exec.capture("git", ["-C", checkout, "ls-remote", "--tags", HTTPS], 5_000).code).not.toBe(0);
+      const remote = tagRemote(exec, checkout);
+      expect(remote).toBe(REMOTE);
+      expect(git(["-C", checkout, "ls-remote", "--tags", remote])).toBe(`${commit}\trefs/tags/v1.0.0`);
+      git(["-C", checkout, "fetch", "--depth", "1", remote, "+refs/tags/v1.0.0:refs/tags/v1.0.0"]);
+      expect(git(["-C", checkout, "rev-parse", "refs/tags/v1.0.0"])).toBe(commit);
+      expect(readFileSync(log, "utf8").trim().split("\n")).toEqual([HTTPS, HTTPS]);
+      expect(readFileSync(localConfig, "utf8")).toBe(before);
+      expect(readFileSync(global, "utf8")).toBe(beforeGlobal);
+      expect(git(["-C", checkout, "remote", "get-url", "--push", "origin"])).toBe("ssh://git@github.com/AltanS/collie.git");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/cli/update-remote.ts
+++ b/cli/update-remote.ts
@@ -1,0 +1,24 @@
+import { gitArgs, parseGithubRemote } from "./install-kind.ts";
+import type { Exec } from "./sys.ts";
+
+/**
+ * Public GitHub release reads must not depend on the service's SSH config or agent. Merely using
+ * `https://` is insufficient: `url.git@github.com:.insteadOf=https://github.com/` rewrites it back
+ * to SSH. Git's explicit `<transport>::<address>` syntax selects the HTTPS helper without that
+ * prefix matching. The helper receives the ordinary HTTPS URL, retaining HTTP proxy and TLS config.
+ * This is per-call: no saved remote, rewrite rule or push URL changes. Mirrors stay operator-owned.
+ */
+export function anonymousTagUrl(url: string): string {
+  const raw = url.trim();
+  const repo = parseGithubRemote(raw);
+  return repo === null ? raw : `https::https://github.com/${repo}.git`;
+}
+
+/** Shared by preflight, managed updates and staged updates; the origin guard still runs first. */
+export function tagRemote(exec: Exec, root: string): string {
+  const r = exec.capture("git", gitArgs(root, ["remote", "get-url", "origin"]));
+  const url = r.found && r.code === 0 ? r.stdout.trim() : "";
+  const remote = anonymousTagUrl(url);
+  // A mirror keeps its named-remote settings (proxy, upload-pack, etc.), not just its URL.
+  return remote === url ? "origin" : remote;
+}

--- a/cli/update.test.ts
+++ b/cli/update.test.ts
@@ -64,9 +64,10 @@ import {
 // managed checkout is never re-linked.
 
 const GIT = `git -C ${ROOT}`;
+const TAG_REMOTE = "https::https://github.com/AltanS/collie.git";
 const DIST = `${ROOT}/web/dist`;
 
-// `git ls-remote --tags origin` as the remote actually answers: an ANNOTATED tag appears twice, and
+// `git ls-remote --tags` as the remote actually answers: an ANNOTATED tag appears twice, and
 // the peeled (`^{}`) line is the one naming a commit. `nightly` is the ref the anchor must drop;
 // `v1.1.0-rc.1` is parsed but reachable only by an install that is itself on a major-1 prerelease.
 const LS_REMOTE = [
@@ -386,7 +387,7 @@ describe("updateCheckout", () => {
       installed,
       answers: [
         ...MANAGED,
-        [`${GIT} ls-remote --tags origin`, { stdout: LS_REMOTE }],
+        [`${GIT} ls-remote --tags ${TAG_REMOTE}`, { stdout: LS_REMOTE }],
         [`${GIT} rev-parse HEAD`, { stdout: "a1a1a1a1\n" }],
         ...SHALLOW,
         [`${GIT} log -1`, { stdout: "abc1234 the newest release\n" }],
@@ -471,7 +472,7 @@ describe("updateCheckout", () => {
     // A STORING refspec, not the bare ref: the bare form writes FETCH_HEAD and stores no local tag,
     // after which `vite.config.ts` finds no `refs/tags/v0.32.0` at HEAD and stamps the build `-dev`.
     expect(gitRuns(h.exec)).toEqual([
-      `${GIT} fetch --depth 1 origin +refs/tags/v0.32.0:refs/tags/v0.32.0`,
+      `${GIT} fetch --depth 1 ${TAG_REMOTE} +refs/tags/v0.32.0:refs/tags/v0.32.0`,
       `${GIT} checkout -q --detach --force FETCH_HEAD`,
     ]);
     expect(h.io.stdout.join("\n")).toContain("detach onto v0.32.0");
@@ -485,7 +486,7 @@ describe("updateCheckout", () => {
       installed: "0.32.0",
       answers: [
         ...MANAGED,
-        [`${GIT} ls-remote --tags origin`, { stdout: LS_REMOTE }],
+        [`${GIT} ls-remote --tags ${TAG_REMOTE}`, { stdout: LS_REMOTE }],
         [`${GIT} rev-parse HEAD`, { stdout: "b2peeled\n" }],
       ],
     });
@@ -498,7 +499,7 @@ describe("updateCheckout", () => {
   test("--major on a managed checkout detaches onto the next major's tag", () => {
     const h = managed([], "0.31.1");
     expect(updateCheckout(h.deps, { crossMajor: true }).code).toBe(EXIT.OK);
-    expect(gitRuns(h.exec)[0]).toBe(`${GIT} fetch --depth 1 origin +refs/tags/v1.0.0:refs/tags/v1.0.0`);
+    expect(gitRuns(h.exec)[0]).toBe(`${GIT} fetch --depth 1 ${TAG_REMOTE} +refs/tags/v1.0.0:refs/tags/v1.0.0`);
     expect(h.io.stdout.join("\n")).toContain("crossing to Collie 1.0.0");
   });
 
@@ -514,7 +515,7 @@ describe("updateCheckout", () => {
       installed: "1.0.0-beta.9",
       answers: [
         ...MANAGED,
-        [`${GIT} ls-remote --tags origin`, { stdout: TRAIN_DONE }],
+        [`${GIT} ls-remote --tags ${TAG_REMOTE}`, { stdout: TRAIN_DONE }],
         [`${GIT} rev-parse HEAD`, { stdout: "b9b9b9b9\n" }],
         ...SHALLOW,
         [`${GIT} log -1`, { stdout: "d0d0d0d the release\n" }],
@@ -522,7 +523,7 @@ describe("updateCheckout", () => {
     });
     expect(updateCheckout(h.deps).code).toBe(EXIT.OK);
     // v1.0.0, NOT v1.0.0-beta.10: the release supersedes every beta that led to it.
-    expect(gitRuns(h.exec)[0]).toBe(`${GIT} fetch --depth 1 origin +refs/tags/v1.0.0:refs/tags/v1.0.0`);
+    expect(gitRuns(h.exec)[0]).toBe(`${GIT} fetch --depth 1 ${TAG_REMOTE} +refs/tags/v1.0.0:refs/tags/v1.0.0`);
     expect(h.io.stdout.join("\n")).toContain("detach onto v1.0.0");
   });
 
@@ -531,7 +532,7 @@ describe("updateCheckout", () => {
       installed: "1.0.0-beta.9",
       answers: [
         ...MANAGED,
-        [`${GIT} ls-remote --tags origin`, { stdout: BETA_TRAIN }],
+        [`${GIT} ls-remote --tags ${TAG_REMOTE}`, { stdout: BETA_TRAIN }],
         [`${GIT} rev-parse HEAD`, { stdout: "b9b9b9b9\n" }],
         ...SHALLOW,
         [`${GIT} log -1`, { stdout: "c0c0c0c the next beta\n" }],
@@ -540,7 +541,7 @@ describe("updateCheckout", () => {
     expect(updateCheckout(h.deps).code).toBe(EXIT.OK);
     // A prerelease tag name reaches `refs/tags/` untouched — it is a ref like any other.
     expect(gitRuns(h.exec)).toEqual([
-      `${GIT} fetch --depth 1 origin +refs/tags/v1.0.0-beta.10:refs/tags/v1.0.0-beta.10`,
+      `${GIT} fetch --depth 1 ${TAG_REMOTE} +refs/tags/v1.0.0-beta.10:refs/tags/v1.0.0-beta.10`,
       `${GIT} checkout -q --detach --force FETCH_HEAD`,
     ]);
     expect(h.io.stdout.join("\n")).toContain("detach onto v1.0.0-beta.10");
@@ -551,7 +552,7 @@ describe("updateCheckout", () => {
       installed: "1.0.0-beta.10",
       answers: [
         ...MANAGED,
-        [`${GIT} ls-remote --tags origin`, { stdout: BETA_TRAIN }],
+        [`${GIT} ls-remote --tags ${TAG_REMOTE}`, { stdout: BETA_TRAIN }],
         [`${GIT} rev-parse HEAD`, { stdout: "c0c0c0c0\n" }],
       ],
     });
@@ -569,7 +570,7 @@ describe("updateCheckout", () => {
       installed: "1.0.0",
       answers: [
         ...MANAGED,
-        [`${GIT} ls-remote --tags origin`, { stdout: LS_REMOTE }],
+        [`${GIT} ls-remote --tags ${TAG_REMOTE}`, { stdout: LS_REMOTE }],
         [`${GIT} rev-parse HEAD`, { stdout: "cccccccc\n" }],
       ],
     });
@@ -584,7 +585,7 @@ describe("updateCheckout", () => {
       installed: "1.0.0-beta.5",
       answers: [
         ...MANAGED,
-        [`${GIT} ls-remote --tags origin`, { stdout: ONLY_0X }],
+        [`${GIT} ls-remote --tags ${TAG_REMOTE}`, { stdout: ONLY_0X }],
         [`${GIT} rev-parse HEAD`, { stdout: "zzz\n" }],
       ],
     });
@@ -597,7 +598,7 @@ describe("updateCheckout", () => {
     const h = harness({
       answers: [
         ...MANAGED,
-        [`${GIT} ls-remote --tags origin`, { stdout: LS_REMOTE }],
+        [`${GIT} ls-remote --tags ${TAG_REMOTE}`, { stdout: LS_REMOTE }],
         [`${GIT} rev-parse HEAD`, { stdout: "zzz\n" }],
         ...SHALLOW,
         [`${GIT} log -1`, { stdout: "abc1234 tip\n" }],
@@ -605,7 +606,7 @@ describe("updateCheckout", () => {
     });
     expect(updateCheckout(h.deps).code).toBe(EXIT.OK);
     expect(gitRuns(h.exec)).toEqual([
-      `${GIT} fetch --depth 1 origin +refs/tags/v1.0.0:refs/tags/v1.0.0`,
+      `${GIT} fetch --depth 1 ${TAG_REMOTE} +refs/tags/v1.0.0:refs/tags/v1.0.0`,
       `${GIT} checkout -q --detach --force FETCH_HEAD`,
     ]);
     expect(h.io.stdout.join("\n")).toContain("pinning to newest release tag v1.0.0");
@@ -615,7 +616,7 @@ describe("updateCheckout", () => {
     const h = harness({
       answers: [
         ...MANAGED,
-        [`${GIT} ls-remote --tags origin`, { stdout: "" }],
+        [`${GIT} ls-remote --tags ${TAG_REMOTE}`, { stdout: "" }],
         [`${GIT} rev-parse HEAD`, { stdout: "zzz\n" }],
       ],
     });
@@ -629,13 +630,13 @@ describe("updateCheckout", () => {
     // detached — a destruction the operator never asked for and cannot undo.
     const h = harness({ installed: "0.31.1", answers: [
       ...MANAGED,
-      [`${GIT} ls-remote --tags origin`, { stdout: LS_REMOTE }],
+      [`${GIT} ls-remote --tags ${TAG_REMOTE}`, { stdout: LS_REMOTE }],
       [`${GIT} rev-parse HEAD`, { stdout: "a1a1a1a1\n" }],
       ...FULL,
     ] });
     expect(updateCheckout(h.deps).code).toBe(EXIT.OK);
     // …and the storing refspec rides along on the full-clone variant too.
-    expect(gitRuns(h.exec)[0]).toBe(`${GIT} fetch origin +refs/tags/v0.32.0:refs/tags/v0.32.0`);
+    expect(gitRuns(h.exec)[0]).toBe(`${GIT} fetch ${TAG_REMOTE} +refs/tags/v0.32.0:refs/tags/v0.32.0`);
   });
 
   test("a non-git checkout names the reinstall command and fails", () => {
@@ -648,7 +649,7 @@ describe("updateCheckout", () => {
   test("an unreachable remote fails before anything moves", () => {
     const h = harness({
       installed: "0.31.1",
-      answers: [...MANAGED, [`${GIT} ls-remote --tags origin`, { code: 128 }]],
+      answers: [...MANAGED, [`${GIT} ls-remote --tags ${TAG_REMOTE}`, { code: 128 }]],
     });
     expect(updateCheckout(h.deps).code).toBe(EXIT.FAIL);
     expect(gitRuns(h.exec)).toEqual([]);
@@ -658,7 +659,7 @@ describe("updateCheckout", () => {
   test("a failed fetch stops before the checkout", () => {
     const h = managed([[`${ROOT}$ ${GIT} fetch`, { code: 1 }]]);
     expect(updateCheckout(h.deps).code).toBe(EXIT.FAIL);
-    expect(gitRuns(h.exec)).toEqual([`${GIT} fetch --depth 1 origin +refs/tags/v0.32.0:refs/tags/v0.32.0`]);
+    expect(gitRuns(h.exec)).toEqual([`${GIT} fetch --depth 1 ${TAG_REMOTE} +refs/tags/v0.32.0:refs/tags/v0.32.0`]);
   });
 });
 
@@ -721,7 +722,7 @@ describe("update", () => {
       installed: "0.31.1",
       answers: [
         ...MANAGED,
-        [`${GIT} ls-remote --tags origin`, { stdout: LS_REMOTE }],
+        [`${GIT} ls-remote --tags ${TAG_REMOTE}`, { stdout: LS_REMOTE }],
         [`${GIT} rev-parse HEAD`, { stdout: "a1a1a1a1\n" }],
         ...SHALLOW,
       ],
@@ -745,7 +746,7 @@ describe("update", () => {
       installed: "0.31.1",
       answers: [
         ...MANAGED,
-        [`${GIT} ls-remote --tags origin`, { stdout: LS_REMOTE }],
+        [`${GIT} ls-remote --tags ${TAG_REMOTE}`, { stdout: LS_REMOTE }],
         [`${GIT} rev-parse HEAD`, { stdout: "a1a1a1a1\n" }],
         ...SHALLOW,
       ],
@@ -766,7 +767,7 @@ describe("update", () => {
       installed: "0.32.0",
       answers: [
         ...MANAGED,
-        [`${GIT} ls-remote --tags origin`, { stdout: LS_REMOTE }],
+        [`${GIT} ls-remote --tags ${TAG_REMOTE}`, { stdout: LS_REMOTE }],
         [`${GIT} rev-parse HEAD`, { stdout: "b2peeled\n" }],
       ],
     });
@@ -823,7 +824,7 @@ describe("update", () => {
       installed: "0.31.1",
       answers: [
         ...MANAGED,
-        [`${GIT} ls-remote --tags origin`, { stdout: LS_REMOTE }],
+        [`${GIT} ls-remote --tags ${TAG_REMOTE}`, { stdout: LS_REMOTE }],
         [`${GIT} rev-parse HEAD`, { stdout: "a1a1a1a1\n" }],
         ...SHALLOW,
       ],
@@ -841,7 +842,7 @@ describe("update", () => {
       installed: "0.32.0",
       answers: [
         ...LINKED,
-        [`${GIT} ls-remote --tags origin`, { stdout: LS_REMOTE }],
+        [`${GIT} ls-remote --tags ${TAG_REMOTE}`, { stdout: LS_REMOTE }],
         [`${GIT} rev-parse HEAD`, { stdout: "b2peeled\n" }],
       ],
     });
@@ -860,7 +861,7 @@ describe("update", () => {
       installed: "0.31.1",
       answers: [
         ...MANAGED,
-        [`${GIT} ls-remote --tags origin`, { stdout: LS_REMOTE }],
+        [`${GIT} ls-remote --tags ${TAG_REMOTE}`, { stdout: LS_REMOTE }],
         [`${GIT} rev-parse HEAD`, { stdout: "a1a1a1a1\n" }],
         ...SHALLOW,
       ],
@@ -877,7 +878,7 @@ describe("update", () => {
       installed: "0.31.1",
       answers: [
         ...MANAGED,
-        [`${GIT} ls-remote --tags origin`, { stdout: ONLY_0X }],
+        [`${GIT} ls-remote --tags ${TAG_REMOTE}`, { stdout: ONLY_0X }],
         [`${GIT} rev-parse HEAD`, { stdout: "a1a1a1a1\n" }],
         ...SHALLOW,
       ],
@@ -891,7 +892,7 @@ describe("update", () => {
       installed: "0.31.1",
       answers: [
         ...MANAGED,
-        [`${GIT} ls-remote --tags origin`, { stdout: LS_REMOTE }],
+        [`${GIT} ls-remote --tags ${TAG_REMOTE}`, { stdout: LS_REMOTE }],
         [`${GIT} rev-parse HEAD`, { stdout: "a1a1a1a1\n" }],
         ...SHALLOW,
       ],
@@ -938,7 +939,11 @@ describe("the origin assertion", () => {
 
   test("COLLIE_UPDATE_REPO moves the assertion — one override, banner and updater together", async () => {
     const h = harness({
-      answers: [...forked, ...MANAGED, [`${GIT} ls-remote --tags origin`, { stdout: LS_REMOTE }]],
+      answers: [
+        ...forked,
+        ...MANAGED,
+        [`${GIT} ls-remote --tags https::https://github.com/youngsecurity/collie.git`, { stdout: LS_REMOTE }],
+      ],
       installed: "1.0.0",
       env: { COLLIE_UPDATE_REPO: "youngsecurity/collie" },
     });
@@ -1376,7 +1381,7 @@ function legacyClone(over: { answers?: Scripted["answers"]; absent?: string[]; i
     answers: [
       ...(over.answers ?? []),
       ...(LINKED ?? []),
-      [`${GIT} ls-remote --tags origin`, { stdout: LS_REMOTE }],
+      [`${GIT} ls-remote --tags ${TAG_REMOTE}`, { stdout: LS_REMOTE }],
       [`${GIT} rev-parse HEAD`, { stdout: "a1a1a1a1\n" }],
       ...(FULL ?? []),
     ],
@@ -1463,7 +1468,7 @@ describe("the staged checkout path", () => {
     const h = legacyClone();
     expect(await cmdUpdate(h.deps)).toBe(EXIT.OK);
     // The tag is FETCHED and STORED, then a worktree of it is added beside the running install.
-    expect(gitRuns(h.exec)).toContain(`${GIT} fetch origin +refs/tags/v0.32.0:refs/tags/v0.32.0`);
+    expect(gitRuns(h.exec)).toContain(`${GIT} fetch ${TAG_REMOTE} +refs/tags/v0.32.0:refs/tags/v0.32.0`);
     expect(gitRuns(h.exec)).toContain(
       `${GIT} worktree add --detach --force ${WT("v0.32.0")} refs/tags/v0.32.0`,
     );
@@ -1533,7 +1538,7 @@ describe("the staged checkout path", () => {
   });
 
   test("a fetch that fails stops before any worktree is added", async () => {
-    const h = legacyClone({ answers: [[`${ROOT}$ git -C ${ROOT} fetch origin +refs/tags`, { code: 1 }]] });
+    const h = legacyClone({ answers: [[`${ROOT}$ git -C ${ROOT} fetch ${TAG_REMOTE} +refs/tags`, { code: 1 }]] });
     expect(await cmdUpdate(h.deps)).toBe(EXIT.FAIL);
     expect(h.io.stderr.join("\n")).toContain("stopped at the FETCH stage");
     expect(gitRuns(h.exec).join("\n")).not.toContain("worktree add");
@@ -1548,7 +1553,7 @@ describe("the staged checkout path", () => {
   });
 
   test("a staged install that is already current stages nothing at all", async () => {
-    const h = stagedHarness({ answers: [[`git -C ${WT("v1.0.0")} ls-remote --tags origin`, { stdout: LS_REMOTE }]] });
+    const h = stagedHarness({ answers: [[`git -C ${WT("v1.0.0")} ls-remote --tags ${TAG_REMOTE}`, { stdout: LS_REMOTE }]] });
     expect(await cmdUpdate(h.deps)).toBe(EXIT.OK);
     expect(h.io.stdout.join("\n")).toContain("already current");
     expect(h.exec.calls.join("\n")).not.toContain("worktree add");

--- a/cli/update.ts
+++ b/cli/update.ts
@@ -32,6 +32,7 @@ import type { Environment, EnvVars } from "./context.ts";
 import { EXIT } from "./io.ts";
 import { cmdLink, isCollieBinaryPath, type LinkReader, linkPath, type LinkWriter } from "./link.ts";
 import type { Exec, Files, Net, NetFailure } from "./sys.ts";
+import { tagRemote } from "./update-remote.ts";
 import { collieBinary, unitName } from "./unit.ts";
 import {
   driveApply,
@@ -600,7 +601,7 @@ function updateManaged(
   toTag: string | null,
 ): CheckoutOutcome {
   const root = deps.ctx.root;
-  const ls = deps.exec.capture("git", gitArgs(root, ["ls-remote", "--tags", "origin"]));
+  const ls = deps.exec.capture("git", gitArgs(root, ["ls-remote", "--tags", tagRemote(deps.exec, root)]));
   if (!ls.found || ls.code !== 0) {
     deps.io.err("error: could not list the upstream release tags — is the remote reachable?");
     return { code: EXIT.FAIL, moved: false, higher: null };
@@ -690,9 +691,10 @@ function detachOnto(deps: UpdateDeps, git: (args: readonly string[]) => number, 
   // `--depth 1` ONLY when we are already shallow, so an update never truncates the history of a full
   // clone someone happens to have detached.
   const spec = `+${ref}:${ref}`;
+  const remote = tagRemote(deps.exec, root);
   const fetch = isShallow(deps.exec, root)
-    ? ["fetch", "--depth", "1", "origin", spec]
-    : ["fetch", "origin", spec];
+    ? ["fetch", "--depth", "1", remote, spec]
+    : ["fetch", remote, spec];
   if (git(fetch) !== EXIT.OK) return EXIT.FAIL;
   // `--force` because `build` runs `bun install`, which can rewrite the TRACKED lockfiles: a plain
   // checkout would then refuse on the dirty tree and re-break the very update path this fixes.
@@ -1570,9 +1572,10 @@ function republishName(deps: UpdateDeps, root: string, previousBinary: string): 
 function fetchTag(deps: UpdateDeps, root: string, tag: string): boolean {
   const ref = `refs/tags/${tag}`;
   const spec = `+${ref}:${ref}`;
+  const remote = tagRemote(deps.exec, root);
   const args = isShallow(deps.exec, root)
-    ? ["fetch", "--depth", "1", "origin", spec]
-    : ["fetch", "origin", spec];
+    ? ["fetch", "--depth", "1", remote, spec]
+    : ["fetch", remote, spec];
   const r = deps.exec.runIn("git", gitArgs(root, args), root);
   if (!r.found) {
     deps.io.err("error: git not found — cannot stage a version");
@@ -1608,7 +1611,7 @@ async function updateStagedCheckout(
   // BEFORE any fetch. See {@link assertOrigin}: a fork's tags are not this install's to take.
   if (!assertOrigin(deps, git)) return EXIT.FAIL;
 
-  const ls = deps.exec.capture("git", gitArgs(git, ["ls-remote", "--tags", "origin"]));
+  const ls = deps.exec.capture("git", gitArgs(git, ["ls-remote", "--tags", tagRemote(deps.exec, git)]));
   if (!ls.found || ls.code !== 0) {
     deps.io.err("error: could not list the upstream release tags — is the remote reachable?");
     return EXIT.FAIL;


### PR DESCRIPTION
<!-- pi-pr:start -->
## Summary

Fix in-app updates being blocked when Git rewrites public GitHub HTTPS URLs to SSH, for example:

```ini
[url "git@github.com:"]
    insteadOf = https://github.com/
```

The preflight already converted a GitHub SSH origin to HTTPS, but Git applied `insteadOf` again. A service without usable SSH configuration/credentials therefore failed the upstream check. The actual managed/staged tag fetches still used `origin`, so fixing only the preflight would not fix the update.

- Share the release-remote selection between preflight, managed updates and staged updates.
- Select Git's HTTPS helper explicitly with `https::https://github.com/<owner>/<repo>.git`, avoiding the HTTPS URL prefix rewrite. The helper receives the normal HTTPS address, retaining HTTP proxy/TLS configuration.
- Leave saved Git configuration and push URLs untouched; retain the fork/origin guard, major-version gate and exact tag refspecs. Non-GitHub mirrors keep their named-remote settings. Binary artifact downloads and the legacy branch-following path are unchanged.
- Add a network-free regression using real Git, global and repository-local rewrite rules, unusable SSH, and a fixture HTTPS helper backed by local upload-pack. It verifies both listing and fetching, the helper's address, and unchanged configuration/push behavior.

Per the fork contribution policy, versions and CHANGELOG are unchanged. Suggested changelog: “Keep public GitHub release checks and tag fetches on HTTPS when Git rewrites HTTPS URLs to SSH.”

## Validation

- `bun run lint` — passed.
- `bun run typecheck` — passed.
- `cd web && bun run typecheck` — passed.
- `bash scripts/check-version.sh` — passed.
- `bun run test` — passed: 2,700 bridge, 1,216 CLI, 47 script tests, plus CLI/shim/version-hook shell suites.
- `cd web && bun run test` — passed: 181 files, 5,050 tests; 30 existing TODOs.
- `git diff --check` — passed.

The shim suite skipped its no-Bun case because Bun is installed in a system location.

## Review

Independent read-only Spec review of patch digest `9bd26ef143af992f05391c17093dd320882303d9`: no actionable findings. Scoped standards/documentation preparation completed; no unrelated documentation or version changes.

## Remaining risks

- The regression proves real Git transport selection and ref operations with a fixture helper, not an end-to-end GitHub HTTPS/TLS connection.
- Local verification was on Linux; no macOS run. This is a draft, not a merge-readiness claim.
<!-- pi-pr:end -->
