### PR TITLE
fix: check the systemd user bus is reachable before handing update to systemd-run

### DIFF
--- a/cli/lifecycle.ts
+++ b/cli/lifecycle.ts
@@ -80,10 +80,23 @@ export type Tier = "systemd" | "launchd" | "unsupervised";
 const TIERS: readonly Tier[] = ["systemd", "launchd", "unsupervised"];
 
 /**
- * Which supervisor runs the bridge. `systemctl --user show-environment` succeeding — not merely
- * `systemctl` existing — is the gate, because a container or a machine with no user instance has
- * the binary and no bus (the pre-shim collie-ctl.sh). launchd is gated on Darwin too: the
- * `gui/<uid>` domain is Darwin-only.
+ * Whether the systemd user manager is actually reachable — `systemctl --user show-environment`
+ * succeeding, not merely `systemctl`/`systemd-run` existing on disk. A container commonly ships
+ * the systemd package (so the binaries are on `PATH`) without ever running a user instance or
+ * session bus, and `capture` fails distinctly from "not found": found, nonzero, `$DBUS_SESSION_BUS_
+ * ADDRESS` unset. Exported so every caller that needs "can I actually ask systemd to do something"
+ * — not just "is a binary present" — asks the same question the same way; `cli/update.ts`'s
+ * `handOff` learned the difference the hard way, retrying a doomed `systemd-run` forever.
+ */
+export function systemdUserReachable(exec: Exec): boolean {
+  const probe = exec.capture("systemctl", ["--user", "show-environment"]);
+  return probe.found && probe.code === 0;
+}
+
+/**
+ * Which supervisor runs the bridge. {@link systemdUserReachable} is the gate, because a container
+ * or a machine with no user instance has the binary and no bus (the pre-shim collie-ctl.sh).
+ * launchd is gated on Darwin too: the `gui/<uid>` domain is Darwin-only.
  *
  * `COLLIE_SUPERVISOR` pins the answer. The shell had no such knob because its tests could redefine
  * `have_launchd` in a heredoc; a compiled binary cannot be monkey-patched, so without this the
@@ -99,8 +112,7 @@ export function supervisionTier(
   const pinned = env.COLLIE_SUPERVISOR?.trim();
   const named = TIERS.find((tier) => tier === pinned);
   if (named !== undefined) return named;
-  const probe = exec.capture("systemctl", ["--user", "show-environment"]);
-  if (probe.found && probe.code === 0) return "systemd";
+  if (systemdUserReachable(exec)) return "systemd";
   if (platform === "darwin" && exec.which("launchctl") !== null) return "launchd";
   return "unsupervised";
 }

--- a/cli/update.test.ts
+++ b/cli/update.test.ts
@@ -1028,6 +1028,8 @@ interface BinaryOptions {
   hooksCheck?: Partial<import("./sys.ts").ExecResult>;
   /** What `/api/health` answers, in order — the detached runner's gate polls it (M15/04). */
   health?: readonly HealthReply[];
+  /** Extra scripted answers, appended after the fixture's own — e.g. a failing systemd bus probe. */
+  answers?: Scripted["answers"];
 }
 
 /** One `/api/health` answer for the fake net: down, deposed, or up as some version. */
@@ -1068,7 +1070,7 @@ function binaryHarness(over: BinaryOptions = {}): Harness {
     version("1.0.0"),
     [`${INST}/current/bin/collie hooks status --check`, over.hooksCheck ?? { code: EXIT.OK }],
   ];
