### PR TITLE
fix: recognize Codex inline queue status

### DIFF
--- a/web/src/fixtures/panes/README.md
+++ b/web/src/fixtures/panes/README.md
@@ -36,6 +36,7 @@ and the observed commands were approved with no dialog painted.
 | `codex--fresh-idle.txt` | Welcome banner box, tips, empty `› Ask Codex to do anything` composer, status row | `idle` |
 | `codex--draft.txt` | One-line draft on the `› ` row | `idle` |
 | `codex--draft-wrapped.txt` | Long draft word-wrapped onto a two-space-indented continuation row | `idle` |
+| `codex--queue-context-inline.txt` | Queue hint and context percentage share one raw footer row while the composer remains visible | `working` |
 | `codex--working.txt` | `• Working (3s • esc to interrupt)` above a still-visible composer (Codex queues mid-turn) | `working` |
 | `codex--approval-exec.txt` | Exec approval: header, Environment/Reason, `$ command`, options `1. Yes, proceed (y)` / `2. …don't ask again… (p)` / `3. No… (esc)`, enter/esc footer. Digits 1 and 3 live-probed (1 ran the command, 3 rejected it — file verified absent); `y` probed too | `blocked` |
 | `codex--ask-fruit.txt` | `request_user_input` card: `Question 1/1` header, options with descriptions plus the auto-added `None of the above`, notes footer. Digit live-probed: answers AND submits | `blocked` |

