### PR TITLE
fix(tools): resolve external tools on Windows

### DIFF
--- a/bridge/tools.ts
+++ b/bridge/tools.ts
@@ -1,5 +1,5 @@
 import { accessSync, constants } from "node:fs";
-import { isAbsolute, join } from "node:path";
+import { delimiter, isAbsolute, join } from "node:path";
 
 // Finding an external tool (`herdr`, `git`, `systemctl`, `tailscale`, `journalctl`) when there may
 // be no PATH at all.
@@ -33,10 +33,17 @@ export function fallbackDirs(home: string): string[] {
   ];
 }
 
-/** The full search list: absolute PATH entries first (if any), then {@link fallbackDirs}. */
+/**
+ * The full search list: absolute PATH entries first (if any), then {@link fallbackDirs}.
+ *
+ * `node:path`'s `delimiter` rather than a literal `":"` — Windows separates PATH with `;`, and a
+ * `:` split there does not merely miss entries, it shreds every one of them at its drive letter
+ * (`C:\Program Files\Git\cmd` becomes `C` and `\Program Files\Git\cmd`), so the absolute-only
+ * filter below drops the lot and PATH contributes nothing at all.
+ */
 export function searchDirs(path: string | undefined, home: string): string[] {
   const fromPath = (path ?? "")
-    .split(":")
+    .split(delimiter)
     .map((d) => d.trim())
     .filter((d) => d.length > 0 && isAbsolute(d));
   const seen = new Set<string>();
@@ -47,15 +54,56 @@ export function searchDirs(path: string | undefined, home: string): string[] {
   });
 }
 
-/** Pure lookup: the first directory in `dirs` holding an executable `name`, or null. */
+/**
+ * An environment variable read case-insensitively on Windows, exactly as the OS itself reads it.
+ *
+ * Windows spells them `Path` and `PathExt`, and case only stops mattering while the environment is
+ * still the live `process.env` — Node's win32 proxy is case-insensitive. Every copy made of it is
+ * a plain object that is not, and this module is handed such copies (the CLI merges `.env` over the
+ * ambient environment before it builds `Exec`). So `env.PATH` reads `undefined` under PowerShell
+ * while working under a shell that happens to export the name uppercase, such as Git Bash — the
+ * tool search then silently falls back to the POSIX directory list and reports every Windows tool
+ * as "not installed on this host".
+ */
+function envGet(env: Record<string, string | undefined>, name: string): string | undefined {
+  const direct = env[name];
+  if (direct !== undefined) return direct;
+  if (process.platform !== "win32") return undefined;
+  const wanted = name.toLowerCase();
+  for (const key of Object.keys(env)) {
+    if (key.toLowerCase() === wanted) return env[key];
+  }
+  return undefined;
+}
+
+/**
+ * The suffixes a bare tool name may carry, most-bare first. `[""]` everywhere but Windows, where
+ * executability is spelled in the extension: `git`, `herdr` and `python3` exist only as `git.exe`,
+ * `herdr.exe`, `python3.exe`, and a lookup for the bare name finds nothing — which reads downstream
+ * as "not installed" rather than "we looked in the wrong place".
+ */
+export function toolExts(env: Record<string, string | undefined>): string[] {
+  if (process.platform !== "win32") return [""];
+  const raw = envGet(env, "PATHEXT") ?? ".COM;.EXE;.BAT;.CMD";
+  const ext = raw.split(";").map((e) => e.trim()).filter((e) => e !== "");
+  return ["", ...ext];
+}
+
+/**
+ * Pure lookup: the first directory in `dirs` holding an executable `name`, or null. Each directory
+ * is tried against every suffix in `exts` before moving on, so PATH order still decides.
+ */
 export function findIn(
   name: string,
   dirs: string[],
   isExecutable: (p: string) => boolean,
+  exts: readonly string[] = [""],
 ): string | null {
   for (const dir of dirs) {
-    const candidate = join(dir, name);
-    if (isExecutable(candidate)) return candidate;
+    for (const ext of exts) {
+      const candidate = join(dir, name + ext);
+      if (isExecutable(candidate)) return candidate;
+    }
   }
   return null;
 }
@@ -85,5 +133,5 @@ export function findTool(
   home: string,
 ): string | null {
   if (isAbsolute(name)) return isExecutableFile(name) ? name : null;
-  return findIn(name, searchDirs(env.PATH, home), isExecutableFile);
+  return findIn(name, searchDirs(envGet(env, "PATH"), home), isExecutableFile, toolExts(env));
 }

--- a/cli/tools.test.ts
+++ b/cli/tools.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
-import { fallbackDirs, findIn, findTool, searchDirs } from "./tools.ts";
+import { fallbackDirs, findIn, findTool, searchDirs, toolExts } from "./tools.ts";
 
 // The whole reason this module exists: Herdr spawns plugin actions with no login shell, so PATH may
 // be minimal or absent (the pre-shim collie-ctl.sh). PATH is a hint here, never the mechanism.
