### PR TITLE
perf(state): skip enrichSessionNames readGrid for unchanged panes

### DIFF
--- a/bridge/mux/herdr/adapter.ts
+++ b/bridge/mux/herdr/adapter.ts
@@ -522,6 +522,7 @@ function toMuxPane(
   // Scrollback depth + viewport = what a `recent` read can yield. Omitted when the server predates
   // `scroll`, so an older Herdr reads as "unknown" rather than "zero".
   if (raw.scroll) pane.readableLines = raw.scroll.max_offset_from_bottom + raw.scroll.viewport_rows;
+  pane.revision = raw.revision;
   return pane;
 }
 

--- a/bridge/mux/types.ts
+++ b/bridge/mux/types.ts
@@ -227,6 +227,12 @@ export interface MuxPane extends MuxIdentity {
    * port's answer to "which agent runs here" is `agentDetection` or `"shell"` — never a process
    * name, however much this one looks like an identity.
    */
+  /**
+   * Content revision from the multiplexer's snapshot — changes when the pane's screen changes.
+   * Herdr provides this natively; tmux and zellij can only derive it per-read, so it is absent from
+   * their snapshot and optional here.
+   */
+  readonly revision?: number;
   readonly foregroundCommand?: string;
   /**
    * A finished English sentence for the operator about this pane, composed server-side.

--- a/bridge/solo-baseline.test.ts
+++ b/bridge/solo-baseline.test.ts
@@ -296,6 +296,7 @@ const PANE_WIRE_KEYS = {
   // Also not a pack dimension: an optional sentence the bridge composes for one kind of pane
   // (M11/05). Absent on every pane in this baseline, so no golden byte moved.
   hint: true,
+  revision: true,
   // The OTHER half of a pane's address, and the one field here that is written by a request rather
   // than by the pane's own state: present only when the caller asked to widen (`?sessions=all`),
   // and then on every pane in the body. Nothing in this baseline asks, so it is absent on every
@@ -415,6 +416,7 @@ describe("solo zero-tax — wire shapes carry no pack dimension", () => {
       "paneId",
       "paneLabel",
       "readableLines",
+      "revision",
       "session",
       "sessionName",
       "status",

--- a/bridge/state-engine.ts
+++ b/bridge/state-engine.ts
@@ -146,6 +146,7 @@ function toView(pane: MuxPane, kind: "agent" | "shell"): AgentView {
   // reads as a shell, and its transcript is still readable. Server-side only, like the ref itself.
   if (pane.sessionAgent) view.sessionAgent = pane.sessionAgent;
   if (pane.readableLines !== undefined) view.readableLines = pane.readableLines;
+  if (pane.revision !== undefined) view.revision = pane.revision;
   // A finished sentence for the operator, composed server-side and carried through untouched. It is
   // presentation: nothing in this engine reads it, and it never reaches `agent` or `status` above.
   if (pane.hint) view.hint = pane.hint;
@@ -186,6 +187,10 @@ export class StateEngine {
   // when a pane momentarily hides its input box (a dialog / working spinner) — only cleared when the
   // pane itself vanishes (see the removal loop). Enriched from pane text each poll (see enrichSessionNames).
   private readonly sessionNames = new Map<string, string>();
+  // Revision at which each pane was last enriched. When the multiplexer provides a revision on the
+  // snapshot (Herdr does; tmux/zellij don't) enrichSessionNames skips the readGrid RPC for any pane
+  // whose revision hasn't moved — turning O(claude_panes) socket calls per poll into O(changed).
+  private readonly enrichedAt = new Map<string, number>();
   private readonly transitionListeners = new Set<TransitionListener>();
   private readonly removeListeners = new Set<RemoveListener>();
   private readonly updateListeners = new Set<UpdateListener>();
@@ -407,6 +412,7 @@ export class StateEngine {
         if (live.has(id)) continue;
         this.prevStatus.delete(id);
         this.sessionNames.delete(id); // drop the cached name so a reused pane id starts clean
+        this.enrichedAt.delete(id);
         for (const fn of this.removeListeners) fn(id);
       }
 
@@ -470,6 +476,13 @@ export class StateEngine {
     if (claude.length === 0) return;
     await Promise.all(
       claude.map(async (a) => {
+        // When the multiplexer provides a content revision (Herdr does), skip the readGrid RPC for
+        // any pane whose screen hasn't changed since the last enrichment. A session with many idle
+        // claude panes drops from O(n) socket calls per poll to O(changed).
+        if (a.revision !== undefined) {
+          const prev = this.enrichedAt.get(a.paneId);
+          if (prev !== undefined && prev === a.revision) return;
+        }
         try {
           // `viewport` — never `recent`; see SESSION_NAME_READ_LINES for what a `recent` read does
           // to the operator's screen. The viewport is also strictly safer to parse: `recent` hands
@@ -484,6 +497,7 @@ export class StateEngine {
           if (!read.ok) return;
           const name = extractClaudeSessionName(read.value.text);
           if (name) this.sessionNames.set(a.paneId, name);
+          if (a.revision !== undefined) this.enrichedAt.set(a.paneId, a.revision);
         } catch {
           // Keep whatever's cached (if anything) — a transient read failure must not blank the name.
         }

--- a/bridge/types.ts
+++ b/bridge/types.ts
@@ -100,6 +100,11 @@ export interface AgentView {
    */
   hint?: string;
   /**
+   * Content revision from the multiplexer's snapshot. Changes when the pane's screen changes; absent
+   * on multiplexers that cannot provide it from their listing (tmux, zellij).
+   */
+  revision?: number;
+  /**
    * Epoch ms of this agent's last observed status transition (bridge/activity.ts). The only thing
    * that can make a pane read as unseen. Absent until the ledger has an entry, and on the very
    * first poll after a fresh install.


### PR DESCRIPTION
## Summary

- Propagates Herdr's per-pane content `revision` through `MuxPane` → `AgentView`
- `enrichSessionNames` now tracks the last-enriched revision per pane and skips the `readGrid` RPC when the revision hasn't changed
- Drops the per-poll cost from O(claude_panes) socket calls to O(changed_panes)

In a session with many idle/blocked/done agent panes, most panes have an unchanged revision between polls. Before this change, every poll issued a `readGrid` RPC for each Claude pane (one-shot socket connection per pane) to scrape the `/rename` session name. Now unchanged panes are skipped entirely.

### Changes

- **`bridge/mux/types.ts`** — Added optional `revision` to `MuxPane` (Herdr provides it natively; tmux/zellij can only derive it per-read)
- **`bridge/mux/herdr/adapter.ts`** — Propagates `WirePane.revision` through `toMuxPane`
- **`bridge/types.ts`** — Added `revision` to `AgentView` so it flows to the state engine
- **`bridge/state-engine.ts`** — `enrichedAt` map tracks per-pane revision; `enrichSessionNames` skips `readGrid` when unchanged; cleanup on pane removal
- **`bridge/solo-baseline.test.ts`** — Updated exhaustive key checks for the new field

## Test plan

- [x] `bun run typecheck` (root) passes
- [x] `cd web && bun run typecheck` passes
- [x] `bun test bridge/state-engine bridge/solo-baseline` — 92 tests pass
- [ ] Manual: verify session names still appear and update on `/rename` with a live Herdr session

🤖 Generated with [Claude Code](https://claude.com/claude-code)