-  const exec = fakeExec({ answers });
+  const exec = fakeExec({ answers: [...answers, ...(over.answers ?? [])] });
   const seed: SeededFiles = {
     [`${BROOT}/herdr-plugin.toml`]: 'id = "herdr.collie"\nversion = "1.0.0"\n',
     [`${BROOT}/bin/collie`]: "OLD BINARY",
@@ -1168,6 +1170,20 @@ describe("collie update on a binary install", () => {
     expect(h.exec.calls.join("\n")).not.toContain("bun ");
     // The state file says `staging`, so a bridge that comes up now reports a run in flight.
     expect(JSON.parse(h.files.read(`${STATE}/update.json`) ?? "{}").state).toBe("staging");
+    expect(h.exec.spawned[0]?.command[0]).toBe("systemd-run");
+  });
+
+  test("a systemd-run binary with no reachable user bus falls back to setsid, not a doomed handoff", async () => {
+    // The exact shape a container ships: the systemd package is on disk (`which systemd-run`
+    // finds it) but no user manager or session bus is running (`systemctl --user
+    // show-environment` fails) — the failure `handOff` used to miss, wedging every update behind
+    // a `systemd-run` that starts, can't reach the bus, and exits without ever handing off.
+    const h = binaryHarness({
+      others: ["0.9.0"],
+      answers: [["systemctl --user show-environment", { code: 1 }]],
+    });
+    expect(await cmdUpdate(h.deps)).toBe(EXIT.OK);
+    expect(h.exec.spawned[0]?.command[0]).toBe("setsid");
   });
 
   test("the runner flips `current` with one rename, restarts through it, and only then prunes", async () => {

--- a/cli/update.ts
+++ b/cli/update.ts
@@ -15,7 +15,7 @@ import {
 import { STALE_AFTER_MS, type UpdateRun } from "../bridge/update-run.ts";
 import { manifestVersionFrom, readBuildInfo } from "../bridge/version.ts";
 import { type BuildDeps, cmdBuild } from "./build.ts";
-import { logFilePath } from "./lifecycle.ts";
+import { logFilePath, systemdUserReachable } from "./lifecycle.ts";
 import {
   binaryLayout,
   type BinaryLayout,
@@ -1964,7 +1964,7 @@ function handOff(
     args: applyArgv({ ...a, handoff: deps.pid }),
     unit: unitName(deps.ctx.instance),
     stamp: now.toString(36),
-    hasSystemdRun: deps.exec.which("systemd-run") !== null,
+    hasSystemdRun: deps.exec.which("systemd-run") !== null && systemdUserReachable(deps.exec),
     hasSetsid: deps.exec.which("setsid") !== null,
   });
   const pid = deps.exec.spawnDetached(plan.command, {


### PR DESCRIPTION
## Summary

- `handOff()` (the detached-runner handoff `collie update` uses) decided whether to use
  `systemd-run` by checking only `which systemd-run` — whether the binary exists on `PATH`.
- In a container that ships the `systemd` package but never runs a user manager or session bus
  (no `$XDG_RUNTIME_DIR`/`$DBUS_SESSION_BUS_ADDRESS`), that check says yes, the update stages,
  hands off to `systemd-run --user --collect`, which immediately fails with `Failed to connect
  to user scope bus via local transport`, and the run is left stuck in `staging` forever — every
  retry hits the exact same doomed handoff.
- `supervisionTier()` in `cli/lifecycle.ts` already asks the right question
  (`systemctl --user show-environment` succeeding, not just binary presence) to decide the
  `start`/`stop`/`restart` supervision tier. This PR extracts that probe into an exported
  `systemdUserReachable(exec)` and has `handOff` require it too, so a bus-less container falls
  back to `setsid` exactly as it already does when `systemd-run` is absent outright.

## Suggested CHANGELOG line

- `collie update`'s handoff to `systemd-run` now checks the user bus is reachable, not just that the binary exists, so a container with systemd installed but not running no longer wedges every update behind a doomed handoff.

## Test plan

- [x] `bun run lint` — clean
- [x] `bun run typecheck` (root) and `cd web && bun run typecheck` — clean
- [x] `bun run test` (root) — 2700+ tests pass, including the shell-driven `collie CLI lifecycle`
      suite
- [x] Added a regression test in `cli/update.test.ts` reproducing the exact shape (systemd-run
      binary present, `systemctl --user show-environment` failing) — confirmed it fails against
      the old code (falls back to `systemd-run` anyway) and passes with the fix (falls back to
      `setsid`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
