### PR TITLE
perf(state): skip enrichSessionNames readGrid for unchanged panes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ PATH. Details and rollback: [`docs/upgrading.md`](./docs/upgrading.md) → *Upgr
 
 ## [Unreleased]
 
+- `enrichSessionNames` skips the `readGrid` RPC for panes whose content revision hasn't changed since the last enrichment, dropping the per-poll cost from O(claude_panes) socket calls to O(changed_panes) (#187)
+
 ## [1.5.6] - 2026-09-07
 
 - Collie carries its own package recipes: `packaging/aur` for Arch (`collie-bin`, not yet on the AUR) and `packages.<system>.collie` from this repository's flake for Nix. Both wrap the release tarball, neither builds anything, and neither updates itself, because the package manager owns that folder. ([bb46def](https://github.com/AltanS/collie/commit/bb46def), [43a23a2](https://github.com/AltanS/collie/commit/43a23a2))

--- a/bridge/mux/herdr/adapter.ts
+++ b/bridge/mux/herdr/adapter.ts
@@ -522,6 +522,7 @@ function toMuxPane(
   // Scrollback depth + viewport = what a `recent` read can yield. Omitted when the server predates
   // `scroll`, so an older Herdr reads as "unknown" rather than "zero".
   if (raw.scroll) pane.readableLines = raw.scroll.max_offset_from_bottom + raw.scroll.viewport_rows;
+  pane.revision = raw.revision;
   return pane;
 }
 

--- a/bridge/mux/types.ts
+++ b/bridge/mux/types.ts
@@ -236,6 +236,12 @@ export interface MuxPane extends MuxIdentity {
    * capability, no grammar and no sort. See the module that composes it, beside the decorator.
    */
   readonly hint?: string;
+  /**
+   * Content revision from the multiplexer's snapshot — changes when the pane's screen changes.
+   * Herdr provides this natively; tmux and zellij can only derive it per-read, so it is absent
+   * from their snapshot and optional here.
+   */
+  readonly revision?: number;
 }
 
 /** One space — a project-scoped container of tabs. Collie's word; the port never uses another. */

--- a/bridge/state-engine.ts
+++ b/bridge/state-engine.ts
@@ -186,6 +186,9 @@ export class StateEngine {
   // when a pane momentarily hides its input box (a dialog / working spinner) — only cleared when the
   // pane itself vanishes (see the removal loop). Enriched from pane text each poll (see enrichSessionNames).
   private readonly sessionNames = new Map<string, string>();
+  // Revision at which each pane was last enriched. enrichSessionNames skips the readGrid RPC for
+  // any pane whose revision hasn't moved — O(claude_panes) socket calls per poll → O(changed).
+  private readonly enrichedAt = new Map<string, number>();
   private readonly transitionListeners = new Set<TransitionListener>();
   private readonly removeListeners = new Set<RemoveListener>();
   private readonly updateListeners = new Set<UpdateListener>();
@@ -407,12 +410,18 @@ export class StateEngine {
         if (live.has(id)) continue;
         this.prevStatus.delete(id);
         this.sessionNames.delete(id); // drop the cached name so a reused pane id starts clean
+        this.enrichedAt.delete(id);
         for (const fn of this.removeListeners) fn(id);
       }
 
       // Enrich claude panes with their own `/rename` session name (read from pane text). Best-effort:
-      // a failed read keeps the last-known name and never fails the poll.
-      await this.enrichSessionNames(agents);
+      // a failed read keeps the last-known name and never fails the poll. The revision map lets
+      // unchanged panes skip the readGrid RPC entirely.
+      const revisions = new Map<string, number>();
+      for (const p of panes) {
+        if (p.revision !== undefined) revisions.set(p.paneId, p.revision);
+      }
+      await this.enrichSessionNames(agents, revisions);
 
       this.agents = agents;
       this.shellPanes = shellPanes;
@@ -465,11 +474,19 @@ export class StateEngine {
    * multiplexer that cannot hand over a rendered grid declines the read, which reads here as
    * "keep whatever's cached" — exactly like a read that failed.
    */
-  private async enrichSessionNames(agents: AgentView[]): Promise<void> {
+  private async enrichSessionNames(
+    agents: AgentView[],
+    revisions: Map<string, number>,
+  ): Promise<void> {
     const claude = agents.filter((a) => a.agent === "claude");
     if (claude.length === 0) return;
     await Promise.all(
       claude.map(async (a) => {
+        const rev = revisions.get(a.paneId);
+        if (rev !== undefined) {
+          const prev = this.enrichedAt.get(a.paneId);
+          if (prev !== undefined && prev === rev) return;
+        }
         try {
           // `viewport` — never `recent`; see SESSION_NAME_READ_LINES for what a `recent` read does
           // to the operator's screen. The viewport is also strictly safer to parse: `recent` hands
@@ -484,6 +501,7 @@ export class StateEngine {
           if (!read.ok) return;
           const name = extractClaudeSessionName(read.value.text);
           if (name) this.sessionNames.set(a.paneId, name);
+          if (rev !== undefined) this.enrichedAt.set(a.paneId, rev);
         } catch {
           // Keep whatever's cached (if anything) — a transient read failure must not blank the name.
         }


### PR DESCRIPTION
## Summary

Re-applies #187 against the current mux-port structure on main. The original PR was based on an old fork that predated the mux abstraction layer and could not be cleanly rebased.

- Adds optional `revision` to `MuxPane` — Herdr provides it natively; tmux/zellij leave it absent
- The Herdr adapter propagates `WirePane.revision` through `toMuxPane`
- `enrichSessionNames` builds a revision map from the snapshot and tracks the last-enriched revision per pane, skipping the `readGrid` RPC when unchanged
- Drops the per-poll cost from O(claude_panes) socket calls to O(changed_panes)

In a session with many idle/blocked/done agent panes, most panes have an unchanged revision between polls. Before this change, every poll issued a `readGrid` RPC for each Claude pane (one-shot socket connection per pane) to scrape the `/rename` session name. Now unchanged panes are skipped entirely.

Supersedes #187.

## Test plan

- [x] `bun run typecheck` (root) passes
- [x] `cd web && bun run typecheck` passes
- [x] `bun run lint` passes
- [x] `bun test bridge/state-engine bridge/solo-baseline` — 92 tests pass
- [x] Full `bun run test` (bridge + scripts) passes
- [ ] Manual: verify session names still appear and update on `/rename` with a live Herdr session

🤖 Generated with [Claude Code](https://claude.com/claude-code)