### PR TITLE
feat(pane): show the newest reply in full when the terminal clipped it

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -300,6 +300,19 @@ graph TD
   and renders a window that grows upward, which is what lets find-in-history and jump-to-user-turn
   work across turns you haven't scrolled to. Rationale and the measured numbers are commented at the
   top of `web/src/routes/history.tsx`.
+  - **The same source also repairs the pane view in place.** A reply longer than the pane is tall
+    reaches the mirror with its opening already scrolled off, and leaving for the history route to
+    read it is a heavy answer to a small question. So the pane view reads the newest turn from the
+    journal and, when `web/src/lib/latest-reply.ts` says that turn IS the one on screen and its start
+    is missing, renders it in full **in place of** the rows it covers — `locateReply` returns where
+    those rows end and `AnsiOutput`'s `hideLeadingLines` takes them off the top, so the message is
+    never printed twice and the mirror below it (tool calls, a dialog, the cursor) is untouched.
+    Both probes fold the two texts to letters and digits only, which is what makes Markdown source
+    comparable to a hard-wrapped, SGR-coloured render; the tail probe is an identity check, and its
+    failure (a streaming reply, a stale read) means *show nothing*. The hiding is render-only and runs
+    after every grammar, so no detector, guard or draft probe can see it; find restores the whole
+    mirror, since find can only highlight there. One journal read per finished message, off the poll
+    path (`web/src/hooks/use-latest-reply.ts`), and switchable off in ⚙ View.
 - **The browser polls too.** `useRevalidator` → `/api/snapshot` on an adaptive interval. There is no
   WebSocket fan-out to the browser and no push of state; pulling is what makes the two recovery loops
   below trivial.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -359,6 +359,13 @@ lint guard, the pack-wire guard or the `flake.lock` guard.
   row in the pane sheet). `MuxPane.focused` is a fact the snapshot reports, and the terminal never
   moves the phone in the other direction — that may not become a side effect of navigation
   ([ADR 0031](./.adr/0031-freshness-is-a-declared-promise.md)).
+- **The "Full reply" card is gated on an identity check, not a length check.** The pane view re-shows
+  the newest journal turn only when the tail probe proves that turn IS the message on screen and the
+  head probe shows its start is not. A failed tail probe means render nothing — don't relax it to "the
+  newest journal turn", which would present a stale or still-streaming reply as the one you're reading
+  (`web/src/lib/latest-reply.ts`). It **replaces** the rows it covers rather than sitting above them
+  (`hideLeadingLines`), and that hiding is render-only, applied after every grammar has run over the
+  whole screen — never trim the text a detector, guard or draft probe sees.
 - **The operator's rows in `commands.toml` replace the shipped command catalog on the panes they
   address, never merge into it** ([ADR 0018](./.adr/0018-operator-command-rows-replace-the-catalog.md));
   the bridge re-reads the file behind an mtime check, so edits are live and need no restart.

--- a/web/src/components/agent-chat.test.tsx
+++ b/web/src/components/agent-chat.test.tsx
@@ -2176,3 +2176,134 @@ describe("AgentChat: Launch section in the switcher", () => {
     expect(screen.queryByText("Launch")).toBeNull();
   });
 });
+
+// Putting a clipped reply back. An agent pane's terminal keeps no scrollback, so a reply longer than
+// the pane is tall reaches the mirror with its opening already gone; the agent's own journal still has
+// it. What has to hold here is BOTH halves: the full message appears when the mirror is showing its
+// tail, and nothing appears when the journal's newest turn is not the message on screen (a streaming
+// reply, a stale read) — presenting an older reply as the current one is the failure that matters.
+describe("AgentChat — full latest reply", () => {
+  const REPLY = [
+    "Short answer: approve-only. The author knows when they want it to land; your job was the",
+    "approval. Enabling auto-merge makes you the actor for the merge itself, which is a materially",
+    "bigger claim than saying this looks fine to me.",
+  ].join(" ");
+
+  /** Serve one assistant turn as the pane's journal, and count the reads so a negative assertion can
+   *  wait for the fetch to have landed rather than racing it. */
+  function withJournalReply(text: string): () => number {
+    let hits = 0;
+    server.use(
+      http.get(/\/api\/pane\/[^/]+\/history/, () => {
+        hits += 1;
+        return HttpResponse.json({
+          paneId: "w1:p1",
+          available: true,
+          entries: [
+            {
+              uuid: "reply-1",
+              ts: "2026-08-28T09:14:00.000Z",
+              role: "assistant",
+              parts: [{ kind: "text", text }],
+            },
+          ],
+          hasMore: false,
+          total: 1,
+          fileTruncated: false,
+        });
+      }),
+    );
+    return () => hits;
+  }
+
+  const card = () => screen.queryByRole("button", { name: /full reply/i });
+  const sessionAgent = () => ({ ...fixtureAgents[0]!, hasSession: true, readableLines: 51 });
+  /** Just the terminal mirror's text — the card renders the same words, so a screen-wide query can't
+   *  tell which surface a match came from. */
+  const mirror = () => document.querySelector("pre")?.textContent ?? "";
+
+  // A screen holding the END of the reply, then what the agent did next.
+  const AFTER = "abc1234 fix";
+  const SCREEN = `${REPLY.slice(120)}\n\nBash(git log --oneline)\n  ${AFTER}`;
+
+  it("shows the whole message, and takes the rows it covers out of the mirror", async () => {
+    withJournalReply(REPLY);
+    renderChat({ agent: sessionAgent(), agents: [sessionAgent()], text: SCREEN });
+    await waitFor(() => expect(card()).toBeInTheDocument());
+
+    // The opening the terminal lost is on screen now, from the transcript…
+    expect(screen.getByText(/Short answer: approve-only/)).toBeInTheDocument();
+    // …the rows that held its tail are gone, so the words appear exactly once…
+    expect(mirror()).not.toContain("bigger claim");
+    // …and the terminal below the reply is untouched.
+    expect(mirror()).toContain(AFTER);
+  });
+
+  it("gives the terminal rows back when you collapse it", async () => {
+    const user = userEvent.setup();
+    withJournalReply(REPLY);
+    renderChat({ agent: sessionAgent(), agents: [sessionAgent()], text: SCREEN });
+    await waitFor(() => expect(card()).toBeInTheDocument());
+
+    await user.click(card()!);
+    expect(screen.queryByText(/Short answer: approve-only/)).not.toBeInTheDocument();
+    expect(mirror()).toContain("bigger claim"); // the raw rows are back
+    expect(card()).toBeInTheDocument(); // and the header stays, so it can be reopened
+  });
+
+  // Find searches the mirror and highlights only there, so a hidden row would be a match you can see
+  // but cannot find. Opening find restores the whole mirror and stands the card down.
+  it("hands the whole mirror back while the find bar is open", async () => {
+    const user = userEvent.setup();
+    withJournalReply(REPLY);
+    renderChat({ agent: sessionAgent(), agents: [sessionAgent()], text: SCREEN });
+    await waitFor(() => expect(card()).toBeInTheDocument());
+
+    await openFind(user);
+    expect(card()).not.toBeInTheDocument();
+    expect(mirror()).toContain("bigger claim");
+  });
+
+  it("shows nothing when the journal's newest reply is not what the mirror is showing", async () => {
+    const hits = withJournalReply(REPLY);
+    renderChat({
+      agent: sessionAgent(),
+      agents: [sessionAgent()],
+      text: "an entirely different screen",
+    });
+    await waitFor(() => expect(hits()).toBe(1));
+    await waitFor(() => expect(card()).not.toBeInTheDocument());
+  });
+
+  it("shows nothing when the mirror already holds the whole reply", async () => {
+    const hits = withJournalReply(REPLY);
+    renderChat({ agent: sessionAgent(), agents: [sessionAgent()], text: REPLY });
+    await waitFor(() => expect(hits()).toBe(1));
+    await waitFor(() => expect(card()).not.toBeInTheDocument());
+    expect(screen.getAllByText(/Short answer/).length).toBe(1); // the mirror's copy, and only it
+  });
+
+  // The pref is the whole opt-out: off, the pane is exactly what it was before this existed — and it
+  // costs no journal read either, which is the reason it is a pref rather than always-on.
+  it("reads no journal at all once the operator turns it off", async () => {
+    localStorage.setItem(
+      "collie:display-prefs:v4",
+      JSON.stringify({ wrap: true, fontSize: 12, expandClippedReply: false }),
+    );
+    const hits = withJournalReply(REPLY);
+    renderChat({ agent: sessionAgent(), agents: [sessionAgent()], text: REPLY.slice(120) });
+    await waitFor(() => expect(screen.getByText(/bigger claim/)).toBeInTheDocument());
+    expect(hits()).toBe(0);
+    expect(card()).not.toBeInTheDocument();
+    localStorage.clear();
+  });
+
+  it("reads no journal at all on a pane that has none", async () => {
+    const hits = withJournalReply(REPLY);
+    const shell = { ...fixtureAgents[0]!, kind: "shell" as const, readableLines: 51 };
+    renderChat({ agent: shell, agents: [shell], text: REPLY.slice(120) });
+    await waitFor(() => expect(screen.getByText(/bigger claim/)).toBeInTheDocument());
+    expect(hits()).toBe(0);
+    expect(card()).not.toBeInTheDocument();
+  });
+});

--- a/web/src/components/agent-chat.tsx
+++ b/web/src/components/agent-chat.tsx
@@ -17,6 +17,7 @@ import { useDashPrefs, openForCount } from "@/hooks/use-dash-prefs";
 import { useLaunchers } from "@/lib/launchers";
 import { buzz } from "@/lib/haptics";
 import { mirrorFont, useDisplayPrefs } from "@/hooks/use-display-prefs";
+import { useLatestReply } from "@/hooks/use-latest-reply";
 import { useStableTerminalDraft } from "@/hooks/use-terminal-draft";
 import { useLocale } from "@/hooks/use-locale";
 import { isConnecting } from "@/lib/connection";
@@ -39,6 +40,7 @@ import { splitLines } from "@/lib/blocks";
 import { adapterFor } from "@/lib/harness";
 import { blockOwnsKeyboard } from "@/lib/harness/dialog-contract";
 import { FindBar } from "@/components/find-bar";
