### PR TITLE
fix(push): recover failed notification setup

### DIFF
--- a/web/src/hooks/use-push.test.ts
+++ b/web/src/hooks/use-push.test.ts
@@ -1,0 +1,40 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { disablePush, enablePush, getPushState } from "@/lib/push";
+import { usePushControl } from "./use-push";
+
+vi.mock("@/lib/push", () => ({
+  disablePush: vi.fn(),
+  enablePush: vi.fn(),
+  getPushState: vi.fn(),
+  isPushDisabledByUser: vi.fn(),
+}));
+
+beforeEach(() => {
+  vi.mocked(getPushState).mockReset().mockResolvedValue({
+    availability: "ready", subscribed: false, userDisabled: true,
+  });
+  vi.mocked(enablePush).mockReset();
+  vi.mocked(disablePush).mockReset();
+});
+
+it("refreshes state and releases the busy flag when enabling throws, then allows retry", async () => {
+  const { result } = renderHook(() => usePushControl());
+  await waitFor(() => expect(result.current.state).not.toBeNull());
+  const calls = vi.mocked(getPushState).mock.calls.length;
+  vi.mocked(enablePush).mockRejectedValueOnce(new Error("push service unavailable"));
+  await act(async () => {
+    await expect(result.current.setEnabled(true)).rejects.toThrow("push service unavailable");
+  });
+  expect(result.current.busy).toBe(false);
+  expect(getPushState).toHaveBeenCalledTimes(calls + 1);
+
+  vi.mocked(enablePush).mockResolvedValueOnce({ ok: true });
+  vi.mocked(getPushState).mockResolvedValueOnce({
+    availability: "ready", subscribed: true, userDisabled: false,
+  });
+  await act(async () => {
+    await expect(result.current.setEnabled(true)).resolves.toEqual({ ok: true });
+  });
+  expect(result.current.state?.subscribed).toBe(true);
+  expect(result.current.busy).toBe(false);
+});

--- a/web/src/hooks/use-push.ts
+++ b/web/src/hooks/use-push.ts
@@ -47,15 +47,16 @@ export function usePushControl() {
       setBusy(true);
       try {
         if (enabled) {
-          const res = await enablePush();
-          await refresh();
-          return res;
+          return await enablePush();
         }
         await disablePush();
-        await refresh();
         return { ok: true };
       } finally {
-        setBusy(false);
+        try {
+          await refresh();
+        } finally {
+          setBusy(false);
+        }
       }
     },
     [refresh],

--- a/web/src/lib/ack-manifest.ts
+++ b/web/src/lib/ack-manifest.ts
@@ -140,6 +140,10 @@ export const ACK_MANIFEST = {
     channel: "echo",
     why: "The switch flips optimistically under the thumb; the server's merged view then reconciles it, and a REVERT is paired with an error status because a switch that moves back in silence misinforms anyone who has stopped looking (hooks/use-notify-prefs.ts).",
   },