--- a/web/src/fixtures/panes/codex--queue-context-inline.txt
+++ b/web/src/fixtures/panes/codex--queue-context-inline.txt
@@ -1,0 +1,5 @@
+Earlier work completed.
+
+[0m[1m[38;5;6m›[0m[0m continue the release checklist[0m
+
+  [38;5;6mTab[0m[2m to queue message[0m                              [2m93% context left[0m

--- a/web/src/lib/harness/codex.test.ts
+++ b/web/src/lib/harness/codex.test.ts
@@ -37,6 +37,7 @@ const PINNED = [
   "codex--draft-wrapped.txt",
   "codex--draft.txt",
   "codex--fresh-idle.txt",
+  "codex--queue-context-inline.txt",
   "codex--submitted-fill-labelled-rule.txt",
   "codex--trust-prompt.txt",
   "codex--v0150-custom-status.txt",
@@ -85,6 +86,7 @@ describe("composerReady — the gate the reply path pre-flights on", () => {
     "codex--draft-wrapped.txt",
     "codex--v0151-draft-indented-line.txt",
     "codex--working.txt",
+    "codex--queue-context-inline.txt",
   ])(
     "%s: the composer is on screen ⇒ true",
     (name) => {
@@ -160,6 +162,19 @@ describe("chrome", () => {
     expect(status).toHaveLength(1);
     expect(lineText(status[0]!)).toMatch(/ · Context \d+% left/);
     expect(codexAdapter.composerPrompt!(lines)).toMatch(/^› /);
+  });
+
+  // RED-FIRST regression: before the parser fix, this real footer shape made the visible composer
+  // indistinguishable from a modal and the guarded reply stalled before submit.
+  it("locates the composer when queue hint and context percentage share one footer row", () => {
+    const lines = fixtureLines("codex--queue-context-inline.txt");
+    expect(lineText(lines.at(-1)!)).toContain("to queue message");
+    expect(lineText(lines.at(-1)!)).toContain("93% context left");
+    expect(locateComposer(lines)).not.toBeNull();
+    expect(codexAdapter.composerReady!(lines)).toBe(true);
+    expect(codexAdapter.extractInputDraft(lines)).toBe(
+      "continue the release checklist",
+    );
   });
 
   it("a transcript `› ` echo without a status row beneath is not a composer", () => {

--- a/web/src/lib/harness/codex/markers.ts
+++ b/web/src/lib/harness/codex/markers.ts
@@ -59,6 +59,11 @@ export function rstrip(text: string): string {
 const STATUS_ROW =
   /^ {2}\S.* · (?:(?:.* · )+Context \d+% (?:left|used)\b|Context \d+% (?:left|used)\b · \S)/;
 
+// Codex can render the queue hint and context metric on one raw footer row while a turn is active.
+// The key is configurable; the queue wording and context metric are the stable parts.
+const INLINE_QUEUE_CONTEXT_ROW =
+  /^ {2}\S.*\bto queue(?: message)?\s+\d+% context (?:left|used)\b/;
+
 /** The exact separator paint Codex renders between status fields. */
 const STATUS_SEPARATOR = " \u00b7 ";
 /** Bounds. A status field is a model name, a path or a branch — never a paragraph. */
@@ -178,7 +183,8 @@ function isStyledStatusRow(text: string, line: StyledLine): boolean {
  *  is located by the prompt-row-above-status shape at the buffer tail, not by any single row.
  *  `line` is the same row, styled; without it only the `Context`-bearing shape can be accepted. */
 export function isStatusRow(text: string, line?: StyledLine): boolean {
-  if (STATUS_ROW.test(rstrip(text))) return true;
+  const row = rstrip(text);
+  if (STATUS_ROW.test(row) || INLINE_QUEUE_CONTEXT_ROW.test(row)) return true;
   return line !== undefined && isStyledStatusRow(text, line);
 }
 

--- a/web/src/lib/reply-action.test.ts
+++ b/web/src/lib/reply-action.test.ts
@@ -1,3 +1,6 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
 import { http, HttpResponse } from "msw";
 
 import { server } from "@/test/setup";
@@ -10,6 +13,8 @@ import { draftCarriesSend, sendGuardedReply } from "./reply-action";
 // approving whatever option was highlighted, while the bridge still reported {ok:true}.
 
 const BOX_RULE = "─".repeat(40); // clears the 20-glyph border threshold in harness/claude/markers
+const PANES_DIR = join(import.meta.dirname, "..", "fixtures", "panes");
+const fixtureText = (name: string) => readFileSync(join(PANES_DIR, name), "utf8");
 const paneWithDraft = (draft: string) => `some output\n${BOX_RULE}\n❯ ${draft}\n${BOX_RULE}`;
 // A focused permission dialog: no input box at the tail at all, so extractInputDraft sees nothing.
 const paneWithDialog = "Do you want to proceed?\n ❯ 1. Yes\n   2. No\n\n Esc to cancel";
@@ -183,6 +188,25 @@ describe("draftCarriesSend", () => {
 });
 
 describe("sendGuardedReply", () => {
+  // RED-FIRST regression: the visible Codex composer used to be classified as absent when its queue
+  // hint and context percentage shared one raw terminal row. This must still verify before submit.
+  it("types, verifies, and submits on Codex's inline queue/context footer", async () => {
+    const calls = harness(() => fixtureText("codex--queue-context-inline.txt"));
+
+    const out = await sendGuardedReply({
+      paneId: "w1:p1",
+      text: "continue the release checklist",
+      agent: "codex",
+      ...instant,
+    });
+
+    expect(out).toEqual({ status: "sent" });
+    expect(calls).toEqual([
+      { text: "continue the release checklist", submit: false },
+      { text: "", submit: true },
+    ]);
+  });
+
   it("types, verifies the text on the input line, then submits", async () => {
     const calls = harness(() => paneWithDraft("ship it please"));
 


### PR DESCRIPTION
## Summary

Codex can render its queue hint and context percentage on the same raw terminal row while a turn is active. Collie's composer locator previously recognized the older dot-separated/context status-row shapes, so this visible composer was treated as absent and the guarded reply path returned `Message didn't reach the input box` before typing or submitting.

The root cause is the raw pane layout, not the phone's visual line wrapping: the captured ANSI buffer contains one footer row with both `to queue message` and `93% context left`. The parser must recognize that generic row shape before applying the existing prompt, verification, and guarded-submit flow.

## Changes

- Recognize the generic inline queue/context Codex footer row in the Codex marker parser.
- Add a small anonymized ANSI fixture preserving the observed SGR styling and one-row layout.
- Add focused parser and `sendGuardedReply` regressions proving type -> verify -> submit ordering.
- Keep dialog detection, text verification, prompt binding, and guarded submit behavior unchanged.

## Red-first evidence

With the pre-change parser, the new fixture produced `locateComposer returned null`. With this change it locates `{ promptRow: 2, statusRow: 4 }`, and the focused send regression passes with submit still guarded.

## Scope

This PR is limited to the Codex parser, its fixture, and the focused regression tests. Release metadata is intentionally untouched, as required for functional changes submitted from a fork.

## Verification

- Backend and web typechecks: passed.
- Lint, version consistency, and `git diff --check`: passed.
- Focused Codex/reply-action tests: passed.
- Full web Vitest suite: passed.
- Bridge root, mux, journal, pack, CLI, and scripts test groups: passed when run independently.

The local full backend invocation also reaches all assertions in the STT suites but does not terminate under the installed Bun 1.3.14/macOS runtime because two existing response-body disposal tests leave a deliberately pending stream cancellation; the changed files are outside that code. The pushed PR's CI run is the authoritative full-suite check.