+import { LatestReply } from "@/components/latest-reply";
 import { Composer, type ComposerHandle } from "@/components/composer";
 import { ThreadSidebar } from "@/components/agent-sidebar";
 import { AgentIcon } from "@/components/agent-icon";
@@ -62,6 +64,7 @@ import { submitMenuKeys } from "@/lib/menu-action";
 import type { PromptBlockAction } from "@/components/prompt-select-block";
 import type { PreviewBlockAction } from "@/components/preview-select-block";
 import type { MenuBlockAction } from "@/components/menu-block";
+import { locateReply } from "@/lib/latest-reply";
 import { canGrowRequestedLines, growRequestedLines } from "@/lib/loaders";
 import { cwdBeyondName } from "@/lib/pane-name";
 import { useMuxCapability } from "@/lib/mux-capability";
@@ -195,7 +198,8 @@ export function AgentChat({
   const { newTab, launch, launching, creatingTab } = useSpaceActions();
   const { launchers, home: launchersHome } = useLaunchers(scope);
   // Single display-prefs instance: the View controls (in <Composer>) write it, the mirror reads it.
-  const { prefs, setWrap, stepFontSize, setRawTerminal, setTapToFocus } = useDisplayPrefs();
+  const { prefs, setWrap, stepFontSize, setRawTerminal, setTapToFocus, setExpandClippedReply } =
+    useDisplayPrefs();
   // The chosen terminal font (Settings → Terminal font), applied by re-pointing `--font-mono` on
   // the two mirror surfaces below and NOWHERE else — see mirrorFont() for how, and why it is not a
   // custom property. Scoped to terminal CONTENT on purpose: app chrome that happens to be monospace
@@ -641,6 +645,41 @@ export function AgentChat({
     agent?.readableLines !== undefined &&
     requestedLines < agent.readableLines &&
     canGrowRequestedLines(paneId, scope);
+
+  // The newest reply, REPLACING the mirror rows that could only hold its end.
+  //
+  // The mirror IS the viewport for an agent pane (alternate screen, no scrollback ring), so a reply
+  // longer than the pane is tall has lost its opening by the time you read it, and getting it back
+  // used to mean leaving for the history route. The journal has it; `locateReply` decides whether this
+  // particular turn is the one on screen and whether its start is missing — and answers "not this
+  // message" for a stale/streaming/clamped read, which is the case that must render nothing rather
+  // than pass an older reply off as the current one (lib/latest-reply.ts).
+  //
+  // It also returns where those rows END, and the card takes their place rather than sitting on top of
+  // them: rendering the message in full above its own last few terminal rows printed the same text
+  // twice. Everything BELOW the reply — tool calls, a dialog, the cursor — is untouched, so the mirror
+  // still reads as the live screen, just starting where the message finished.
+  //
+  // Memoised on the DISPLAYED text: it folds a whole screenful, and it runs beside the grammar
+  // passes above on every poll.
+  const latestReply = useLatestReply({
+    paneId,
+    scope,
+    enabled: historyAvailable && prefs.expandClippedReply,
+    mirrorText: display,
+  });
+  const placement = useMemo(
+    () => (latestReply ? locateReply(display, latestReply) : null),
+    [latestReply, display],
+  );
+  // Find searches the mirror, so while it is open the mirror is WHOLE and the card stands down —
+  // otherwise a hit inside the reply would be unfindable in the one surface find can highlight.
+  const clippedReply = placement?.fit === "clipped" && !findOpen ? latestReply : null;
+  // Collapsing the card is a judgement about ONE message ("show me the raw rows instead"), so it is
+  // remembered by uuid: a new reply arrives expanded without an effect to reset anything.
+  const [collapsedReply, setCollapsedReply] = useState<string | null>(null);
+  const replyOpen = clippedReply !== null && collapsedReply !== clippedReply.uuid;
+  const hiddenMirrorLines = replyOpen && placement ? placement.endLine + 1 : 0;
 
   // Load older scrollback: raise the per-pane requested line count and refetch. The enlarged buffer
   // prepends older lines at the top, so we adopt it into the frozen display and re-anchor the scroll
@@ -1649,6 +1688,18 @@ export function AgentChat({
                       {t("chat.scrollback.noSessionReported", { agent: agent?.agent ?? "" })}
                     </p>
                   )}
+                  {/* The newest reply in full, standing IN PLACE OF the rows it covers (the mirror
+                      below starts after it — see hideLeadingLines). It appears above a bottom-pinned
+                      scroller, which ChatMessageList's child-list observer re-pins, so the live tail
+                      never moves. */}
+                  {clippedReply && (
+                    <LatestReply
+                      entry={clippedReply}
+                      agent={agent?.agent}
+                      open={replyOpen}
+                      onToggle={() => setCollapsedReply(replyOpen ? clippedReply.uuid : null)}
+                    />
+                  )}
                   <AnsiOutput
                     text={display}
                     wrap={prefs.wrap}
@@ -1663,6 +1714,7 @@ export function AgentChat({
                     onMultiSelectAction={handleMultiSelectAction}
                     onMenuAction={handleMenuAction}
                     promptDisabled={readOnly || gone}
+                    hideLeadingLines={hiddenMirrorLines}
                   />
                 </>
               ) : (
@@ -1865,6 +1917,7 @@ export function AgentChat({
                   stepFontSize={stepFontSize}
                   setRawTerminal={setRawTerminal}
                   setTapToFocus={setTapToFocus}
+                  setExpandClippedReply={setExpandClippedReply}
                   onSent={onSent}
                 />
               </div>

--- a/web/src/components/ansi-output.tsx
+++ b/web/src/components/ansi-output.tsx
@@ -5,6 +5,7 @@ import { cn } from "@/lib/utils";
 import { parseAnsi, type AnsiSegment } from "@/lib/ansi";
 import { buildBlocks } from "@/lib/harness";
 import {
+  dropLeadingLines,
   lineText,
   splitLines,
   type Block,
@@ -84,6 +85,16 @@ export interface AnsiOutputProps {
   onMenuAction?: (action: MenuBlockAction, menu: MenuModel) => void | Promise<void>;
   /** Disable the prompt-select/wizard/preview/multi-select/menu buttons (read-only / gone pane). */
   promptDisabled?: boolean;
+  /**
+   * Hide this many screen rows off the TOP of the mirror. Default 0.
+   *
+   * Purely presentational and applied AFTER the grammars have run over the whole screen, so no
+   * detection, guard or draft probe can see it. Its one caller (AgentChat) uses it to drop the rows a
+   * clipped reply occupies while the full message is rendered from the journal directly above them —
+   * printing both was the same text twice. Find offsets are recomputed over what is left, which is
+   * why AgentChat sets this to 0 whenever the find bar is open.
+   */
+  hideLeadingLines?: number;
 }
 
 // Stable empty result so the "not searching" path keeps the same `matches` reference across polls
@@ -217,13 +228,18 @@ export const AnsiOutput = memo(function AnsiOutput({
   onMultiSelectAction,
   onMenuAction,
   promptDisabled,
+  hideLeadingLines = 0,
 }: AnsiOutputProps) {
   const segments = useMemo(() => parseAnsi(text), [text]);
   const blocks = useMemo(() => buildBlocks(splitLines(segments), { agent }), [segments, agent]);
 
   const rawBlocks = useMemo(
-    () => blocks.filter((b): b is RawBlock => b.kind === "raw"),
-    [blocks],
+    () =>
+      dropLeadingLines(
+        blocks.filter((b): b is RawBlock => b.kind === "raw"),
+        hideLeadingLines,
+      ),
+    [blocks, hideLeadingLines],
   );
   const promptBlock = useMemo(
     () => blocks.find((b): b is PromptBlock => b.kind === "prompt-select") ?? null,

--- a/web/src/components/composer-stt.test.tsx
+++ b/web/src/components/composer-stt.test.tsx
@@ -86,11 +86,12 @@ function baseProps(
     text: "pane output",
     terminalDraft: null,
     rawTerminalDraft: null,
-    prefs: { wrap: true, fontSize: 11, draftFontSize: 14, fontFamily: "system", rawTerminal: false, tapToFocus: true },
+    prefs: { wrap: true, fontSize: 11, draftFontSize: 14, fontFamily: "system", rawTerminal: false, tapToFocus: true, expandClippedReply: true },
     setWrap: vi.fn(),
     stepFontSize: vi.fn(),
     setRawTerminal: vi.fn(),
     setTapToFocus: vi.fn(),
+    setExpandClippedReply: vi.fn(),
     onSent: vi.fn(),
     ...overrides,
   };

--- a/web/src/components/composer.test.tsx
+++ b/web/src/components/composer.test.tsx
@@ -68,11 +68,12 @@ function renderComposer(overrides: Partial<ComponentProps<typeof Composer>> = {}
     text: "pane output",
     terminalDraft: null,
     rawTerminalDraft: null,
-    prefs: { wrap: true, fontSize: 11, draftFontSize: 14, fontFamily: "system", rawTerminal: false, tapToFocus: true },
+    prefs: { wrap: true, fontSize: 11, draftFontSize: 14, fontFamily: "system", rawTerminal: false, tapToFocus: true, expandClippedReply: true },
     setWrap: vi.fn(),
     stepFontSize: vi.fn(),
     setRawTerminal: vi.fn(),
     setTapToFocus: vi.fn(),
+    setExpandClippedReply: vi.fn(),
     onSent: vi.fn(),
     ...overrides,
   };
@@ -119,11 +120,12 @@ function renderComposerWithStatus(
     text: "pane output",
     terminalDraft: null,
     rawTerminalDraft: null,
-    prefs: { wrap: true, fontSize: 11, draftFontSize: 14, fontFamily: "system", rawTerminal: false, tapToFocus: true },
+    prefs: { wrap: true, fontSize: 11, draftFontSize: 14, fontFamily: "system", rawTerminal: false, tapToFocus: true, expandClippedReply: true },
     setWrap: vi.fn(),
     stepFontSize: vi.fn(),
     setRawTerminal: vi.fn(),
     setTapToFocus: vi.fn(),
+    setExpandClippedReply: vi.fn(),
     onSent: vi.fn(),
     ...overrides,
   };
@@ -494,11 +496,12 @@ describe("Composer — send", () => {
               text="pane output"
               terminalDraft={null}
               rawTerminalDraft="leftover"
-              prefs={{ wrap: true, fontSize: 11, draftFontSize: 14, fontFamily: "system", rawTerminal: false, tapToFocus: true }}
+              prefs={{ wrap: true, fontSize: 11, draftFontSize: 14, fontFamily: "system", rawTerminal: false, tapToFocus: true, expandClippedReply: true }}
               setWrap={vi.fn()}
               stepFontSize={vi.fn()}
               setRawTerminal={vi.fn()}
               setTapToFocus={vi.fn()}
+              setExpandClippedReply={vi.fn()}
               onSent={vi.fn()}
             />
           </>
@@ -587,11 +590,12 @@ describe("Composer — send", () => {
       text: "pane output",
       terminalDraft: null,
       rawTerminalDraft: null,
-      prefs: { wrap: true, fontSize: 11, draftFontSize: 14, fontFamily: "system", rawTerminal: false, tapToFocus: true },
+      prefs: { wrap: true, fontSize: 11, draftFontSize: 14, fontFamily: "system", rawTerminal: false, tapToFocus: true, expandClippedReply: true },
       setWrap: vi.fn(),
       stepFontSize: vi.fn(),
       setRawTerminal: vi.fn(),
       setTapToFocus: vi.fn(),
+      setExpandClippedReply: vi.fn(),
       onSent: vi.fn(),
     };
     const router = createMemoryRouter([
@@ -683,11 +687,12 @@ describe("Composer — typing into the terminal", () => {
             text="pane output"
             terminalDraft={null}
             rawTerminalDraft={null}
-            prefs={{ wrap: true, fontSize: 11, draftFontSize: 14, fontFamily: "system", rawTerminal: false, tapToFocus: true }}
+            prefs={{ wrap: true, fontSize: 11, draftFontSize: 14, fontFamily: "system", rawTerminal: false, tapToFocus: true, expandClippedReply: true }}
             setWrap={vi.fn()}
             stepFontSize={vi.fn()}
             setRawTerminal={vi.fn()}
             setTapToFocus={vi.fn()}
+            setExpandClippedReply={vi.fn()}
             onSent={vi.fn()}
           />
         </>
@@ -815,11 +820,12 @@ describe("Composer — typing into the terminal", () => {
             text="pane output"
             terminalDraft={null}
             rawTerminalDraft={null}
-            prefs={{ wrap: true, fontSize: 11, draftFontSize: 14, fontFamily: "system", rawTerminal: false, tapToFocus: true }}
+            prefs={{ wrap: true, fontSize: 11, draftFontSize: 14, fontFamily: "system", rawTerminal: false, tapToFocus: true, expandClippedReply: true }}
             setWrap={vi.fn()}
             stepFontSize={vi.fn()}
             setRawTerminal={vi.fn()}
             setTapToFocus={vi.fn()}
+            setExpandClippedReply={vi.fn()}
             onSent={vi.fn()}
           />
         </>
@@ -1006,11 +1012,12 @@ describe("Composer — typing into the terminal", () => {
             text="pane output"
             terminalDraft={null}
             rawTerminalDraft={null}
-            prefs={{ wrap: true, fontSize: 11, draftFontSize: 14, fontFamily: "system", rawTerminal: false, tapToFocus: true }}
+            prefs={{ wrap: true, fontSize: 11, draftFontSize: 14, fontFamily: "system", rawTerminal: false, tapToFocus: true, expandClippedReply: true }}
             setWrap={vi.fn()}
             stepFontSize={vi.fn()}
             setRawTerminal={vi.fn()}
             setTapToFocus={vi.fn()}
+            setExpandClippedReply={vi.fn()}
             onSent={vi.fn()}
           />
         </>
@@ -1115,6 +1122,7 @@ describe("Composer — the draft field wears its own size", () => {
         fontSize: 11,
         draftFontSize: 13,
         fontFamily: "jetbrains",
+        expandClippedReply: true,
         rawTerminal: false,
         tapToFocus: true,
       },
@@ -1724,11 +1732,12 @@ function renderDraftHarness(overrides: Partial<ComponentProps<typeof Composer>> 
       readOnly: false,
       dialogPresent: false,
       text: "pane output",
-      prefs: { wrap: true, fontSize: 11, draftFontSize: 14, fontFamily: "system", rawTerminal: false, tapToFocus: true },
+      prefs: { wrap: true, fontSize: 11, draftFontSize: 14, fontFamily: "system", rawTerminal: false, tapToFocus: true, expandClippedReply: true },
       setWrap: vi.fn(),
       stepFontSize: vi.fn(),
       setRawTerminal: vi.fn(),
       setTapToFocus: vi.fn(),
+      setExpandClippedReply: vi.fn(),
       onSent: vi.fn(),
       ...rest,
       terminalDraft: stable,
@@ -1995,11 +2004,12 @@ describe("Composer — in-flight echo suppression (match-last-sent)", () => {
       text: "pane output",
       terminalDraft: draft,
       rawTerminalDraft: draft,
-      prefs: { wrap: true, fontSize: 11, draftFontSize: 14, fontFamily: "system", rawTerminal: false, tapToFocus: true },
+      prefs: { wrap: true, fontSize: 11, draftFontSize: 14, fontFamily: "system", rawTerminal: false, tapToFocus: true, expandClippedReply: true },
       setWrap: vi.fn(),
       stepFontSize: vi.fn(),
       setRawTerminal: vi.fn(),
       setTapToFocus: vi.fn(),
+      setExpandClippedReply: vi.fn(),
       onSent: vi.fn(),
     };
     return (
@@ -2631,11 +2641,12 @@ describe("Composer — draft persistence", () => {
       text: "pane output",
       terminalDraft: null,
       rawTerminalDraft: null,
-      prefs: { wrap: true, fontSize: 11, draftFontSize: 14, fontFamily: "system", rawTerminal: false, tapToFocus: true },
+      prefs: { wrap: true, fontSize: 11, draftFontSize: 14, fontFamily: "system", rawTerminal: false, tapToFocus: true, expandClippedReply: true },
       setWrap: vi.fn(),
       stepFontSize: vi.fn(),
       setRawTerminal: vi.fn(),
       setTapToFocus: vi.fn(),
+      setExpandClippedReply: vi.fn(),
       onSent: vi.fn(),
       ...overrides,
     };

--- a/web/src/components/composer.tsx
+++ b/web/src/components/composer.tsx
@@ -121,6 +121,7 @@ interface ComposerProps {
   stepFontSize: (delta: number) => void;
   setRawTerminal: (raw: boolean) => void;
   setTapToFocus: (tapToFocus: boolean) => void;
+  setExpandClippedReply: (expandClippedReply: boolean) => void;
   /** Snap the mirror to the live tail (follow + revalidate + scroll) after a successful send. */
   onSent: () => void;
 }
@@ -236,7 +237,7 @@ function ComposerDock({
 const ATTACH_PRESS_MS = 220;
 
 export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Composer(
-  { paneId, scope, agent, isShell, status, stale, gone, readOnly, hostBlock, composing, dialogPresent, text, terminalDraft, rawTerminalDraft, prefs, setWrap, stepFontSize, setRawTerminal, setTapToFocus, onSent },
+  { paneId, scope, agent, isShell, status, stale, gone, readOnly, hostBlock, composing, dialogPresent, text, terminalDraft, rawTerminalDraft, prefs, setWrap, stepFontSize, setRawTerminal, setTapToFocus, setExpandClippedReply, onSent },
   ref,
 ) {
   const revalidator = useRevalidator();
@@ -1138,6 +1139,7 @@ export const Composer = forwardRef<ComposerHandle, ComposerProps>(function Compo
               stepFontSize={stepFontSize}
               setRawTerminal={setRawTerminal}
               setTapToFocus={setTapToFocus}
+              setExpandClippedReply={setExpandClippedReply}
             />
           </ComposerDock>
         )}

--- a/web/src/components/display-prefs.tsx
+++ b/web/src/components/display-prefs.tsx
@@ -26,6 +26,7 @@ interface DisplayPrefsContentProps {
   stepFontSize: (delta: number) => void;
   setRawTerminal: (raw: boolean) => void;
   setTapToFocus: (tapToFocus: boolean) => void;
+  setExpandClippedReply: (expandClippedReply: boolean) => void;
 }
 
 // One settings row: name (+ optional explanation) on the left, control on the right. Module-level so
@@ -60,6 +61,7 @@ export function DisplayPrefsContent({
   stepFontSize,
   setRawTerminal,
   setTapToFocus,
+  setExpandClippedReply,
 }: DisplayPrefsContentProps) {
   useLocale();
   return (
@@ -87,6 +89,19 @@ export function DisplayPrefsContent({
             checked={prefs.tapToFocus}
             onCheckedChange={setTapToFocus}
             aria-label={t("settings.display.tapToType.label")}
+          />
+        }
+      />
+      <Row
+        label={t("settings.display.fullReply.label")}
+        hint={t("settings.display.fullReply.hint")}
+        htmlFor="pref-expand-clipped-reply"
+        control={
+          <Switch
+            id="pref-expand-clipped-reply"
+            checked={prefs.expandClippedReply}
+            onCheckedChange={setExpandClippedReply}
+            aria-label={t("settings.display.fullReply.label")}
           />
         }
       />

--- a/web/src/components/latest-reply.tsx
+++ b/web/src/components/latest-reply.tsx
@@ -1,0 +1,66 @@
+import { ChevronRight } from "lucide-react";
+
+import { TranscriptView } from "@/components/transcript-view";
+import { useLocale } from "@/hooks/use-locale";
+import { t } from "@/lib/i18n";
+import { cn } from "@/lib/utils";
+import type { TranscriptEntry } from "@/lib/types";
+
+// The agent's newest reply, standing IN PLACE OF the mirror rows that could only hold its end.
+//
+// Rendered by AgentChat only when lib/latest-reply.ts says the message on screen is this one and its
+// opening has scrolled off. AgentChat hides the rows it covers (AnsiOutput's `hideLeadingLines`), so
+// the two never print the same words twice: this card, then the mirror picking up exactly where the
+// message finished — tool calls, a dialog, the cursor, all untouched.
+//
+// Open state is the PARENT's, because it decides what the mirror shows: collapsing here is "give me
+// the raw rows back", so the hiding and the folding have to be one decision, not two that can drift.
+//
+// This is a TRANSCRIPT surface, not a mirror one: it goes through TranscriptView, so it renders
+// Markdown in ordinary app theming and never touches MIRROR_SPACE (ADR 0002 has nothing to say about
+// it). The XSS boundary is the one TranscriptView and MarkdownText already own — React elements from
+// an AST, never a constructed HTML string.
+export function LatestReply({
+  entry,
+  agent,
+  open,
+  onToggle,
+}: {
+  entry: TranscriptEntry;
+  agent?: string;
+  /** Expanded shows the message and the mirror rows below it stay hidden; collapsed does the reverse. */
+  open: boolean;
+  onToggle: () => void;
+}) {
+  useLocale();
+  return (
+    <div className="mb-2 rounded-lg border bg-muted/30">
+      <button
+        type="button"
+        onClick={onToggle}
+        aria-expanded={open}
+        className="flex w-full items-center gap-1.5 px-2.5 py-2 text-left transition-colors active:bg-muted/60"
+      >
+        <ChevronRight
+          className={cn(
+            "size-3.5 shrink-0 text-muted-foreground transition-transform",
+            open && "rotate-90",
+          )}
+        />
+        <span className="text-[11px] font-semibold tracking-wide text-muted-foreground uppercase">
+          {t("chat.fullReply.title")}
+        </span>
+        {/* Says which of the two sources you are looking at, since the toggle swaps them rather than
+            hiding one. */}
+        <span className="ml-auto truncate text-[11px] text-muted-foreground">
+          {open ? t("chat.fullReply.fromTranscript") : t("chat.fullReply.showingTerminal")}
+        </span>
+      </button>
+      {open && (
+        <div className="border-t px-2.5 py-2">
+          <TranscriptView entries={[entry]} agent={agent} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/hooks/use-display-prefs.test.ts
+++ b/web/src/hooks/use-display-prefs.test.ts
@@ -19,7 +19,7 @@ describe("useDisplayPrefs", () => {
 
   it("returns defaults when localStorage is empty", () => {
     const { result } = renderHook(() => useDisplayPrefs());
-    expect(result.current.prefs).toEqual({ wrap: true, fontSize: 10, draftFontSize: 14, fontFamily: "system", rawTerminal: false, tapToFocus: true });
+    expect(result.current.prefs).toEqual({ wrap: true, fontSize: 10, draftFontSize: 14, fontFamily: "system", rawTerminal: false, tapToFocus: true, expandClippedReply: true });
   });
 
   it("persists wrap=true and reloads it on mount", () => {
@@ -37,9 +37,12 @@ describe("useDisplayPrefs", () => {
   });
 
   it("loads persisted prefs from localStorage on mount", () => {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify({ wrap: false, fontSize: 14, rawTerminal: true, tapToFocus: false }));
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ wrap: false, fontSize: 14, rawTerminal: true, tapToFocus: false, expandClippedReply: false }),
+    );
     const { result } = renderHook(() => useDisplayPrefs());
-    expect(result.current.prefs).toEqual({ wrap: false, fontSize: 14, draftFontSize: 14, fontFamily: "system", rawTerminal: true, tapToFocus: false });
+    expect(result.current.prefs).toEqual({ wrap: false, fontSize: 14, draftFontSize: 14, fontFamily: "system", rawTerminal: true, tapToFocus: false, expandClippedReply: false });
   });
 
   it("persists rawTerminal and reloads it on mount (the escape hatch survives a reload)", () => {
@@ -66,7 +69,7 @@ describe("useDisplayPrefs", () => {
   it("reads a pre-tapToFocus payload without discarding the prefs it does have", () => {
     localStorage.setItem(STORAGE_KEY, JSON.stringify({ wrap: false, fontSize: 15, rawTerminal: true }));
     const { result } = renderHook(() => useDisplayPrefs());
-    expect(result.current.prefs).toEqual({ wrap: false, fontSize: 15, draftFontSize: 14, fontFamily: "system", rawTerminal: true, tapToFocus: true });
+    expect(result.current.prefs).toEqual({ wrap: false, fontSize: 15, draftFontSize: 14, fontFamily: "system", rawTerminal: true, tapToFocus: true, expandClippedReply: true });
   });
 
   it("persists fontFamily and reloads it on mount", () => {
@@ -146,6 +149,28 @@ describe("useDisplayPrefs", () => {
     const { result } = renderHook(() => useDisplayPrefs());
     act(() => result.current.stepFontSize(-10)); // 12 - 10 = 2 → clamp to 9
     expect(result.current.prefs.fontSize).toBe(9);
+  });
+
+  it("persists expandClippedReply and reloads it on mount", () => {
+    const { result } = renderHook(() => useDisplayPrefs());
+    expect(result.current.prefs.expandClippedReply).toBe(true);
+    act(() => result.current.setExpandClippedReply(false));
+    expect(JSON.parse(localStorage.getItem(STORAGE_KEY)!).expandClippedReply).toBe(false);
+    const { result: reloaded } = renderHook(() => useDisplayPrefs());
+    expect(reloaded.current.prefs.expandClippedReply).toBe(false);
+  });
+
+  // Same reasoning as the tapToFocus case above: the key stayed at v4, so an older payload must keep
+  // every choice it does carry and take the default for the one it doesn't.
+  it("reads a pre-expandClippedReply payload without discarding the prefs it does have", () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ wrap: false, fontSize: 15, rawTerminal: true, tapToFocus: false }),
+    );
+    const { result } = renderHook(() => useDisplayPrefs());
+    expect(result.current.prefs.expandClippedReply).toBe(true);
+    expect(result.current.prefs.tapToFocus).toBe(false);
+    expect(result.current.prefs.fontSize).toBe(15);
   });
 
   // ── THE DRAFT FIELD'S OWN SIZE ────────────────────────────────────────────────────────────────
@@ -231,12 +256,12 @@ describe("useDisplayPrefs — the rest", () => {
   it("falls back to defaults on malformed JSON", () => {
     localStorage.setItem(STORAGE_KEY, "not-json{{{");
     const { result } = renderHook(() => useDisplayPrefs());
-    expect(result.current.prefs).toEqual({ wrap: true, fontSize: 10, draftFontSize: 14, fontFamily: "system", rawTerminal: false, tapToFocus: true });
+    expect(result.current.prefs).toEqual({ wrap: true, fontSize: 10, draftFontSize: 14, fontFamily: "system", rawTerminal: false, tapToFocus: true, expandClippedReply: true });
   });
 
   it("falls back to defaults when stored value is not an object", () => {
     localStorage.setItem(STORAGE_KEY, JSON.stringify(42));
     const { result } = renderHook(() => useDisplayPrefs());
-    expect(result.current.prefs).toEqual({ wrap: true, fontSize: 10, draftFontSize: 14, fontFamily: "system", rawTerminal: false, tapToFocus: true });
+    expect(result.current.prefs).toEqual({ wrap: true, fontSize: 10, draftFontSize: 14, fontFamily: "system", rawTerminal: false, tapToFocus: true, expandClippedReply: true });
   });
 });

--- a/web/src/hooks/use-display-prefs.ts
+++ b/web/src/hooks/use-display-prefs.ts
@@ -56,6 +56,17 @@ export interface DisplayPrefs {
    * that IS ours to give.
    */
   tapToFocus: boolean;
+  /**
+   * Whether a reply whose opening has scrolled off the mirror is re-shown in full above it, read from
+   * the agent's own session log (default: true).
+   *
+   * An agent's TUI runs on the alternate screen, so the mirror is the viewport and nothing more — a
+   * long answer loses its start, and reading it used to mean leaving the pane for the history route.
+   * On, the pane puts it back in place; off, the pane behaves exactly as it did before this existed.
+   * The cost of "on" is one journal read per finished message (see hooks/use-latest-reply.ts), which
+   * is why it is a pref at all rather than unconditional.
+   */
+  expandClippedReply: boolean;
 }
 
 /** The terminal font families offered in Settings. A closed list, not a free-text box: an
@@ -178,6 +189,7 @@ const DEFAULTS: DisplayPrefs = {
   fontFamily: "system",
   rawTerminal: false,
   tapToFocus: true,
+  expandClippedReply: true,
 };
 
 function readFontFamily(value: string | undefined): FontFamily {
@@ -266,6 +278,7 @@ function loadPrefs(): DisplayPrefs {
       fontFamily: readFontFamily(asJsonString(p.fontFamily)),
       rawTerminal: asJsonBoolean(p.rawTerminal) ?? DEFAULTS.rawTerminal,
       tapToFocus: asJsonBoolean(p.tapToFocus) ?? DEFAULTS.tapToFocus,
+      expandClippedReply: asJsonBoolean(p.expandClippedReply) ?? DEFAULTS.expandClippedReply,
     };
   } catch {
     return DEFAULTS;
@@ -298,6 +311,8 @@ export interface UseDisplayPrefsReturn {
   setRawTerminal: (raw: boolean) => void;
   /** Toggle or explicitly set whether a mirror tap focuses the composer. */
   setTapToFocus: (tapToFocus: boolean) => void;
+  /** Toggle or explicitly set whether a clipped reply is re-shown in full above the mirror. */
+  setExpandClippedReply: (expandClippedReply: boolean) => void;
 }
 
 export function useDisplayPrefs(): UseDisplayPrefsReturn {
@@ -359,6 +374,14 @@ export function useDisplayPrefs(): UseDisplayPrefsReturn {
     });
   }, []);
 
+  const setExpandClippedReply = useCallback((expandClippedReply: boolean) => {
+    setPrefs((p) => {
+      const next: DisplayPrefs = { ...p, expandClippedReply };
+      savePrefs(next);
+      return next;
+    });
+  }, []);
+
   return {
     prefs,
     setWrap,
@@ -368,5 +391,6 @@ export function useDisplayPrefs(): UseDisplayPrefsReturn {
     stepDraftFontSize,
     setRawTerminal,
     setTapToFocus,
+    setExpandClippedReply,
   };
 }

--- a/web/src/hooks/use-latest-reply.test.ts
+++ b/web/src/hooks/use-latest-reply.test.ts
@@ -1,0 +1,91 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+
+import { server } from "@/test/setup";
+import { fixtureTranscript } from "@/test/handlers";
+import { useLatestReply } from "./use-latest-reply";
+
+// What the pane view needs from the journal, and — just as much — what it must NOT do to get it: no
+// fetch when the feature is off, and never a reply left over from the pane you just left.
+
+/** Count history requests, keeping the default handler's response. */
+function countHistory(): { hits: () => number } {
+  let hits = 0;
+  server.use(
+    http.get(/\/api\/pane\/[^/]+\/history/, () => {
+      hits += 1;
+      return HttpResponse.json({
+        paneId: "w1:p1",
+        available: true,
+        entries: fixtureTranscript,
+        hasMore: false,
+        total: fixtureTranscript.length,
+        fileTruncated: false,
+      });
+    }),
+  );
+  return { hits: () => hits };
+}
+
+describe("useLatestReply", () => {
+  it("reads the newest spoken turn as soon as the pane opens", async () => {
+    const { result } = renderHook(() =>
+      useLatestReply({ paneId: "w1:p1", enabled: true, mirrorText: "some output" }),
+    );
+    await waitFor(() => expect(result.current?.uuid).toBe("t2"));
+  });
+
+  it("fetches nothing while the feature is off", async () => {
+    const counter = countHistory();
+    const { result } = renderHook(() =>
+      useLatestReply({ paneId: "w1:p1", enabled: false, mirrorText: "some output" }),
+    );
+    await waitFor(() => expect(result.current).toBeNull());
+    expect(counter.hits()).toBe(0);
+  });
+
+  it("does not carry a reply across a pane switch", async () => {
+    const { result, rerender } = renderHook(
+      ({ paneId }) => useLatestReply({ paneId, enabled: true, mirrorText: "some output" }),
+      { initialProps: { paneId: "w1:p1" } },
+    );
+    await waitFor(() => expect(result.current?.uuid).toBe("t2"));
+
+    server.use(
+      http.get(/\/api\/pane\/[^/]+\/history/, () =>
+        HttpResponse.json({ paneId: "w1:p2", available: false, reason: "no-log" }),
+      ),
+    );
+    rerender({ paneId: "w1:p2" });
+    expect(result.current).toBeNull();
+    // …and an unavailable journal leaves it null rather than restoring the previous pane's turn.
+    await waitFor(() => expect(result.current).toBeNull());
+  });
+
+  it("holds null when the pane's journal has nothing spoken in it", async () => {
+    server.use(
+      http.get(/\/api\/pane\/[^/]+\/history/, () =>
+        HttpResponse.json({
+          paneId: "w1:p1",
+          available: true,
+          entries: [fixtureTranscript[0]],
+          hasMore: false,
+          total: 1,
+          fileTruncated: false,
+        }),
+      ),
+    );
+    const { result } = renderHook(() =>
+      useLatestReply({ paneId: "w1:p1", enabled: true, mirrorText: "some output" }),
+    );
+    await waitFor(() => expect(result.current).toBeNull());
+  });
+
+  // The mirror is empty on a pane that has never been read (a degraded/offline open). There is
+  // nothing to compare a reply against yet, so there is no reason to pay for one.
+  it("fetches nothing while the mirror is empty", async () => {
+    const counter = countHistory();
+    renderHook(() => useLatestReply({ paneId: "w1:p1", enabled: true, mirrorText: "" }));
+    await waitFor(() => expect(counter.hits()).toBe(0));
+  });
+});

--- a/web/src/hooks/use-latest-reply.ts
+++ b/web/src/hooks/use-latest-reply.ts
@@ -1,0 +1,83 @@
+import { useEffect, useState } from "react";
+
+import { fetchHistory } from "@/lib/api";
+import { newestReply } from "@/lib/latest-reply";
+import { paneScopeKey, type Scope } from "@/lib/scope";
+import type { TranscriptEntry } from "@/lib/types";
+
+// Keeps the pane view holding the agent's newest spoken turn, read from its own session log.
+//
+// The pane route CANNOT get this from the mirror: an agent's TUI runs on the alternate screen, so
+// `pane.read` returns the viewport and nothing above it (see lib/latest-reply.ts for the full why).
+// The journal is a second source with a different cost, which is what this hook is really managing.
+//
+// WHEN IT FETCHES. Not on the poll. The mirror revalidates every ~1.5 s and a fetch here re-parses the
+// agent's log bridge-side whenever its mtime moved (bridge/journal/store.ts caches on size+mtime), so
+// fetching per poll would put a whole-journal parse on a loop. Instead it waits for the mirror text to
+// SETTLE — unchanged for SETTLE_MS — which a streaming reply never does. In practice that is one fetch
+// per finished message, the same cost as opening the history route once, which is what this replaces.
+//
+// The first fetch is immediate rather than settle-delayed: opening a pane whose reply is already
+// clipped should show it, not make you wait out a timer for output that may never change again.
+
+/** Turns requested. The newest SPOKEN turn may sit behind a run of tool calls, so ask for a few. */
+const TURNS = 8;
+
+/** How long the mirror must hold still before its content counts as a finished message. */
+const SETTLE_MS = 1500;
+
+/**
+ * The agent's newest prose turn, or null when there isn't one (yet), the pane has no journal, or the
+ * caller switched this off.
+ *
+ * Errors are swallowed on purpose: this is an enhancement over the mirror, and the mirror is still
+ * right there. A failed read must cost nothing more than the card not appearing.
+ */
+export function useLatestReply({
+  paneId,
+  scope,
+  enabled,
+  mirrorText,
+}: {
+  paneId: string;
+  /** Which machine + session this pane lives on — the same address every other pane read carries. */
+  scope?: Scope;
+  /** False for a pane with no journal, or when the operator turned the feature off. */
+  enabled: boolean;
+  /** The mirror as displayed — its stillness is the trigger, its content is not read here. */
+  mirrorText: string;
+}): TranscriptEntry | null {
+  const [reply, setReply] = useState<TranscriptEntry | null>(null);
+  const [settled, setSettled] = useState(mirrorText);
+
+  // A reply belongs to the pane it was read from — never let one outlive a switch to another pane,
+  // where locateReply would be comparing it against a screen it has nothing to do with. Keyed on the
+  // ADDRESS, not the pane id: the same pane id on another host or session is a different pane.
+  const address = paneScopeKey(scope, paneId);
+  useEffect(() => setReply(null), [address]);
+
+  useEffect(() => {
+    if (!enabled) return;
+    const timer = setTimeout(() => setSettled(mirrorText), SETTLE_MS);
+    return () => clearTimeout(timer);
+  }, [mirrorText, enabled]);
+
+  useEffect(() => {
+    if (!enabled || settled === "") return;
+    const abort = new AbortController();
+    let live = true;
+    fetchHistory(paneId, { limit: TURNS }, scope, abort.signal)
+      .then((page) => {
+        if (live && page.available) setReply(newestReply(page.entries));
+      })
+      .catch(() => {});
+    return () => {
+      live = false;
+      abort.abort();
+    };
+    // `scope` is safe in a dependency array: scopes read off a URL are interned to one frozen
+    // instance per (host, session), so its identity is as stable as the string it replaced.
+  }, [paneId, scope, enabled, settled]);
+
+  return enabled ? reply : null;
+}

--- a/web/src/lib/blocks.test.ts
+++ b/web/src/lib/blocks.test.ts
@@ -3,7 +3,7 @@ import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 
 import { parseAnsi, type AnsiSegment } from "./ansi";
-import { lineText, splitLines, type StyledLine } from "./blocks";
+import { dropLeadingLines, lineText, splitLines, type StyledLine } from "./blocks";
 import { buildBlocks } from "./harness";
 import { isBoxBorder, isHorizontalRule } from "./harness/claude/markers";
 
@@ -431,5 +431,29 @@ describe("buildBlocks — Claude grammars (ctx.agent === 'claude')", () => {
     expect(blocks).toHaveLength(1);
     expect(blocks[0]!.kind).toBe("raw");
     expect(blocks[0]!.lines).toBe(lines);
+  });
+});
+
+// The render-only subtraction behind the "Full reply" card: the message is being drawn from the
+// journal, so the terminal rows it covers come off the top of the mirror rather than printing twice.
+describe("dropLeadingLines", () => {
+  const raw = (...texts: string[]) => ({ kind: "raw" as const, lines: texts.map((t) => ({ segments: [seg(t)] })) });
+  const texts = (blocks: ReturnType<typeof raw>[]) => blocks.map((b) => b.lines.map(lineText));
+
+  it("drops rows off the top of the leading block", () => {
+    expect(texts(dropLeadingLines([raw("a", "b", "c", "d")], 2))).toEqual([["c", "d"]]);
+  });
+
+  it("keeps counting across blocks once one is used up", () => {
+    expect(texts(dropLeadingLines([raw("a", "b"), raw("c", "d")], 3))).toEqual([["d"]]);
+  });
+
+  it("leaves nothing behind when the count covers everything — the <pre> then renders not at all", () => {
+    expect(dropLeadingLines([raw("a", "b")], 5)).toEqual([]);
+  });
+
+  it("is the identity for a count of zero, reference and all", () => {
+    const blocks = [raw("a", "b")];
+    expect(dropLeadingLines(blocks, 0)).toBe(blocks);
   });
 });

--- a/web/src/lib/blocks.ts
+++ b/web/src/lib/blocks.ts
@@ -332,3 +332,27 @@ export function trimTrailingBlank(lines: StyledLine[]): StyledLine[] {
   while (end > 0 && isBlank(lineText(lines[end - 1]!))) end--;
   return end === lines.length ? lines : lines.slice(0, end);
 }
+
+/**
+ * Drop the first `count` screen rows from a run of raw blocks, emptied blocks and all.
+ *
+ * A RENDER-ONLY subtraction: detection has already run over the whole screen by the time anyone calls
+ * this, so nothing a grammar decided can change. Its one caller hides the rows a clipped reply
+ * occupies, because the full message is being rendered from the journal directly above them
+ * (components/latest-reply.tsx). Counting in rows works because every pipeline lifts its dialog off
+ * the TAIL — the leading raw block still starts at screen row 0.
+ */
+export function dropLeadingLines(blocks: RawBlock[], count: number): RawBlock[] {
+  if (count <= 0) return blocks;
+  let left = count;
+  const kept: RawBlock[] = [];
+  for (const block of blocks) {
+    if (left >= block.lines.length) {
+      left -= block.lines.length;
+      continue;
+    }
+    kept.push(left > 0 ? { ...block, lines: block.lines.slice(left) } : block);
+    left = 0;
+  }
+  return kept;
+}

--- a/web/src/lib/i18n/messages/de.ts
+++ b/web/src/lib/i18n/messages/de.ts
@@ -175,6 +175,9 @@ export const de: Dictionary = {
   "settings.display.tapToType.label": "Tippen zum Schreiben",
   "settings.display.tapToType.hint":
     "Aktiv: Antippen des Spiegels öffnet überall die Tastatur. Deaktiviert: Spiegel bleibt Textanzeige, Tastatur öffnet nur im Eingabefeld.",
+  "settings.display.fullReply.label": "Vollständige letzte Antwort",
+  "settings.display.fullReply.hint":
+    "Das Terminal eines Agenten hat keinen Verlaufspuffer, daher fehlt bei langen Antworten der Anfang. Aktiv: Die Antwort erscheint vollständig aus dem Protokoll des Agenten und ersetzt die abgeschnittenen Zeilen.",
   "settings.display.rawTerminal.label": "Rohes Terminal",
   "settings.display.rawTerminal.hint":
     "Zeigt den reinen Terminal-Puffer ohne Buttons, Rahmen oder Statusleisten. Gedacht für falsch dargestellte TUI-Dialoge zur manuellen Tastensteuerung.",
@@ -277,6 +280,9 @@ export const de: Dictionary = {
   "chat.scrollback.loading": "Wird geladen…",
   "chat.scrollback.noSessionReported":
     "{agent} hat keine Sitzung an Herdr gemeldet. Herdr-Integration installieren oder aktualisieren und den Agenten in diesem Pane neu starten.",
+  "chat.fullReply.title": "Vollständige Antwort",
+  "chat.fullReply.fromTranscript": "aus dem Protokoll",
+  "chat.fullReply.showingTerminal": "Terminal wird gezeigt",
   "chat.output.empty": "(keine neue Ausgabe)",
   "chat.switcher.aria": "Pane wechseln",
   "chat.switcher.title": "Pane wechseln",

--- a/web/src/lib/i18n/messages/en.ts
+++ b/web/src/lib/i18n/messages/en.ts
@@ -187,6 +187,9 @@ export const en = {
   "settings.display.tapToType.label": "Tap to type",
   "settings.display.tapToType.hint":
     "On, tapping the mirror anywhere opens the keyboard. Off, the mirror behaves like a document — taps land on the text and only the composer opens the keyboard.",
+  "settings.display.fullReply.label": "Full latest reply",
+  "settings.display.fullReply.hint":
+    "An agent's terminal keeps no scrollback, so a long answer loses its start. On, that reply is shown in full from the agent's own log, in place of the rows it covers.",
   "settings.display.rawTerminal.label": "Raw terminal",
   "settings.display.rawTerminal.hint":
     "Shows the plain mirror — no tappable prompt buttons, no chrome or status strips. Use it when a dialog renders wrong and you want to drive it by hand from Keys.",
@@ -294,6 +297,9 @@ export const en = {
   "chat.scrollback.loading": "Loading…",
   "chat.scrollback.noSessionReported":
     "{agent} has not reported a session to Herdr. Install or update the Herdr integration for it, then restart the agent in this pane.",
+  "chat.fullReply.title": "Full reply",
+  "chat.fullReply.fromTranscript": "from transcript",
+  "chat.fullReply.showingTerminal": "showing the terminal",
   "chat.output.empty": "(no recent output)",
   "chat.switcher.aria": "Switch pane",
   "chat.switcher.title": "Switch pane",

--- a/web/src/lib/i18n/messages/es.ts
+++ b/web/src/lib/i18n/messages/es.ts
@@ -173,6 +173,9 @@ export const es: Dictionary = {
   "settings.display.tapToType.label": "Tocar para escribir",
   "settings.display.tapToType.hint":
     "Si esta activo, pulsar en cualquier parte abre el teclado. Si no, funciona como documento de texto y solo el editor abre el teclado.",
+  "settings.display.fullReply.label": "Respuesta completa",
+  "settings.display.fullReply.hint":
+    "La terminal de un agente no guarda historial, así que una respuesta larga pierde su inicio. Si esta activo, se muestra completa desde el registro del agente, en lugar de las lineas que cubre.",
   "settings.display.rawTerminal.label": "Terminal sin formato",
   "settings.display.rawTerminal.hint":
     "Muestra la sesion directa sin botones de interfaz ni barras. Util si un dialogo falla y requiere control manual mediante Teclas.",
@@ -275,6 +278,9 @@ export const es: Dictionary = {
   "chat.scrollback.loading": "Cargando…",
   "chat.scrollback.noSessionReported":
     "{agent} no ha registrado ninguna sesión en Herdr. Instala o actualiza la integración de Herdr correspondiente y reinicia el agente en este panel.",
+  "chat.fullReply.title": "Respuesta completa",
+  "chat.fullReply.fromTranscript": "desde el registro",
+  "chat.fullReply.showingTerminal": "mostrando la terminal",
   "chat.output.empty": "(sin salida reciente)",
   "chat.switcher.aria": "Cambiar panel",
   "chat.switcher.title": "Cambiar panel",

--- a/web/src/lib/i18n/messages/ja.ts
+++ b/web/src/lib/i18n/messages/ja.ts
@@ -171,6 +171,9 @@ export const ja: Dictionary = {
   "settings.display.tapToType.label": "タップで入力開始",
   "settings.display.tapToType.hint":
     "有効時はターミナル領域のタップでキーボードが開きます。無効時はテキスト選択が優先され、キーボードは入力欄タップ時のみ開きます。",
+  "settings.display.fullReply.label": "最新の返答を全文表示",
+  "settings.display.fullReply.hint":
+    "エージェントのターミナルはスクロールバックを保持しないため、長い返答は冒頭が失われます。有効時はエージェント自身のログから全文を表示し、該当する行を置き換えます。",
   "settings.display.rawTerminal.label": "未加工ターミナル",
   "settings.display.rawTerminal.hint":
     "プロンプトボタンやステータス表示を除いた素の出力を表示します。ダイアログの表示崩れを手動で制御する際に使用します。",
@@ -272,6 +275,9 @@ export const ja: Dictionary = {
   "chat.scrollback.loading": "読み込み中…",
   "chat.scrollback.noSessionReported":
     "{agent} のセッションが Herdr に報告されていません。Herdr 連携をインストールまたは更新し、このペインでエージェントを再起動してください。",
+  "chat.fullReply.title": "返答の全文",
+  "chat.fullReply.fromTranscript": "ログより",
+  "chat.fullReply.showingTerminal": "ターミナルを表示中",
   "chat.output.empty": "(直近の出力なし)",
   "chat.switcher.aria": "ペインを切り替え",
   "chat.switcher.title": "ペインを切り替え",

--- a/web/src/lib/i18n/messages/ko.ts
+++ b/web/src/lib/i18n/messages/ko.ts
@@ -170,6 +170,9 @@ export const ko: Dictionary = {
   "settings.display.tapToType.label": "탭하여 입력",
   "settings.display.tapToType.hint":
     "활성화하면 미러 영역 어디를 눌러도 키보드가 열립니다. 끄면 일반 문서처럼 동작하며 입력기를 눌러야 키보드가 표시됩니다.",
+  "settings.display.fullReply.label": "최신 답변 전체 보기",
+  "settings.display.fullReply.hint":
+    "에이전트 터미널은 스크롤백을 남기지 않아 긴 답변은 앞부분이 사라집니다. 켜면 에이전트 로그에서 전체 답변을 가져와 해당 줄을 대신 표시합니다.",
   "settings.display.rawTerminal.label": "원시 터미널",
   "settings.display.rawTerminal.hint":
     "프롬프트 버튼, UI 장식, 상태 바 없이 순수 화면만 표시합니다. 대화상자가 깨져서 직접 키를 입력해야 할 때 유용합니다.",
@@ -270,6 +273,9 @@ export const ko: Dictionary = {
   "chat.scrollback.loading": "불러오는 중…",
   "chat.scrollback.noSessionReported":
     "{agent}가 Herdr에 세션을 보고하지 않았습니다. 에이전트용 Herdr 연동 패키지를 설치하거나 업데이트한 후 이 창에서 에이전트를 재시작하십시오.",
+  "chat.fullReply.title": "답변 전체",
+  "chat.fullReply.fromTranscript": "로그에서",
+  "chat.fullReply.showingTerminal": "터미널 표시 중",
   "chat.output.empty": "(최근 출력 없음)",
   "chat.switcher.aria": "창 전환",
   "chat.switcher.title": "창 전환",

--- a/web/src/lib/i18n/messages/zh-TW.ts
+++ b/web/src/lib/i18n/messages/zh-TW.ts
@@ -160,6 +160,9 @@ export const zhTW: Dictionary = {
   "settings.display.tapToType.label": "點擊喚出鍵盤",
   "settings.display.tapToType.hint":
     "啟用後點擊鏡像任意位置都會彈出鍵盤。關閉後鏡像以文件模式互動，僅點擊輸入框時喚出鍵盤。",
+  "settings.display.fullReply.label": "完整顯示最新回覆",
+  "settings.display.fullReply.hint":
+    "Agent 的終端機不保留回捲緩衝，較長回覆的開頭會遺失。啟用後會從 Agent 自身的記錄取出完整回覆，取代它所覆蓋的那幾行。",
   "settings.display.rawTerminal.label": "原始終端機",
   "settings.display.rawTerminal.hint":
     "僅顯示純終端機鏡像，隱藏提示按鈕與狀態列。適用於對話框呈現異常時透過按鍵手動操作。",
@@ -258,6 +261,9 @@ export const zhTW: Dictionary = {
   "chat.scrollback.loading": "正在載入…",
   "chat.scrollback.noSessionReported":
     "{agent} 尚未向 Herdr 回報工作階段。請安裝或更新對應的 Herdr 整合，並在目前窗格重新啟動該 Agent。",
+  "chat.fullReply.title": "完整回覆",
+  "chat.fullReply.fromTranscript": "來自記錄",
+  "chat.fullReply.showingTerminal": "正在顯示終端機",
   "chat.output.empty": "（暫無近期輸出）",
   "chat.switcher.aria": "切換窗格",
   "chat.switcher.title": "切換窗格",

--- a/web/src/lib/i18n/messages/zh.ts
+++ b/web/src/lib/i18n/messages/zh.ts
@@ -161,6 +161,9 @@ export const zh: Dictionary = {
   "settings.display.tapToType.label": "点击唤起键盘",
   "settings.display.tapToType.hint":
     "开启后点击镜像任意位置均弹出键盘。关闭后镜像以文档模式交互，仅点击输入框时调出键盘。",
+  "settings.display.fullReply.label": "完整显示最新回复",
+  "settings.display.fullReply.hint":
+    "智能体终端不保留回滚缓冲，长回复的开头会丢失。开启后将从智能体自身日志中取出完整回复，替换它所覆盖的那几行。",
   "settings.display.rawTerminal.label": "原始终端",
   "settings.display.rawTerminal.hint":
     "仅显示纯终端镜像，隐藏提示按钮与状态栏。适用于对话框渲染异常时通过按键手动操作。",
@@ -259,6 +262,9 @@ export const zh: Dictionary = {
   "chat.scrollback.loading": "正在加载…",
   "chat.scrollback.noSessionReported":
     "{agent} 尚未向 Herdr 上报会话。请安装或更新对应的 Herdr 集成，并在当前窗格重启该 Agent。",
+  "chat.fullReply.title": "完整回复",
+  "chat.fullReply.fromTranscript": "来自日志",
+  "chat.fullReply.showingTerminal": "正在显示终端",
   "chat.output.empty": "（暂无近期输出）",
   "chat.switcher.aria": "切换窗格",
   "chat.switcher.title": "切换窗格",

--- a/web/src/lib/latest-reply.test.ts
+++ b/web/src/lib/latest-reply.test.ts
@@ -1,0 +1,176 @@
+import { fold, locateReply, newestReply, PROBE_CHARS, replyProse } from "./latest-reply";
+import type { TranscriptEntry } from "./types";
+
+// The predicates behind "the mirror is only showing the end of this reply". The cases that matter are
+// the ones where the two sides of the comparison are written differently — Markdown source against a
+// rendered, hard-wrapped, SGR-coloured screen — and the one where they are different MESSAGES.
+
+function turn(
+  role: TranscriptEntry["role"],
+  text: string,
+  extra: { uuid?: string; truncated?: boolean } = {},
+): TranscriptEntry {
+  return {
+    uuid: extra.uuid ?? `${role}-${text.slice(0, 8)}`,
+    ts: "2026-08-28T10:00:00.000Z",
+    role,
+    parts: [{ kind: "text", text, ...(extra.truncated ? { truncated: true } : {}) }],
+  };
+}
+
+// A reply comfortably longer than two probes, with Markdown in it.
+const REPLY = [
+  "Short answer: **approve-only**. The author knows when they want it to land; your job was the",
+  "approval. Enabling auto-merge makes you the actor for the merge itself, which is a materially",
+  "bigger claim than \"this looks fine to me\".",
+  "",
+  "- `deployment_tools` gates production, so an automated approval there is a different risk class.",
+  "- A fast manual approval keeps your name on something you actually saw.",
+].join("\n");
+
+/** Wrap text the way a terminal does — at word boundaries, with continuation rows indented. */
+function hardWrap(text: string, cols: number): string {
+  return text
+    .split("\n")
+    .flatMap((line) => {
+      const rows: string[] = [];
+      let row = "";
+      for (const word of line.split(" ")) {
+        const candidate = row === "" ? word : `${row} ${word}`;
+        if (candidate.length > cols && row !== "") {
+          rows.push(row);
+          row = word;
+        } else {
+          row = candidate;
+        }
+      }
+      rows.push(row);
+      return rows.map((r, i) => (i === 0 ? r : `  ${r}`));
+    })
+    .join("\n");
+}
+
+/** What Claude paints: no Markdown markers, emphasis as SGR, an ⏺ lead, hard-wrapped. */
+function rendered(text: string, cols = 40): string {
+  const painted = text.replace(/\*\*(.+?)\*\*/g, "\x1b[1m$1\x1b[0m").replace(/`/g, "");
+  return `⏺ ${hardWrap(painted, cols)}`;
+}
+
+describe("fold", () => {
+  it("erases every difference between Markdown source and a wrapped, coloured render", () => {
+    expect(fold("**bold** text")).toBe(fold("\x1b[1mbold\x1b[0m text".replace(/\x1b\[\d+m/g, "")));
+    expect(fold("hello world")).toBe(fold("hello\n  world"));
+    expect(fold("- a bullet")).toBe(fold("  • a bullet"));
+  });
+
+  it("keeps non-Latin content rather than folding it away", () => {
+    expect(fold("こんにちは、世界")).toBe("こんにちは世界");
+  });
+});
+
+describe("newestReply", () => {
+  const entries: TranscriptEntry[] = [
+    turn("user", "what should I do?"),
+    turn("assistant", "first thought"),
+    turn("assistant", "second thought"),
+  ];
+
+  it("picks the last assistant turn carrying prose", () => {
+    expect(replyProse(newestReply(entries)!)).toBe("second thought");
+  });
+
+  it("skips a trailing turn that is only a tool call", () => {
+    const toolOnly: TranscriptEntry = {
+      uuid: "tool",
+      ts: "",
+      role: "assistant",
+      parts: [{ kind: "tool", name: "Bash", summary: "ls" }],
+    };
+    expect(replyProse(newestReply([...entries, toolOnly])!)).toBe("second thought");
+  });
+
+  it("returns null when the agent has not spoken", () => {
+    expect(newestReply([turn("user", "hello")])).toBeNull();
+  });
+});
+
+describe("locateReply", () => {
+  const fitOf = (mirror: string, entry: TranscriptEntry) => locateReply(mirror, entry).fit;
+  const reply = turn("assistant", REPLY);
+
+  it("calls it clipped when the tail is painted but the opening has scrolled off", () => {
+    const screen = rendered(REPLY).split("\n").slice(4).join("\n");
+    expect(fitOf(screen, reply)).toBe("clipped");
+  });
+
+  it("calls it whole when the whole message is on screen, markers and colour notwithstanding", () => {
+    expect(fitOf(rendered(REPLY), reply)).toBe("whole");
+  });
+
+  it("survives a pane narrow enough to wrap every line several times", () => {
+    const screen = rendered(REPLY, 18).split("\n").slice(6).join("\n");
+    expect(fitOf(screen, reply)).toBe("clipped");
+  });
+
+  // The identity check: the journal's newest reply is not automatically the one being displayed.
+  it("calls it off-screen when the mirror is showing some other message", () => {
+    expect(fitOf(rendered("a completely different answer about something else"), reply)).toBe(
+      "off-screen",
+    );
+  });
+
+  it("calls it off-screen when the mirror has moved on past this reply entirely", () => {
+    const screen = `${rendered(REPLY).split("\n").slice(0, 3).join("\n")}\n⏺ and then a new message`;
+    expect(fitOf(screen, reply)).toBe("off-screen");
+  });
+
+  // A clamped part's real ending never reaches us, so the tail probe could never match — say so
+  // explicitly rather than leaving it to fall out of the probe.
+  it("calls it off-screen when the bridge clamped the part", () => {
+    expect(fitOf(rendered(REPLY), turn("assistant", REPLY, { truncated: true }))).toBe(
+      "off-screen",
+    );
+  });
+
+  it("calls a reply shorter than two probes whole without probing at all", () => {
+    const short = turn("assistant", "a".repeat(PROBE_CHARS * 2 - 10));
+    expect(fitOf("nothing of the sort is on this screen", short)).toBe("whole");
+  });
+
+  // SGR parameters are digits, and digits survive the fold — an unstripped escape would corrupt the
+  // probe it landed in. parseAnsi runs first precisely so it cannot.
+  it("does not let SGR parameters leak into the comparison", () => {
+    const coloured = `\x1b[38;5;213m${REPLY}\x1b[0m`;
+    expect(fitOf(coloured, reply)).toBe("whole");
+  });
+});
+
+// endLine is what lets the caller REPLACE the clipped rows instead of printing the message twice, so
+// it has to name the row the reply actually finishes on — not the screen's last row.
+describe("locateReply — where the reply ends", () => {
+  const reply = turn("assistant", REPLY);
+
+  it("names the last row of the reply, with the terminal's own tail below it", () => {
+    const painted = rendered(REPLY).split("\n").slice(4); // clipped: the opening is gone
+    const after = ["", "⏺ Bash(git log --oneline)", "  ⎿ abc1234 fix"];
+    const { fit, endLine } = locateReply([...painted, ...after].join("\n"), reply);
+
+    expect(fit).toBe("clipped");
+    // The reply's own rows are 0..endLine, and everything the agent did afterwards survives.
+    expect(endLine).toBe(painted.length - 1);
+    expect([...painted, ...after].slice(endLine + 1)).toEqual(after);
+  });
+
+  it("names the final row when the reply is the last thing painted", () => {
+    const painted = rendered(REPLY).split("\n").slice(4);
+    const { endLine } = locateReply(painted.join("\n"), reply);
+    expect(endLine).toBe(painted.length - 1);
+  });
+
+  // Nothing may be hidden on a verdict that isn't `clipped` — -1 makes a caller that forgets to check
+  // hide nothing rather than hide a row.
+  it("reports no row at all when the reply is not the clipped message on screen", () => {
+    expect(locateReply("some other screen entirely", reply).endLine).toBe(-1);
+    expect(locateReply(rendered(REPLY), reply).endLine).toBe(-1);
+  });
+});

--- a/web/src/lib/latest-reply.ts
+++ b/web/src/lib/latest-reply.ts
@@ -1,0 +1,137 @@
+// Deciding whether the newest reply in the agent's journal is the one on the mirror, and whether the
+// mirror is showing all of it.
+//
+// WHY THIS EXISTS. A Claude pane runs on the terminal's alternate screen, which keeps no scrollback
+// ring, so `pane.read` can only ever hand back the visible viewport — a reply longer than the pane is
+// tall has its opening simply gone, and the only copy that still exists is the agent's own session log
+// (bridge/journal/, GET /api/pane/:id/history). Reaching it used to mean leaving the pane for the
+// history route. locateReply lets the pane view put the full message back in place instead —
+// including WHERE the clipped rows end, so the card replaces them rather than printing them twice.
+//
+// This is NOT a step toward rendering the terminal from the journal, and it must not become one: the
+// mirror stays the mirror (ADR 0008), and nothing here synthesises scrollback. All it answers is "is
+// the start of the message on screen, and if not, is this even the message on screen".
+//
+// THE NORMALISATION IS THE WHOLE TRICK. Both sides describe the same prose in different notations:
+// the journal holds Markdown source (`**bold**`, `- bullet`, one logical line per paragraph), while
+// the mirror holds what Claude's renderer painted (emphasis turned into SGR runs, bullets possibly
+// re-glyphed, an `⏺` prefix, and every paragraph hard-wrapped at the pane width with indentation on
+// the continuation rows). Folding both to LETTERS AND DIGITS ONLY — dropping whitespace along with
+// punctuation — collapses every one of those differences at once. Wrapping is the case that makes it
+// necessary rather than merely convenient: the mirror breaks a paragraph wherever the pane width
+// falls, the journal breaks it nowhere, and only deleting the spaces makes the two comparable
+// (`hello\n  world` and `hello world` both fold to `helloworld`).
+//
+// Escapes must go BEFORE the fold: `\x1b[38;5;1m` is mostly digits, and digits survive folding, so an
+// un-stripped SGR run would inject garbage into the middle of a probe. parseAnsi is the repo's one
+// place that knows escape shapes — use it rather than a second regex that can drift from it.
+
+import { parseAnsi } from "./ansi";
+import type { TranscriptEntry } from "./types";
+
+/**
+ * How much of the reply each probe compares, in folded characters.
+ *
+ * Long enough that a coincidental match is not a real risk (48 letters of prose is a sentence), short
+ * enough to sit inside the first and last rendered lines of a message.
+ */
+export const PROBE_CHARS = 48;
+
+/** Where the newest reply sits relative to what the mirror is showing. */
+export type ReplyFit =
+  /** Its tail is on screen but its opening has scrolled off — the case worth surfacing. */
+  | "clipped"
+  /** All of it is on screen (or it is too short to be worth the machinery). */
+  | "whole"
+  /** Not the message the mirror is showing at all — see the note on {@link locateReply}. */
+  | "off-screen";
+
+/** Keep letters and digits, lose everything else. Unicode-aware, so a non-Latin reply still folds to
+ *  its own content rather than to nothing. */
+export function fold(text: string): string {
+  return text.toLowerCase().replace(/[^\p{L}\p{N}]+/gu, "");
+}
+
+/** Plain text of a mirror read: the ANSI parse, reassembled. Newlines live inside the segments, so
+ *  joining with "" reproduces the screen exactly — and the fold then removes them anyway. */
+function plain(mirrorText: string): string {
+  return parseAnsi(mirrorText)
+    .map((segment) => segment.text)
+    .join("");
+}
+
+/** A turn's prose — its `text` parts only. Thinking is not the reply, and a tool call is not speech. */
+export function replyProse(entry: TranscriptEntry): string {
+  return entry.parts
+    .filter((part) => part.kind === "text")
+    .map((part) => part.text)
+    .join("\n")
+    .trim();
+}
+
+/** True when the bridge capped one of those parts (MAX_TEXT_CHARS), so what we hold is not the end. */
+function proseTruncated(entry: TranscriptEntry): boolean {
+  return entry.parts.some((part) => part.kind === "text" && part.truncated === true);
+}
+
+/** The newest turn that is the agent SPEAKING — the last assistant entry carrying prose. */
+export function newestReply(entries: TranscriptEntry[]): TranscriptEntry | null {
+  for (let i = entries.length - 1; i >= 0; i--) {
+    const entry = entries[i];
+    if (entry && entry.role === "assistant" && replyProse(entry) !== "") return entry;
+  }
+  return null;
+}
+
+/** Where a turn sits on the mirror, and — when it is clipped — which row it ends on. */
+export interface ReplyPlacement {
+  fit: ReplyFit;
+  /** Index of the last mirror row the reply occupies. Only meaningful when `fit` is `clipped`. */
+  endLine: number;
+}
+
+/**
+ * Locate a journal turn on the mirror.
+ *
+ * Two probes, and the ORDER OF THE VERDICTS matters more than either of them:
+ *
+ * - The **tail** probe is the identity check. The journal's newest reply is not necessarily the one
+ *   on screen — the log lags a message that is still streaming, the operator may have frozen the
+ *   mirror by scrolling, and a >20 000-character part reaches us clamped so its real ending never
+ *   arrives. When the tail is missing we answer `off-screen` and the caller shows NOTHING. Presenting
+ *   an older message as "the reply you are looking at" is the one failure this must not have.
+ * - The **head** probe then answers the actual question: is its opening still on the screen.
+ *
+ * A reply shorter than two probes is `whole` by construction — it cannot be meaningfully clipped, and
+ * overlapping probes would compare a string against itself.
+ *
+ * `endLine` exists so the caller can REPLACE those rows with the full message rather than print it
+ * twice. Folding erases the row boundaries, so the row that the reply ends on is recovered by keeping
+ * each row's cumulative folded length and finding the first that reaches the tail probe's end.
+ */
+export function locateReply(mirrorText: string, entry: TranscriptEntry): ReplyPlacement {
+  const elsewhere = (fit: ReplyFit): ReplyPlacement => ({ fit, endLine: -1 });
+
+  const reply = fold(replyProse(entry));
+  if (reply.length < PROBE_CHARS * 2) return elsewhere("whole");
+  if (proseTruncated(entry)) return elsewhere("off-screen");
+
+  const rows = plain(mirrorText).split("\n");
+  // Folding each row and concatenating is the same string as folding the whole screen — the fold
+  // drops the separators either way — so these offsets index into one folded mirror.
+  const rowEnds: number[] = [];
+  let mirror = "";
+  for (const row of rows) {
+    mirror += fold(row);
+    rowEnds.push(mirror.length);
+  }
+
+  const tail = reply.slice(-PROBE_CHARS);
+  const at = mirror.indexOf(tail);
+  if (at === -1) return elsewhere("off-screen");
+  if (mirror.includes(reply.slice(0, PROBE_CHARS))) return elsewhere("whole");
+
+  const end = at + tail.length;
+  const endLine = rowEnds.findIndex((rowEnd) => rowEnd >= end);
+  return { fit: "clipped", endLine: endLine === -1 ? rows.length - 1 : endLine };
+}


### PR DESCRIPTION
An agent's TUI runs on the alternate screen, which keeps no scrollback ring, so `pane.read` can only ever return the visible viewport. A reply longer than the pane is tall reaches the mirror with its opening already gone, and the only copy that still exists is the agent's own session log — so reading a message you are already looking at meant leaving the pane for the history route.

The pane view now reads the newest turn from the journal and, when that turn *is* the message on screen and its start is missing, renders it in full **in place of** the rows it covers. Everything below the reply — tool calls, a dialog, the cursor — is untouched, so the mirror still reads as the live screen, just starting where the message finished.

### The two decisions worth reviewing

**The gate is an identity check, not a length check** (`web/src/lib/latest-reply.ts`). `locateReply` folds both texts to letters and digits only — which is what makes Markdown source comparable to a hard-wrapped, SGR-coloured render, and is what makes the wrapping irrelevant — then runs two probes:

- The **tail** probe asks whether this journal turn is the message on screen at all. It often is not: the log lags a reply that is still streaming, the operator may have frozen the mirror by scrolling, and a part past `MAX_TEXT_CHARS` arrives clamped so its real ending never does. A missed tail renders **nothing**. Presenting an older message as "the reply you are looking at" is the one failure this must not have.
- The **head** probe then answers the actual question: is its opening still on screen.

**The hiding is render-only.** `locateReply` also returns where the clipped rows end, and `AnsiOutput`'s new `hideLeadingLines` drops them — applied *after* every grammar has run over the whole screen, so no detector, race guard or draft probe ever sees a trimmed buffer. Counting in screen rows is sound because every harness's `stripChrome` slices from the tail only and every pipeline lifts its dialog off the tail, so the leading raw block still starts at row 0; codex's `decorateCodexDisplay` is one-to-one. Collapsing the card gives the raw rows back, which is why the open state lives in `AgentChat` rather than the card — the hiding and the folding have to be one decision. Find restores the whole mirror and stands the card down, since find can only highlight there.

### Cost, and the opt-out

Fetching waits for the mirror to **settle** rather than riding the 1.5 s poll — a streaming reply never settles — so it is roughly one journal read per finished message, the same cost as opening the history route once, which is what it replaces. New `expandClippedReply` display pref, default on, in the ⚙ View dock; off, the pane behaves exactly as it did before and costs no journal read at all.

### Notes

- No version bump and no `CHANGELOG.md` line, per CLAUDE.md's fork rule. Suggested Unreleased line:
  `- A reply whose opening scrolled off the terminal is shown in full from the agent's own log, in place of the rows it covers; ⚙ View → Full latest reply turns it off`
- Five new message keys, added to all seven dictionaries. The six non-English ones are my own work and would benefit from a native reader's eye — `zh-TW` in particular, which I wrote in that file's own Traditional register rather than converting the Simplified entries.
- No ADR: this closes off no option. It respects ADR 0008 — the mirror stays the mirror, and nothing here synthesises scrollback.
- Verified on a real install (Herdr, 1.5.x) against live Claude panes, not only in tests.

### Tests

`locateReply`'s three verdicts over wrapped / emphasised / `⏺`-prefixed screens, the clamped-part case, and `endLine` (including that it reports `-1` on any non-clipped verdict, so a caller that forgets to check hides nothing); `dropLeadingLines`; and seven `AgentChat` cases asserting against the `<pre>`'s own text — rows gone while expanded, back on collapse, back while find is open, nothing on a stale journal read, and no journal read at all when the pref is off or the pane has no log.

5177 web tests and 4028 bridge tests green, both typechecks clean, `scripts/check-version.sh` ✓ at 1.5.5.