+  registerPushSubscription: {
+    channel: "inline",
+    why: "Settings switches on only after the bridge acknowledges registration; setup failures stay beside the switch so the operator can read them and retry (routes/settings.tsx).",
+  },
   checkForUpdates: {
     channel: "inline",
     why: "The answer — up to date, an offer, or 'the check itself failed' — is a standing fact about this install that belongs in the card that states it, and it must not fade out from under the operator (components/update-check-control.tsx).",

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -29,6 +29,7 @@ import type {
   WorktreeListResponse,
   WorktreeOpenResponse,
 } from "./types";
+import type { SubscribeBody } from "./push";
 
 export type { NotifyPrefs, UpdateInfo };
 
@@ -650,6 +651,11 @@ export function openWorktree(
  */
 export function fetchConfig(): Promise<BridgeConfig> {
   return req<BridgeConfig>("/api/config");
+}
+
+/** Register push through the same timeout, authentication and error handling as the other APIs. */
+export function registerPushSubscription(body: SubscribeBody): Promise<void> {
+  return req<void>("/api/subscribe", { method: "POST", body: JSON.stringify(body) });
 }
 
 /**

--- a/web/src/lib/i18n/messages/de.ts
+++ b/web/src/lib/i18n/messages/de.ts
@@ -47,6 +47,8 @@ export const de: Dictionary = {
     "Benachrichtigungen sind blockiert. In den Browsereinstellungen aktivieren.",
   "settings.push.reason.unsupported": "Dieser Browser unterstützt keine Push-Benachrichtigungen.",
   "settings.push.reason.default": "Push-Benachrichtigungen konnten nicht aktiviert werden.",
+  "settings.push.reason.timeout": "Zeitüberschreitung beim Einrichten der Benachrichtigungen. Prüfe, ob dieses Gerät den Push-Dienst erreichen kann, und versuche es erneut.",
+  "settings.push.availability.unavailable": "Die Benachrichtigungseinstellungen konnten nicht geprüft werden. Prüfe deine Verbindung oder melde dich erneut an und versuche es noch einmal.",
   "settings.push.availability.insecure":
     "Über HTTP nicht verfügbar. Collie über HTTPS bereitstellen, um Push zu nutzen.",
   "settings.push.availability.serverOff":

--- a/web/src/lib/i18n/messages/en.ts
+++ b/web/src/lib/i18n/messages/en.ts
@@ -56,6 +56,8 @@ export const en = {
     "Notifications are blocked — enable them in your browser settings.",
   "settings.push.reason.unsupported": "This browser doesn't support push notifications.",
   "settings.push.reason.default": "Couldn't enable push notifications.",
+  "settings.push.reason.timeout": "Notification setup timed out. Check that this device can reach its push service, then try again.",
+  "settings.push.availability.unavailable": "Could not check notification setup. Check your connection or sign in again, then retry.",
   "settings.push.availability.insecure":
     "Unavailable over plain HTTP — serve Collie over HTTPS to enable push.",
   "settings.push.availability.serverOff":

--- a/web/src/lib/i18n/messages/es.ts
+++ b/web/src/lib/i18n/messages/es.ts
@@ -46,6 +46,8 @@ export const es: Dictionary = {
     "Notificaciones bloqueadas en los permisos del navegador.",
   "settings.push.reason.unsupported": "Este navegador no soporta Web Push.",
   "settings.push.reason.default": "No se pudieron activar las notificaciones push.",
+  "settings.push.reason.timeout": "Se agotó el tiempo para configurar las notificaciones. Comprueba que este dispositivo pueda conectarse al servicio push y vuelve a intentarlo.",
+  "settings.push.availability.unavailable": "No se pudo comprobar la configuración de notificaciones. Revisa la conexión o inicia sesión de nuevo y vuelve a intentarlo.",
   "settings.push.availability.insecure":
     "No disponible en HTTP. Sirve Collie sobre HTTPS para habilitar push.",
   "settings.push.availability.serverOff":

--- a/web/src/lib/i18n/messages/ja.ts
+++ b/web/src/lib/i18n/messages/ja.ts
@@ -45,6 +45,8 @@ export const ja: Dictionary = {
   "settings.push.reason.denied": "通知がブロックされています。ブラウザの設定で許可してください。",
   "settings.push.reason.unsupported": "使用中のブラウザはプッシュ通知に対応していません。",
   "settings.push.reason.default": "プッシュ通知を有効化できませんでした。",
+  "settings.push.reason.timeout": "通知の設定がタイムアウトしました。この端末がプッシュサービスに接続できることを確認して、もう一度お試しください。",
+  "settings.push.availability.unavailable": "通知の設定を確認できませんでした。接続を確認するか、再度ログインしてからお試しください。",
   "settings.push.availability.insecure":
     "HTTP 経由では利用できません。プッシュ通知には HTTPS 配信が必要です。",
   "settings.push.availability.serverOff":

--- a/web/src/lib/i18n/messages/ko.ts
+++ b/web/src/lib/i18n/messages/ko.ts
@@ -46,6 +46,8 @@ export const ko: Dictionary = {
   "settings.push.reason.denied": "알림 권한이 차단되어 있습니다. 브라우저 설정에서 활성화하십시오.",
   "settings.push.reason.unsupported": "이 브라우저는 푸시 알림을 지원하지 않습니다.",
   "settings.push.reason.default": "푸시 알림을 활성화할 수 없습니다.",
+  "settings.push.reason.timeout": "알림 설정 시간이 초과되었습니다. 이 기기에서 푸시 서비스에 연결할 수 있는지 확인한 후 다시 시도하세요.",
+  "settings.push.availability.unavailable": "알림 설정을 확인할 수 없습니다. 연결을 확인하거나 다시 로그인한 후 다시 시도하세요.",
   "settings.push.availability.insecure":
     "HTTP 연결에서는 푸시 알림을 지원하지 않습니다. HTTPS로 Collie를 호스팅하십시오.",
   "settings.push.availability.serverOff":

--- a/web/src/lib/i18n/messages/zh-TW.ts
+++ b/web/src/lib/i18n/messages/zh-TW.ts
@@ -45,6 +45,8 @@ export const zhTW: Dictionary = {
   "settings.push.reason.denied": "通知權限已被拒絕，請在瀏覽器設定中啟用。",
   "settings.push.reason.unsupported": "目前瀏覽器不支援推播通知。",
   "settings.push.reason.default": "無法啟用推播通知。",
+  "settings.push.reason.timeout": "通知設定逾時。請確認目前裝置能連線至推播服務，然後重試。",
+  "settings.push.availability.unavailable": "無法檢查通知設定。請檢查網路或重新登入，然後重試。",
   "settings.push.availability.insecure": "一般 HTTP 環境不可用。請透過 HTTPS 部署 Collie 以啟用推播。",
   "settings.push.availability.serverOff": "Bridge 缺少 VAPID 金鑰設定，伺服器端已停用推播功能。",
   "settings.push.availability.denied": "目前網站的通知權限已被拒絕。請在瀏覽器設定中重新允許。",

--- a/web/src/lib/i18n/messages/zh.ts
+++ b/web/src/lib/i18n/messages/zh.ts
@@ -46,6 +46,8 @@ export const zh: Dictionary = {
   "settings.push.reason.denied": "通知权限已被拒绝，请在浏览器设置中启用。",
   "settings.push.reason.unsupported": "当前浏览器不支持推送通知。",
   "settings.push.reason.default": "无法启用推送通知。",
+  "settings.push.reason.timeout": "通知设置超时。请确认当前设备能连接推送服务，然后重试。",
+  "settings.push.availability.unavailable": "无法检查通知配置。请检查网络或重新登录，然后重试。",
   "settings.push.availability.insecure": "普通 HTTP 环境不可用。请通过 HTTPS 部署 Collie 以启用推送。",
   "settings.push.availability.serverOff": "网桥缺少 VAPID 密钥配置，服务端已禁用推送功能。",
   "settings.push.availability.denied": "当前站点的通知权限已被拒绝。请在浏览器设置中重新允许。",

--- a/web/src/lib/push-lifecycle.test.ts
+++ b/web/src/lib/push-lifecycle.test.ts
@@ -1,0 +1,164 @@
+import { fetchConfig, registerPushSubscription } from "@/lib/api";
+import { disablePush, enablePush, getPushState } from "./push";
+
+vi.mock("@/lib/api", () => ({
+  fetchConfig: vi.fn(),
+  registerPushSubscription: vi.fn(),
+}));
+
+const key = Uint8Array.from({ length: 65 }, (_, i) => i === 0 ? 4 : 1);
+const vapidPublicKey = btoa(String.fromCharCode(...key)).replace(/=/g, "");
+const subscription = {
+  endpoint: "https://push.example.test/device",
+  options: { applicationServerKey: key.buffer },
+  toJSON: () => ({
+    endpoint: "https://push.example.test/device",
+    keys: { p256dh: "test-key", auth: "test-auth" },
+  }),
+  unsubscribe: vi.fn(async () => {
+    current = null;
+    return true;
+  }),
+};
+let current: typeof subscription | null = null;
+const pushManager = {
+  getSubscription: vi.fn(async () => current),
+  subscribe: vi.fn(async () => {
+    current = subscription;
+    return subscription;
+  }),
+};
+const registration = { pushManager };
+let serviceWorkerDescriptor: PropertyDescriptor | undefined;
+
+beforeEach(() => {
+  current = null;
+  vi.mocked(fetchConfig).mockReset().mockResolvedValue({ push: true, vapidPublicKey });
+  vi.mocked(registerPushSubscription).mockReset().mockResolvedValue(undefined);
+  pushManager.getSubscription.mockReset().mockImplementation(async () => current);
+  pushManager.subscribe.mockReset().mockImplementation(async () => {
+    current = subscription;
+    return subscription;
+  });
+  subscription.unsubscribe.mockReset().mockImplementation(async () => {
+    current = null;
+    return true;
+  });
+  serviceWorkerDescriptor = Object.getOwnPropertyDescriptor(navigator, "serviceWorker");
+  Object.defineProperty(navigator, "serviceWorker", {
+    configurable: true,
+    value: {
+      register: vi.fn().mockResolvedValue(registration),
+      getRegistration: vi.fn().mockResolvedValue(registration),
+      ready: Promise.resolve(registration),
+    },
+  });
+  vi.stubGlobal("PushManager", vi.fn());
+  vi.stubGlobal("Notification", { permission: "granted" });
+  vi.stubGlobal("isSecureContext", true);
+  localStorage.setItem("collie:push-disabled", "1");
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+  if (serviceWorkerDescriptor) {
+    Object.defineProperty(navigator, "serviceWorker", serviceWorkerDescriptor);
+  } else {
+    Reflect.deleteProperty(navigator, "serviceWorker");
+  }
+});
+
+describe("push subscription lifecycle", () => {
+  it("can enable, disable, and enable again after both registrations succeed", async () => {
+    await expect(enablePush()).resolves.toEqual({ ok: true });
+    expect((await getPushState()).subscribed).toBe(true);
+    await disablePush();
+    expect(await getPushState()).toMatchObject({ subscribed: false, userDisabled: true });
+    await expect(enablePush()).resolves.toEqual({ ok: true });
+    expect(await getPushState()).toMatchObject({ subscribed: true, userDisabled: false });
+    expect(pushManager.subscribe).toHaveBeenCalledTimes(2);
+    expect(registerPushSubscription).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps push off when the bridge rejects registration, and can retry the same subscription", async () => {
+    vi.mocked(registerPushSubscription).mockRejectedValueOnce(new Error("sign in required"));
+    await expect(enablePush()).rejects.toThrow("sign in required");
+    expect(await getPushState()).toMatchObject({ subscribed: false, userDisabled: true });
+    expect(localStorage.getItem("collie:push-endpoint")).toBeNull();
+
+    await expect(enablePush()).resolves.toEqual({ ok: true });
+    expect(await getPushState()).toMatchObject({ subscribed: true, userDisabled: false });
+    expect(pushManager.subscribe).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not show an unacknowledged subscription as on for a first-time user", async () => {
+    localStorage.removeItem("collie:push-disabled");
+    vi.mocked(registerPushSubscription).mockRejectedValueOnce(new Error("registration refused"));
+    await expect(enablePush()).rejects.toThrow("registration refused");
+    expect((await getPushState()).subscribed).toBe(false);
+  });
+
+  it("surfaces a browser registration failure and allows a later attempt", async () => {
+    pushManager.subscribe.mockRejectedValueOnce(
+      new DOMException("Registration failed - push service error", "AbortError"),
+    );
+    await expect(enablePush()).rejects.toThrow("push service error");
+    expect(registerPushSubscription).not.toHaveBeenCalled();
+    expect((await getPushState()).userDisabled).toBe(true);
+    await expect(enablePush()).resolves.toEqual({ ok: true });
+  });
+
+  it("reports an unavailable config as retryable rather than claiming VAPID is disabled", async () => {
+    vi.mocked(fetchConfig).mockRejectedValueOnce(new Error("offline"));
+    expect(await getPushState()).toMatchObject({ availability: "unavailable", userDisabled: true });
+    await expect(enablePush()).resolves.toEqual({ ok: true });
+  });
+
+  it("still distinguishes a bridge that actually has no push configuration", async () => {
+    vi.mocked(fetchConfig).mockResolvedValue({ push: false, vapidPublicKey: "" });
+    expect((await getPushState()).availability).toBe("server-off");
+  });
+
+  it("times out a stalled subscription without registering it after the timeout", async () => {
+    vi.useFakeTimers();
+    let finish: ((value: typeof subscription) => void) | undefined;
+    pushManager.subscribe.mockImplementationOnce(() => new Promise((resolve) => {
+      finish = resolve;
+    }));
+    const rejected = expect(enablePush()).rejects.toThrow(/timed out/);
+    await vi.advanceTimersByTimeAsync(30_000);
+    await rejected;
+    expect(registerPushSubscription).not.toHaveBeenCalled();
+    expect(localStorage.getItem("collie:push-disabled")).toBe("1");
+
+    current = subscription;
+    finish?.(subscription);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(registerPushSubscription).not.toHaveBeenCalled();
+    await expect(enablePush()).resolves.toEqual({ ok: true });
+    expect(registerPushSubscription).toHaveBeenCalledTimes(1);
+  });
+
+  it("waits for an active service worker before subscribing", async () => {
+    vi.useFakeTimers();
+    Object.defineProperty(navigator.serviceWorker, "ready", { value: new Promise(() => {}) });
+    const rejected = expect(enablePush()).rejects.toThrow(/timed out/);
+    await vi.advanceTimersByTimeAsync(30_000);
+    await rejected;
+    expect(pushManager.subscribe).not.toHaveBeenCalled();
+  });
+
+  it("remembers a successful registration for this page when storage writes are blocked", async () => {
+    const setItem = vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new DOMException("Storage unavailable", "QuotaExceededError");
+    });
+    try {
+      await expect(enablePush()).resolves.toEqual({ ok: true });
+      expect((await getPushState()).subscribed).toBe(true);
+    } finally {
+      setItem.mockRestore();
+      await disablePush();
+    }
+  });
+});

--- a/web/src/lib/push-registration.test.ts
+++ b/web/src/lib/push-registration.test.ts
@@ -1,0 +1,33 @@
+import { http, HttpResponse } from "msw";
+import { server } from "@/test/setup";
+import { registerPushSubscription } from "./api";
+
+const body = {
+  endpoint: "https://push.example.test/device",
+  keys: { p256dh: "test-key", auth: "test-auth" },
+};
+
+it("registers push with the API's XHR header and accepts the bridge's empty acknowledgement", async () => {
+  let received: unknown;
+  let xhr: string | null = null;
+  server.use(http.post("/api/subscribe", async ({ request }) => {
+    received = await request.json();
+    xhr = request.headers.get("X-Requested-With");
+    return new HttpResponse(null, { status: 204 });
+  }));
+  await expect(registerPushSubscription(body)).resolves.toBeUndefined();
+  expect(received).toEqual(body);
+  expect(xhr).toBe("XMLHttpRequest");
+});
+
+it.each([401, 403, 500])("rejects a failed push registration with status %s", async (status) => {
+  server.use(http.post("/api/subscribe", () => new HttpResponse("refused", { status })));
+  await expect(registerPushSubscription(body)).rejects.toMatchObject({ status });
+});
+
+it("treats a sign-in redirect as an authentication failure, not a successful registration", async () => {
+  server.use(http.post("/api/subscribe", () =>
+    new HttpResponse(null, { status: 302, headers: { Location: "/auth/sign-in" } }),
+  ));
+  await expect(registerPushSubscription(body)).rejects.toMatchObject({ status: 401 });
+});

--- a/web/src/lib/push.ts
+++ b/web/src/lib/push.ts
@@ -1,4 +1,5 @@
-import { fetchConfig, XHR_HEADER, XHR_HEADER_VALUE } from "@/lib/api";
+import { fetchConfig, registerPushSubscription } from "@/lib/api";
+import { t } from "@/lib/i18n";
 import type { BridgeConfig } from "@/lib/types";
 
 // Client-side control of Web Push: the browser subscription plus a per-device preference. We persist
@@ -18,17 +19,20 @@ import type { BridgeConfig } from "@/lib/types";
 const PREF_KEY = "collie:push-disabled";
 /** The endpoint this device last registered with the bridge, so the next one can supersede it. */
 const ENDPOINT_KEY = "collie:push-endpoint";
+let volatileEndpoint: string | null | undefined;
+const PUSH_OPERATION_TIMEOUT_MS = 30_000;
 
 export type PushAvailability =
   | "unsupported" // browser lacks service worker / Push API
   | "insecure" // not a secure context (plain HTTP) — Push can't run
   | "server-off" // the bridge has no VAPID keys configured
+  | "unavailable" // configuration could not be checked; allow a retry
   | "denied" // notifications blocked at the OS/browser level
   | "ready"; // available to toggle
 
 export interface PushState {
   availability: PushAvailability;
-  /** A live PushManager subscription currently exists on this device. */
+  /** This device has a subscription it successfully registered with the bridge. */
   subscribed: boolean;
   /** The user turned push off here (persisted), so we don't auto-resubscribe. */
   userDisabled: boolean;
@@ -57,6 +61,7 @@ function setUserDisabled(disabled: boolean): void {
 }
 
 function rememberedEndpoint(): string | null {
+  if (volatileEndpoint !== undefined) return volatileEndpoint;
   try {
     return localStorage.getItem(ENDPOINT_KEY);
   } catch {
@@ -68,8 +73,29 @@ function rememberEndpoint(endpoint: string | null): void {
   try {
     if (endpoint === null) localStorage.removeItem(ENDPOINT_KEY);
     else localStorage.setItem(ENDPOINT_KEY, endpoint);
+    volatileEndpoint = undefined;
   } catch {
-    /* private mode / storage blocked — we just can't supersede next time */
+    // Keep the acknowledgement for this page when persistent storage is unavailable.
+    volatileEndpoint = endpoint;
+  }
+}
+
+// PushManager operations cannot be aborted. Stop awaiting a stalled operation so Settings can
+// recover; a late subscription may be reused on retry, but must not register itself behind the UI.
+async function pushOperation<T>(operation: Promise<T>): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      operation,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(
+          () => reject(new Error(t("settings.push.reason.timeout"))),
+          PUSH_OPERATION_TIMEOUT_MS,
+        );
+      }),
+    ]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
   }
 }
 
