### PR TITLE
fix: bind guarded submit to verified prompt

### DIFF
--- a/web/src/lib/reply-action.test.ts
+++ b/web/src/lib/reply-action.test.ts
@@ -16,16 +16,19 @@ const paneWithDialog = "Do you want to proceed?\n ❯ 1. Yes\n   2. No\n\n Esc t
 
 /** Record every reply POST, and let the fake pane's screen be swapped per test. */
 function harness(screen: () => string) {
-  const calls: Array<{ text: string; submit: boolean }> = [];
+  const calls: Array<{ text: string; submit: boolean; expected_prompt?: string }> = [];
   server.use(
     http.get(/\/api\/pane\/[^/]+$/, () =>
       HttpResponse.json({ paneId: "w1:p1", text: screen(), truncated: false, revision: 1 }),
     ),
-    http.post<never, { text: string; submit: boolean }>(/\/api\/pane\/[^/]+\/reply$/, async ({ request }) => {
-      const body = await request.json();
-      calls.push(body);
-      return HttpResponse.json({ ok: true });
-    }),
+    http.post<never, { text: string; submit: boolean; expected_prompt?: string }>(
+      /\/api\/pane\/[^/]+\/reply$/,
+      async ({ request }) => {
+        const body = await request.json();
+        calls.push(body);
+        return HttpResponse.json({ ok: true });
+      },
+    ),
   );
   return calls;
 }
@@ -202,6 +205,55 @@ describe("sendGuardedReply", () => {
     ]);
   });
 
+  it("binds submit to the verified region and preserves text when the prompt changes", async () => {
+    const suggestion = "\x1b[38;2;111;115;119m to the deploy host\x1b[0m";
+    const initial =
+      `some output\n\x1b[38;2;74;80;88m╭── statusline ───╮\x1b[0m\n` +
+      `\x1b[38;2;74;80;88m╰─ \x1b[0mship it please${suggestion}   \x1b[38;2;74;80;88m ─╯\x1b[0m`;
+    const expectedPrompt = "╰─ ship it please to the deploy host    ─╯";
+    const calls: Array<{ text: string; submit: boolean; expected_prompt?: string }> = [];
+    let reads = 0;
+    let promptChanged = false;
+    server.use(
+      http.get(/\/api\/pane\/[^/]+$/, () => {
+        reads++;
+        // The second read is the successful post-type verification. The dialog appears immediately
+        // after that read, before the submit request reaches the bridge.
+        if (reads === 2) promptChanged = true;
+        return HttpResponse.json({ paneId: "w1:p1", text: initial, truncated: false, revision: 1 });
+      }),
+      http.post<never, { text: string; submit: boolean; expected_prompt?: string }>(
+        /\/api\/pane\/[^/]+\/reply$/,
+        async ({ request }) => {
+          const body = await request.json();
+          calls.push(body);
+          if (body.submit && promptChanged) {
+            // A real bridge binding check returns this before its adapter sends any submit keys.
+            return HttpResponse.json(
+              { ok: false, error: "prompt changed", code: "prompt_changed" },
+              { status: 409 },
+            );
+          }
+          return HttpResponse.json({ ok: true });
+        },
+      ),
+    );
+
+    const out = await sendGuardedReply({
+      paneId: "w1:p1",
+      text: "ship it please",
+      agent: "omp",
+      ...instant,
+    });
+
+    expect(out).toMatchObject({ status: "error", textDelivered: true });
+    expect(out).toHaveProperty("error", expect.stringMatching(/screen changed/i));
+    expect(calls).toEqual([
+      { text: "ship it please", submit: false },
+      { text: "", submit: true, expected_prompt: expectedPrompt },
+    ]);
+  });
+
   // GHOST TEXT must never vouch for a send. A newer Claude Code paints a generated "suggested next
   // prompt" into an otherwise empty box, faint (SGR 2). `draftCarriesSend` accepts any draft whose
   // visible characters appear contiguously in the sent text, so a suggestion that happens to be an
