### PR TITLE
chore(packaging): point the Arch and Nix recipes at 1.5.6

### DIFF
--- a/packaging/aur/.SRCINFO
+++ b/packaging/aur/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = collie-bin
 	pkgdesc = Phone web UI for the AI agents running in your terminal, served over Tailscale (official binary release)
-	pkgver = 1.5.5
+	pkgver = 1.5.6
 	pkgrel = 1
 	url = https://github.com/AltanS/collie
 	arch = x86_64
@@ -14,9 +14,9 @@ pkgbase = collie-bin
 	conflicts = collie
 	options = !strip
 	options = !debug
-	source_x86_64 = collie-bin-1.5.5-x86_64.tar.gz::https://github.com/AltanS/collie/releases/download/v1.5.5/collie-1.5.5-linux-x64.tar.gz
-	sha256sums_x86_64 = 16cd55c080a58f2fabc5bfecef6cf3f70ae66586a8ebf16cc208f90f0201f5d1
-	source_aarch64 = collie-bin-1.5.5-aarch64.tar.gz::https://github.com/AltanS/collie/releases/download/v1.5.5/collie-1.5.5-linux-arm64.tar.gz
-	sha256sums_aarch64 = a0e8638fd636e03807e09fe9fa434c8334b381c5b53e311b4f5cef225f8b5bb1
+	source_x86_64 = collie-bin-1.5.6-x86_64.tar.gz::https://github.com/AltanS/collie/releases/download/v1.5.6/collie-1.5.6-linux-x64.tar.gz
+	sha256sums_x86_64 = dc5b386684d07a6bdc67424d0e4e176481327a9cbc29492ffab0f801e0b5473b
+	source_aarch64 = collie-bin-1.5.6-aarch64.tar.gz::https://github.com/AltanS/collie/releases/download/v1.5.6/collie-1.5.6-linux-arm64.tar.gz
+	sha256sums_aarch64 = 9519d762ca232d637da0083da1af37c702ab215cbeabebd9ba317568c7325701
 
 pkgname = collie-bin

--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -11,7 +11,7 @@
 
 pkgname=collie-bin
 _pkgname=collie
-pkgver=1.5.5
+pkgver=1.5.6
 pkgrel=1
 pkgdesc="Phone web UI for the AI agents running in your terminal, served over Tailscale (official binary release)"
 arch=('x86_64' 'aarch64')
@@ -53,8 +53,8 @@ source_aarch64=("$pkgname-$pkgver-aarch64.tar.gz::$_baseurl/collie-$pkgver-linux
 # three lines — `pkgver` above and the two arrays below — are the only ones
 # `scripts/refresh-packages.ts` rewrites, and it copies them from that manifest. Nothing here
 # hashes a file itself.
-sha256sums_x86_64=('16cd55c080a58f2fabc5bfecef6cf3f70ae66586a8ebf16cc208f90f0201f5d1')
-sha256sums_aarch64=('a0e8638fd636e03807e09fe9fa434c8334b381c5b53e311b4f5cef225f8b5bb1')
+sha256sums_x86_64=('dc5b386684d07a6bdc67424d0e4e176481327a9cbc29492ffab0f801e0b5473b')
+sha256sums_aarch64=('9519d762ca232d637da0083da1af37c702ab215cbeabebd9ba317568c7325701')
 
 # The tarball's own directory name, which carries the upstream platform spelling rather than $CARCH.
 _distdir() {

--- a/packaging/nix/sources.json
+++ b/packaging/nix/sources.json
@@ -1,17 +1,17 @@
 {
-  "version": "1.5.5",
+  "version": "1.5.6",
   "platforms": {
     "linux-x64": {
-      "url": "https://github.com/AltanS/collie/releases/download/v1.5.5/collie-1.5.5-linux-x64.tar.gz",
-      "sha256": "16cd55c080a58f2fabc5bfecef6cf3f70ae66586a8ebf16cc208f90f0201f5d1"
+      "url": "https://github.com/AltanS/collie/releases/download/v1.5.6/collie-1.5.6-linux-x64.tar.gz",
+      "sha256": "dc5b386684d07a6bdc67424d0e4e176481327a9cbc29492ffab0f801e0b5473b"
     },
     "linux-arm64": {
-      "url": "https://github.com/AltanS/collie/releases/download/v1.5.5/collie-1.5.5-linux-arm64.tar.gz",
-      "sha256": "a0e8638fd636e03807e09fe9fa434c8334b381c5b53e311b4f5cef225f8b5bb1"
+      "url": "https://github.com/AltanS/collie/releases/download/v1.5.6/collie-1.5.6-linux-arm64.tar.gz",
+      "sha256": "9519d762ca232d637da0083da1af37c702ab215cbeabebd9ba317568c7325701"
     },
     "darwin-arm64": {
-      "url": "https://github.com/AltanS/collie/releases/download/v1.5.5/collie-1.5.5-macos-arm64.tar.gz",
-      "sha256": "04a0a9726ad88066426681c55d68b526845ad169c47274edb79034e690193d2c"
+      "url": "https://github.com/AltanS/collie/releases/download/v1.5.6/collie-1.5.6-macos-arm64.tar.gz",
+      "sha256": "ddae9a6636b31a2c12f13695de0f22c162294d55df7d6d9420f8777b61327575"
     }
   }
 }


### PR DESCRIPTION
Generated by the release workflow's refresh-packages job for v1.5.6: pkgver, sha256sums and packaging/nix/sources.json now name the 1.5.6 tarballs. The job could not open this pull request itself because the repository does not yet allow GitHub Actions to create pull requests.