@@ -128,38 +154,35 @@ export async function enablePush(): Promise<EnableResult> {
   if (!pushSupported()) return { ok: false, reason: "unsupported" };
   if (!window.isSecureContext) return { ok: false, reason: "insecure" };
 
-  const reg = await navigator.serviceWorker.register("/sw.js");
+  await pushOperation(navigator.serviceWorker.register("/sw.js"));
+  const reg = await pushOperation(navigator.serviceWorker.ready);
   const cfg = await fetchConfig();
   if (!cfg.push || !cfg.vapidPublicKey) return { ok: false, reason: "server-off" };
   if (Notification.permission === "denied") return { ok: false, reason: "denied" };
   if (Notification.permission !== "granted") {
-    const perm = await Notification.requestPermission();
+    const perm = await pushOperation(Notification.requestPermission());
     if (perm !== "granted") return { ok: false, reason: "denied" };
   }
 
   const serverKey = urlB64ToUint8Array(cfg.vapidPublicKey);
-  let sub = await reg.pushManager.getSubscription();
+  let sub = await pushOperation(reg.pushManager.getSubscription());
   // A stale subscription bound to a rotated (or otherwise different) VAPID key would keep receiving
   // nothing — drop it and re-subscribe fresh against the current key.
   if (sub && !keysMatch(sub.options.applicationServerKey, serverKey)) {
-    await sub.unsubscribe();
+    await pushOperation(sub.unsubscribe());
     sub = null;
   }
   if (!sub) {
-    sub = await reg.pushManager.subscribe({
+    sub = await pushOperation(reg.pushManager.subscribe({
       userVisibleOnly: true,
       applicationServerKey: serverKey,
-    });
+    }));
   }
   const body = subscribeBody(sub.toJSON(), rememberedEndpoint());
-  const res = await fetch("/api/subscribe", {
-    method: "POST",
-    headers: { "content-type": "application/json", [XHR_HEADER]: XHR_HEADER_VALUE },
-    body: JSON.stringify(body),
-  });
+  await registerPushSubscription(body);
   // Only a registration the bridge actually took supersedes the one we remembered — otherwise the
   // next attempt must still be able to name the endpoint that is on the server.
-  if (res.ok) rememberEndpoint(body.endpoint);
+  rememberEndpoint(body.endpoint);
   setUserDisabled(false);
   return { ok: true };
 }