@@ -235,11 +287,10 @@ describe("sendGuardedReply", () => {
   // stalled — while the message really was sitting in the box.
   it("submits on an omp pane whose composer shows an inline suggestion", async () => {
     const suggestion = "\x1b[38;2;111;115;119m to the deploy host\x1b[0m";
-    const calls = harness(
-      () =>
-        `some output\n\x1b[38;2;74;80;88m╭── statusline ───╮\x1b[0m\n` +
-        `\x1b[38;2;74;80;88m╰─ \x1b[0mship it please${suggestion}   \x1b[38;2;74;80;88m ─╯\x1b[0m`,
-    );
+    const screen =
+      `some output\n\x1b[38;2;74;80;88m╭── statusline ───╮\x1b[0m\n` +
+      `\x1b[38;2;74;80;88m╰─ \x1b[0mship it please${suggestion}   \x1b[38;2;74;80;88m ─╯\x1b[0m`;
+    const calls = harness(() => screen);
 
     const out = await sendGuardedReply({
       paneId: "w1:p1",
@@ -251,7 +302,7 @@ describe("sendGuardedReply", () => {
     expect(out).toEqual({ status: "sent" });
     expect(calls).toEqual([
       { text: "ship it please", submit: false },
-      { text: "", submit: true },
+      { text: "", submit: true, expected_prompt: "╰─ ship it please to the deploy host    ─╯" },
     ]);
   });
 

--- a/web/src/lib/reply-action.ts
+++ b/web/src/lib/reply-action.ts
@@ -296,6 +296,7 @@ export async function sendGuardedReply(args: GuardedReplyArgs): Promise<ReplyOut
     // POLL_DELAY_MS off the common path — the old blind flow always paid a fixed 350ms here.
     if (attempt > 0) await sleep(POLL_DELAY_MS);
     let draft: string | null = null;
+    let verifiedPrompt: string | undefined;
     try {
       const fresh = await fetchPane(args.paneId, args.requestedLines, args.scope);
       const lines = splitLines(parseAnsi(fresh.text));
@@ -309,10 +310,13 @@ export async function sendGuardedReply(args: GuardedReplyArgs): Promise<ReplyOut
       const composerVisible = adapter.composerReady?.(lines) ?? false;
       lastSeen = composerVisible ? null : detectNoEchoPrompt(lines);
       draft = adapter.extractInputDraft(lines);
+      // Carry the exact region from the same read that verified the text. The bridge checks it again
+      // before sending submitKeys, so a focus change after verification becomes prompt_changed.
+      verifiedPrompt = adapter.composerPrompt?.(lines) ?? undefined;
     } catch {
       continue; // transient read failure — the bounded loop is the timeout
     }
-    if (draftCarriesSend(args.text, draft)) return submitOnly(args);
+    if (draftCarriesSend(args.text, draft)) return submitOnly(args, verifiedPrompt);
     // The adapter gets a second look, and only a second look: a harness can SWALLOW what we typed and
     // paint a token of its own instead (Claude collapses anything past its paste threshold into
     // `[Pasted text #N +M lines]`), so the box never holds our words and the match above structurally
@@ -320,7 +324,9 @@ export async function sendGuardedReply(args: GuardedReplyArgs): Promise<ReplyOut
     // thing that knows its harness's token and whether this one is consistent with THIS send
     // (.adr/0010). It can only widen the evidence, never narrow it, so a harness without the
     // capability is untouched.
-    if (draft !== null && adapter.draftCarriesSend?.(args.text, draft)) return submitOnly(args);
+    if (draft !== null && adapter.draftCarriesSend?.(args.text, draft)) {
+      return submitOnly(args, verifiedPrompt);
+    }
   }
 
   // The text never showed up on the input line. The likeliest cause is a dialog holding focus and
@@ -471,12 +477,15 @@ async function oneShot(args: GuardedReplyArgs): Promise<ReplyOutcome> {
 
 /**
  * Empty text + submit: `sendReplySteps` skips the send_text step entirely and sends ONLY the
- * bridge's configured submit keys (COLLIE_SUBMIT_KEYS). So the submit-key contract stays
- * server-owned and this whole guard needs no bridge change.
+ * bridge's configured submit keys (COLLIE_SUBMIT_KEYS). When available, the verified prompt region
+ * rides along as `expected_prompt`, so the bridge can refuse a stale submit before those keys land.
  */
-async function submitOnly(args: GuardedReplyArgs): Promise<ReplyOutcome> {
+async function submitOnly(
+  args: GuardedReplyArgs,
+  expectedPrompt?: string,
+): Promise<ReplyOutcome> {
   try {
-    const res = await sendReply(args.paneId, "", true, args.scope);
+    const res = await sendReply(args.paneId, "", true, args.scope, expectedPrompt);
     if (res.ok) return { status: "sent" };
     // The text is verifiably sitting in the input box and only the submit key failed — same shape as
     // the bridge's own partial-failure case. Tell the caller not to resend.
@@ -484,7 +493,10 @@ async function submitOnly(args: GuardedReplyArgs): Promise<ReplyOutcome> {
       // The bridge's own `reply.not_submitted` case, reached from the client side — so it says it
       // with the bridge's own catalogued sentence rather than a second copy of the English.
       status: "error",
-      error: t("apiError.reply.not_submitted"),
+      error:
+        res.code === "prompt_changed"
+          ? t("apiError.prompt_changed")
+          : t("apiError.reply.not_submitted"),
       textDelivered: true,
     };
   } catch (e) {


### PR DESCRIPTION
## Summary

- Bind guarded submit to the prompt region verified immediately after typing.
- Forward that region as `expected_prompt` so the bridge rejects a stale submit with `prompt_changed` before sending submit keys.
- Preserve the verified draft and existing screen-changed error behavior.

## Tests

- `web/src/lib/reply-action.test.ts`: verifies the binding and the prompt-change race, including that text remains unsent.
- Focused reply-action tests: 42 passed.
- Backend and web typechecks plus lint passed.

This fork PR intentionally leaves version files and `CHANGELOG.md` unchanged, per `CONTRIBUTING.md`.
