### PR TITLE
fix: recognize a binary install's bridge across a version-flip restart

### DIFF
--- a/cli/lifecycle.test.ts
+++ b/cli/lifecycle.test.ts
@@ -198,6 +198,19 @@ describe("the pidfile guard", () => {
     expect(isOurBridge(`${BINARY} status`, BINARY)).toBe(false);
   });
 
+  test("recognises a binary install's bridge across a version flip, but not a stranger install", () => {
+    const OLD = "/home/pat/.local/share/collie/versions/1.5.6/bin/collie";
+    const NEW = "/home/pat/.local/share/collie/versions/1.6.0/bin/collie";
+    // The post-flip restart runs as NEW (`ctx.root` resolves through `process.execPath`), and must
+    // still recognise the OLD version's bridge as its own to stop it — the one case a self-update
+    // wedges forever in if this predicate cannot see past the version directory.
+    expect(isOurBridge(`${OLD} _exec-bridge`, NEW)).toBe(true);
+    expect(isOurBridge(`${NEW} _exec-bridge`, OLD)).toBe(true);
+    // A different install entirely — same version string, different root — is still refused.
+    const STRANGER = "/home/pat/.local/share/collie-other/versions/1.6.0/bin/collie";
+    expect(isOurBridge(`${STRANGER} _exec-bridge`, NEW)).toBe(false);
+  });
+
   test("kills the pid only when it is still our bridge, and always drops the record", () => {
     const h = harness({
       files: { [`${CONFIG}/collie.pid`]: "4242\n" },

--- a/cli/lifecycle.ts
+++ b/cli/lifecycle.ts
@@ -132,6 +132,18 @@ export const logFilePath = (configDir: string, instance: string | null = null): 
 // ── The pidfile guard ────────────────────────────────────────────────────────
 
 /**
+ * A binary install's own path names the version directory it runs from
+ * (`<installRoot>/versions/<version>/bin/collie`), and that segment is exactly what a restart
+ * changes: `pluginRoot()` resolves `ctx.root` from `process.execPath`, so the process carrying out
+ * a post-flip restart names ITS OWN (new) version, never the prior one it needs to recognise as its
+ * own bridge in order to stop it. Collapsing the version segment answers "same install" without
+ * caring which version either side is — a checkout's binary has no such segment and is untouched.
+ */
+function collapseVersionDir(path: string): string {
+  return path.replace(/\/versions\/[^/\s]+\//, "/");
+}
+
+/**
  * Is `commandLine` one of our own bridges? The pidfile outlives its process (SIGKILL, a panic, a
  * reboot) and pids get recycled, so a kill has to be justified by the process table — and this also
  * runs on `start`, where a wrong guess kills a bystander (the pre-shim collie-ctl.sh).
@@ -139,6 +151,13 @@ export const logFilePath = (configDir: string, instance: string | null = null): 
  * The shell matched `bridge/index.ts`, the tail of its `ExecStart`. That string does not appear in
  * the compiled binary's command line, so the predicate moves in lockstep with `ExecStart`: the
  * program we launch, plus the role argument that distinguishes the daemon from a CLI invocation.
+ *
+ * The comparison runs on both sides with their version directory collapsed (see
+ * {@link collapseVersionDir}), so a binary install's post-flip restart recognises the bridge it is
+ * about to replace even though that bridge names a different version than this process does — the
+ * one case `process.execPath`-derived paths never agree on, and a self-update wedges forever if this
+ * predicate cannot see past it. Everything outside that one segment still has to match exactly, so a
+ * bystander under a different install root is refused exactly as before.
  *
  * And, since two instances can run out of ONE checkout, plus the instance marker `bridgeCommand`
  * puts there. It is checked in both directions: a suffixed instance demands its own `--instance
@@ -150,7 +169,12 @@ export function isOurBridge(
   binary: string,
   instance: string | null = null,
 ): boolean {
-  if (!commandLine.includes(binary) || !commandLine.includes("_exec-bridge")) return false;
+  if (
+    !collapseVersionDir(commandLine).includes(collapseVersionDir(binary)) ||
+    !commandLine.includes("_exec-bridge")
+  ) {
+    return false;
+  }
   return instance === null
     ? !/--instance(\s|=)/.test(commandLine)
     : new RegExp(`--instance(\\s+|=)${instance}(\\s|$)`).test(commandLine);


### PR DESCRIPTION
## Summary

- `isOurBridge()` (`cli/lifecycle.ts`) only kills the pidfile's recorded process when its command
  line literally contains **this process's own** binary path. For a `versions/<version>` binary
  install, `ctx.root` resolves from `process.execPath` (`bridge/root.ts`'s `pluginRoot()`), so the
  restart that runs right after a version flip resolves to the *new* version's own path.
- That means it can never recognize the bridge it just flipped away from — which still answers
  with the *old* version's path — so the kill is silently skipped every single time a binary
  install updates across versions.
- The prior bridge keeps the port. The freshly-spawned replacement hangs on its own startup
  handshake (in the repro, on its Herdr socket connection — `state: S`, one open non-TCP fd, never
  reaches the point of binding the HTTP port) and never binds. The health check keeps talking to
  the untouched old process, sees the wrong version, and rolls back — leaving yet another orphaned
  process behind on every attempt. Confirmed live: `ss -tlnp` showed the exact same pid holding
  `:8787` across an entire staging→verifying→rollback cycle, while every newly spawned process for
  that cycle never appeared in the listener table at all.
- Fix: `isOurBridge` now compares both sides with their `versions/<ver>` path segment collapsed, so
  a binary install recognizes its own bridge regardless of which version either side names — while
  a genuinely different install (different root, coincidentally matching version string) is still
  refused exactly as before. Checkout installs have no such segment and are byte-for-byte
  unaffected.

## Suggested CHANGELOG line

### Fixed

- **A binary install's restart now recognizes its own bridge across a version flip.** `isOurBridge` matched a pidfile's process against the exact version currently executing, so it could never recognize the prior version's bridge it just flipped away from — the kill was silently skipped on every update, the old process kept the port, and the freshly-spawned replacement hung on its own startup handshake and never came up, so the health check kept finding the untouched original and rolling back forever. Thanks @chernesk (#195).

## Test plan

- [x] `bun run lint` — clean
- [x] `bun run typecheck` (root) and `cd web && bun run typecheck` — clean
- [x] `bun run test` (root) — full suite passes (2776 + 1308 + 74 unit tests, plus every shell
      integration suite), including `collie CLI lifecycle`
- [x] Added a regression test in `cli/lifecycle.test.ts` proving `isOurBridge` recognizes a prior
      version's bridge under the same install root, and still refuses a same-version process under
      a *different* install root (the safety property the version-specific check existed to
      protect) — confirmed it fails against the old code and passes with the fix
- [x] Root-caused against a live reproduction: `ps aux`, `ss -tlnp`, and `/proc/<pid>/fd` output
      across a real stuck update on a binary install in a container, not just inferred from reading
      the code

🤖 Generated with [Claude Code](https://claude.com/claude-code)