@@ -172,9 +195,9 @@ export async function disablePush(): Promise<void> {
   setUserDisabled(true);
   if (!pushSupported()) return;
   try {
-    const reg = await navigator.serviceWorker.getRegistration();
-    const sub = await reg?.pushManager.getSubscription();
-    await sub?.unsubscribe();
+    const reg = await pushOperation(navigator.serviceWorker.getRegistration());
+    const sub = reg ? await pushOperation(reg.pushManager.getSubscription()) : null;
+    if (sub) await pushOperation(sub.unsubscribe());
     rememberEndpoint(null);
   } catch {
     /* best-effort: the persisted preference still prevents re-subscription */
@@ -189,8 +212,9 @@ export async function getPushState(): Promise<PushState> {
 
   let subscribed = false;
   try {
-    const reg = await navigator.serviceWorker.getRegistration();
-    subscribed = Boolean(await reg?.pushManager.getSubscription());
+    const reg = await pushOperation(navigator.serviceWorker.getRegistration());
+    const sub = reg ? await pushOperation(reg.pushManager.getSubscription()) : null;
+    subscribed = sub !== null && sub.endpoint === rememberedEndpoint();
   } catch {
     /* ignore — treat as not subscribed */
   }
@@ -203,7 +227,7 @@ export async function getPushState(): Promise<PushState> {
   try {
     cfg = await fetchConfig();
   } catch {
-    cfg = { push: false, vapidPublicKey: "" };
+    return { availability: "unavailable", subscribed, userDisabled };
   }
   if (!cfg.push || !cfg.vapidPublicKey) {
     return { availability: "server-off", subscribed, userDisabled };

--- a/web/src/routes/settings.test.tsx
+++ b/web/src/routes/settings.test.tsx
@@ -1,9 +1,20 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { createMemoryRouter, RouterProvider } from "react-router";
 
 import { type DevicesData } from "@/lib/loaders";
 import { withHeaderHost } from "@/test/header-host";
 import { SettingsRoute } from "./settings";
+import { usePushControl } from "@/hooks/use-push";
+
+vi.mock("@/hooks/use-push", () => ({ usePushControl: vi.fn() }));
+
+beforeEach(() => {
+  vi.mocked(usePushControl).mockReturnValue({
+    state: { availability: "ready", subscribed: false, userDisabled: true },
+    busy: false,
+    setEnabled: vi.fn().mockResolvedValue({ ok: true }),
+  });
+});
 
 // Settings' HEADER, and only its header.
 //
@@ -69,5 +80,44 @@ describe("SettingsRoute — the update surfaces", () => {
     // Both of those live on /settings/updates now.
     expect(screen.queryByText("Update Collie")).toBeNull();
     expect(screen.queryByRole("button", { name: "Check for updates" })).toBeNull();
+  });
+});
+
+describe("SettingsRoute — recovering push setup", () => {
+  it("shows a thrown setup error and lets the user retry", async () => {
+    const setEnabled = vi.fn()
+      .mockRejectedValueOnce(new Error("Registration failed - push service error"))
+      .mockResolvedValueOnce({ ok: true });
+    vi.mocked(usePushControl).mockReturnValue({
+      state: { availability: "ready", subscribed: false, userDisabled: true },
+      busy: false, setEnabled,
+    });
+    renderSettings();
+    const toggle = await screen.findByRole("switch", { name: "Push notifications" });
+    fireEvent.click(toggle);
+    expect(await screen.findByRole("alert")).toHaveTextContent("push service error");
+    expect(toggle).toBeEnabled();
+    fireEvent.click(toggle);
+    await waitFor(() => expect(screen.queryByRole("alert")).toBeNull());
+    expect(setEnabled).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps the toggle retryable when configuration could not be checked", async () => {
+    vi.mocked(usePushControl).mockReturnValue({
+      state: { availability: "unavailable", subscribed: false, userDisabled: true },
+      busy: false, setEnabled: vi.fn().mockResolvedValue({ ok: true }),
+    });
+    renderSettings();
+    expect(await screen.findByRole("switch", { name: "Push notifications" })).toBeEnabled();
+    expect(screen.getByText(/Could not check notification setup/)).toBeInTheDocument();
+  });
+
+  it("keeps a denied browser permission from being treated as a transient failure", async () => {
+    vi.mocked(usePushControl).mockReturnValue({
+      state: { availability: "denied", subscribed: false, userDisabled: true },
+      busy: false, setEnabled: vi.fn().mockResolvedValue({ ok: true }),
+    });
+    renderSettings();
+    expect(await screen.findByRole("switch", { name: "Push notifications" })).toBeDisabled();
   });
 });

--- a/web/src/routes/settings.tsx
+++ b/web/src/routes/settings.tsx
@@ -29,6 +29,7 @@ import { type DevicesData } from "@/lib/loaders";
 import { homePath } from "@/lib/nav";
 import { useScope } from "@/lib/session";
 import type { PushAvailability } from "@/lib/push";
+import { describeThrownError } from "@/lib/api-error-message";
 import { useOptionalRootData } from "@/lib/route-data";
 
 const EMPTY_DEVICES: DevicesData = { enforced: false, current: null, devices: [], error: false };
@@ -65,13 +66,18 @@ export function SettingsRoute() {
   // "On" = the user hasn't disabled it AND a live subscription exists on this device.
   const on = Boolean(state && !state.userDisabled && state.subscribed);
   const blocked = Boolean(state && state.availability !== "ready");
-  // When blocked we can still allow turning OFF a lingering subscription, but never turning ON.
-  const toggleDisabled = busy || !state || (blocked && !on);
+  // Capability/permission refusals block enabling; a failed config read must remain retryable.
+  const toggleDisabled =
+    busy || !state || (blocked && !on && state.availability !== "unavailable");
 
   async function toggle(next: boolean) {
     setError(null);
-    const res = await setEnabled(next);
-    if (next && !res.ok) setError(reasonText(res.reason));
+    try {
+      const res = await setEnabled(next);
+      if (next && !res.ok) setError(reasonText(res.reason));
+    } catch (err) {
+      setError(describeThrownError(err));
+    }
   }
 
   return (
@@ -185,7 +191,7 @@ export function SettingsRoute() {
             </p>
           )}
           {error && (
-            <p className="border-t border-border px-4 py-2.5 text-xs text-status-blocked">
+            <p role="alert" className="border-t border-border px-4 py-2.5 text-xs text-status-blocked">
               {error}
             </p>
           )}
@@ -239,6 +245,8 @@ function reasonText(reason: PushAvailability | undefined): string {
       return t("settings.push.reason.insecure");
     case "server-off":
       return t("settings.push.reason.serverOff");
+    case "unavailable":
+      return t("settings.push.availability.unavailable");
     case "denied":
       return t("settings.push.reason.denied");
     case "unsupported":
@@ -254,6 +262,8 @@ function availabilityNote(a: PushAvailability): string {
       return t("settings.push.availability.insecure");
     case "server-off":
       return t("settings.push.availability.serverOff");
+    case "unavailable":
+      return t("settings.push.availability.unavailable");
     case "denied":
       return t("settings.push.availability.denied");
     case "unsupported":


### PR DESCRIPTION
Turning mobile push back on could leave Settings disabled after a transient config failure, silently drop browser registration errors, or report success after the bridge rejected the subscription.

Keep unavailable configuration retryable, show setup errors beside the switch, bound service-worker/PushManager waits, and register through the shared API client. The enabled state now requires a remembered bridge acknowledgement; a subscription that resolves after a timeout is left for an explicit retry.

Closes #178.

Regression tests cover off/on cycles, stalled and rejected browser operations, late resolution after timeout, failed config reads, denied permissions, blocked storage, and HTTP 401/403/500/sign-in redirects. Browser lifecycle tests use mocked PushManager APIs; HTTP cases use MSW.

**Base branch** — see [CONTRIBUTING.md](../CONTRIBUTING.md#base-branch):

- [x] Opened against `main` — there is one line of development, and `main` is it

**Checks**

- [x] `bun run typecheck` (root **and** `web/`), `bun run lint`, `bun test ./bridge ./cli ./scripts`, `cd web && bun run test` all pass
- [x] CHANGELOG entry added — or this is a fork PR / docs-only change, where the maintainer picks the version

This is a fork PR; version files and CHANGELOG are unchanged. Validation: 4,080 backend/CLI/script tests and 5,125 frontend tests passed (30 existing frontend TODOs).