@@ -67,5 +67,43 @@ describe("findIn", () => {
 
   test("no dirs is null", () => {
     expect(findIn("git", [], () => true)).toBeNull();
+  });
+
+  // On Windows the executable is `git.exe`, and a lookup for the bare name finds nothing — which
+  // reads downstream as "git is not installed" rather than "we looked for the wrong filename".
+  test("every suffix is tried within a directory before moving to the next one", () => {
+    expect(findIn("git", ["/a", "/b"], (p) => p === "/b/git.exe", ["", ".exe"])).toBe("/b/git.exe");
+  });
+
+  test("the bare name wins over a suffixed sibling in the same directory", () => {
+    expect(findIn("git", ["/a"], () => true, ["", ".exe"])).toBe("/a/git");
+  });
+
+  test("PATH order still decides — an earlier dir's suffixed hit beats a later dir's bare one", () => {
+    expect(findIn("git", ["/a", "/b"], (p) => p === "/a/git.exe" || p === "/b/git", ["", ".exe"])).toBe(
+      "/a/git.exe",
+    );
+  });
+});
+
+describe("toolExts", () => {
+  // Off Windows there is no such thing as an executable suffix, so the search must not grow one:
+  // a lone `""` keeps `findIn` doing exactly what it did before suffixes existed.
+  test.skipIf(process.platform === "win32")("is the bare name alone off win32", () => {
+    expect(toolExts({ PATHEXT: ".COM;.EXE" })).toEqual([""]);
+  });
+
+  test.skipIf(process.platform !== "win32")("is the bare name first, then PATHEXT, on win32", () => {
+    expect(toolExts({ PATHEXT: ".COM;.EXE" })).toEqual(["", ".COM", ".EXE"]);
+  });
+
+  test.skipIf(process.platform !== "win32")("falls back to the standard suffixes with no PATHEXT", () => {
+    expect(toolExts({})).toEqual(["", ".COM", ".EXE", ".BAT", ".CMD"]);
+  });
+
+  // Windows spells it `PathExt`, and case survives only while the environment is the live
+  // `process.env` proxy — this module is handed plain copies of it.
+  test.skipIf(process.platform !== "win32")("reads the name case-insensitively on win32", () => {
+    expect(toolExts({ PathExt: ".COM;.EXE" })).toEqual(["", ".COM", ".EXE"]);
   });
 });

--- a/cli/tools.ts
+++ b/cli/tools.ts
@@ -11,4 +11,5 @@ export {
   findTool,
   isExecutableFile,
   searchDirs,
+  toolExts,
 } from "../bridge/tools.ts";


### PR DESCRIPTION
## What

`bridge/tools.ts` assumes a POSIX environment in three ways. On Windows all three fail closed, so every external tool resolves as "not installed on this host".

The user-visible symptom is on the phone: **"The preflight couldn't be run on this machine."** The chain behind it is `findTool("git") → null` → `isGitCheckout` false → install kind `unknown` → `collie update` refuses. `collie doctor` reports the same machine as having no `herdr` and no `python3` while both sit on `PATH`, and `collie update`'s own build step fails with *bun not found*.

## The three

1. **PATH split on `":"`.** Windows separates with `;`, so the split does not merely miss entries — it shreds each one at its drive letter (`C:\Program Files\Git\cmd` becomes `C` and `\Program Files\Git\cmd`). `searchDirs`' absolute-only filter then drops every fragment and PATH contributes nothing at all. Now `node:path`'s `delimiter`.

2. **No `PATHEXT`.** The bare name was joined to each directory as-is, but the executable is `git.exe`, `herdr.exe`, `python3.exe`. `findIn` now takes an `exts` list and tries each suffix *within* a directory before moving on, bare name first, so PATH order still decides. The parameter defaults to `[""]` and `toolExts` returns `[""]` off win32 — the search is byte-for-byte unchanged on Linux and macOS.

3. **`env.PATH` misses Windows' `Path` spelling.** Case-insensitivity survives only while the environment is the live `process.env` proxy; this module is handed plain copies of it (the CLI merges `.env` over the ambient environment before building `Exec`). So `PATH` and `PATHEXT` are read case-insensitively on win32.

The third one is why this was not caught earlier by anyone poking at it from a terminal: the same binary passes under Git Bash, which exports the name uppercase, and fails under PowerShell — which is what a Windows bridge actually runs under.

## Verification

On Windows 11, against a Herdr-managed checkout at v1.5.3, `collie doctor` goes from

```
error: herdr-version   no `herdr` on this host
error: hook-python3    no `python3` on PATH
warn:  install         cannot tell how this Collie was installed (… has no .git of its own …)
```

to `herdr 0.8.2`, `python3.EXE`, and `Herdr-managed checkout … (detached at 1.5.3)`. `collie update --check --local --json` then produces a real preflight (`bun` green, `tree` green, `upstream` green) instead of `update.preflight_unavailable`, and the Updates page on the phone works.

Checks run on Linux, all green: `bun run typecheck`, `cd web && bun run typecheck`, `bun run lint` (0 warnings, 0 errors), `bun test ./cli/tools.test.ts ./bridge/dial.test.ts` (23 pass, 3 skip), and `cd web && bun run test` (181 files, 5050 pass).

## Notes

- No version bump, per CONTRIBUTING's fork rule. Suggested `## [Unreleased]` entry:
  `- Fixed: external tools (git, herdr, python3, bun) now resolve on Windows, so doctor and update work there.`
- New tests cover the suffix search cross-platform and `toolExts` on both sides of the platform check; the three win32-only assertions `skipIf` off Windows.
- Two things remain Windows-rough and are deliberately **not** in this PR, since each is a separate decision: the manifest skips `build` on win32 so there is no `bin/collie` for `canRunUpdate` to find (and a `bun build --compile` there emits `bin/collie.exe`, not the bare name the bridge checks), and `doctor`'s `disk` check cannot read free space on Windows. Happy to follow up on either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UDQT5GAR9qRs6ukXrmDzhL
