### PR TITLE
fix(codex): recognize wrapped question cards

### DIFF
--- a/web/src/lib/harness/codex/ASK_NOTES.md
+++ b/web/src/lib/harness/codex/ASK_NOTES.md
@@ -35,3 +35,18 @@ required: `Question X/Y (N unanswered)` header, a non-empty question line, conse
 pointer rows, and the notes footer. The NOTES-FOCUSED state refuses to raw (footer
 `tab or esc to clear notes`, or a `› Add notes` row): a digit there would type into the box.
 Typing notes from the phone is deliberately not offered — it has no probed recipe.
+
+## Wrapped cards (2026-09-10, Codex 0.153.4)
+
+A read-only inspection found cards with wrapped questions and descriptions. One footer put
+`esc to interrupt` on its own final row. The released detector returned null for that card.
+
+`ask.test.ts` applies those layout changes to the public fruit capture through
+`parseAnsi → splitLines`. These are synthetic variants, not new byte-faithful captures.
+The parser joins question and description rows, keeps the original rows in its signature,
+and accepts the standalone interrupt hint only directly below the submit footer.
+A continuation must belong to an existing description and start at or beyond its column.
+Wrapped labels, incomplete options, notes mode, and output after the footer stay raw.
+
+The digit recipe above is unchanged. No keys were sent to the observed work session.
+Maintainer live-verification on a wrapped card is still needed before merge.

--- a/web/src/lib/harness/codex/ask.test.ts
+++ b/web/src/lib/harness/codex/ask.test.ts
@@ -1,0 +1,62 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { parseAnsi } from "../../ansi";
+import { splitLines } from "../../blocks";
+import { codexAdapter } from "./index";
+import { detectAskRegion } from "./ask";
+import { lineText } from "./markers";
+
+const fruit = readFileSync(join(import.meta.dirname, "../../../fixtures/panes/codex--ask-fruit.txt"), "utf8");
+const linesOf = (text: string) => splitLines(parseAnsi(text));
+
+// Layout-only variants of the public capture, not new live captures.
+describe("wrapped Codex questions", () => {
+  it.each(["question", "description", "footer", "all"])("lifts a wrapped %s", (part) => {
+    let screen = fruit;
+    if (part === "question" || part === "all") screen = screen.replaceAll("Pick a fruit?", "Pick a\n  fruit?");
+    if (part === "description" || part === "all") {
+      screen = screen.replace("Choose a soft, juicy pear.", "Choose a soft,\n                                              juicy pear.");
+    }
+    if (part === "footer" || part === "all") screen = screen.replace(" | esc to interrupt", "\n  esc to interrupt");
+    const lines = linesOf(screen);
+    const ask = detectAskRegion(lines);
+    expect(ask?.model.question).toBe("Pick a fruit?");
+    expect(ask?.model.options.map((o) => o.keys)).toEqual([["1"], ["2"], ["3"]]);
+    expect(ask?.model.options[1]?.description).toBe("Choose a soft, juicy pear.");
+    const prompt = codexAdapter.buildBlocks(lines).find((b) => b.kind === "prompt-select");
+    expect(prompt?.lines.map(lineText).join("\n")).toContain("1. Apple");
+    expect(codexAdapter.composerReady!(lines)).toBe(false);
+    expect(detectAskRegion(linesOf(screen + "\nnew output"))).toBeNull();
+    if (part === "all") {
+      const changed = detectAskRegion(linesOf(screen.replace("juicy pear", "green pear")));
+      expect(changed?.model.signature).not.toBe(ask?.model.signature);
+    }
+  });
+
+  it.each(["        unexpected row", "                                              10. Another option", "  › Add notes", ""])(
+    "refuses an invalid option continuation: %j", (row) => {
+      const screen = [
+        "  Question 1/1 (1 unanswered)", "  Pick?", "",
+        "  › 1. A  First description", row, "    2. B  Second description", "",
+        "  tab to add notes | enter to submit answer", "  esc to interrupt",
+      ].join("\n");
+      expect(detectAskRegion(linesOf(screen))).toBeNull();
+    },
+  );
+
+  it("refuses continuations without a description", () => {
+    const screen = [
+      "  Question 1/1 (1 unanswered)", "  Pick?", "",
+      "  › 1. A", "              continuation", "    2. B", "",
+      "  tab to add notes | enter to submit answer", "  esc to interrupt",
+    ].join("\n");
+    expect(detectAskRegion(linesOf(screen))).toBeNull();
+  });
+
+  it("refuses notes mode with a wrapped footer", () => {
+    const notes = readFileSync(join(import.meta.dirname, "../../../fixtures/panes/codex--ask-notes-focused.txt"), "utf8")
+      .replace(" | esc to interrupt", "\n  esc to interrupt");
+    expect(detectAskRegion(linesOf(notes))).toBeNull();
+  });
+});

--- a/web/src/lib/harness/codex/ask.ts
+++ b/web/src/lib/harness/codex/ask.ts
@@ -30,48 +30,67 @@ const OPTION = /^(?:\s{2}› |\s{4})([1-9])\. (.+)$/;
 /** request_user_input card at the tail, or null. */
 export function detectAskRegion(lines: StyledLine[]): AskRegion | null {
   const texts = lines.map((l) => rstrip(lineText(l)));
-  const fi = lastNonBlankIndex(texts);
+  const end = lastNonBlankIndex(texts);
+  let fi = end;
+  if (/^\s*esc to interrupt$/.test(texts[fi] ?? "")) fi--;
   if (fi < 0) return null;
   // The notes-focused state is explicitly refused rather than merely unrecognized, so the
   // refusal survives layout drift in the rows above.
   if (NOTES_FOOTER.test(texts[fi]!)) return null;
   if (!FOOTER.test(texts[fi]!)) return null;
 
-  // One blank row separates the footer from the option run; the options are contiguous.
+  // One blank row separates the footer from the option run. Descriptions may wrap.
   const bottom = skipBlanksUp(texts, fi - 1);
   if (bottom < 0) return null;
   if (NOTES_BOX.test(texts[bottom]!)) return null;
 
   const options: PromptOption[] = [];
+  let continuation: string[] = [];
   let i = bottom;
   for (; i >= 0; i--) {
     const t = texts[i]!;
     if (NOTES_BOX.test(t)) return null;
     const opt = OPTION.exec(t);
-    if (opt === null) break;
+    if (opt === null) {
+      if (/^ {6,}\S/.test(t) && !/^\s*\d+\./.test(t)) {
+        continuation.unshift(t);
+        continue;
+      }
+      break;
+    }
     const raw = opt[2]!.trim();
     const split = raw.split(/\s{2,}/);
     const label = (split[0] ?? raw).trim();
     const description = split.slice(1).join(" ").trim();
     const option: PromptOption = { label, keys: [opt[1]!] };
-    if (description !== "") option.description = description;
+    if (continuation.length > 0) {
+      // Only description rows may continue. A label-only option stays raw when it wraps.
+      const separator = /\s{2,}/.exec(raw);
+      if (separator === null) return null;
+      const descriptionColumn = t.indexOf(raw) + separator.index + separator[0].length;
+      if (description === "" || continuation.some((row) => row.search(/\S/) < descriptionColumn)) {
+        return null;
+      }
+      option.description = [description, ...continuation.map((row) => row.trim())].join(" ");
+      continuation = [];
+    } else if (description !== "") option.description = description;
     options.unshift(option);
   }
-  if (options.length < 2) return null;
+  if (continuation.length > 0 || options.length < 2) return null;
   for (let k = 0; k < options.length; k++) {
     if (options[k]!.keys[0] !== String(k + 1)) return null;
   }
 
-  // Above the options (across one blank row): the question line, with the Question X/Y header
-  // directly above it. Both are required — they are what separates this card from any other
-  // pointer-numbered list.
-  const questionRow = skipBlanksUp(texts, i);
-  if (questionRow < 1) return null;
-  const question = texts[questionRow]!.trim();
-  if (question === "" || !HEADER.test(texts[questionRow - 1]!)) return null;
-
-  const start = bottom - options.length + 1;
-  const signature = regionSignature(lines, questionRow - 1, fi + 1);
+  const start = i + 1;
+  const questionEnd = skipBlanksUp(texts, i);
+  let header = questionEnd;
+  while (header >= 0 && /^ {2}\S/.test(texts[header]!) && !HEADER.test(texts[header]!)) {
+    if (NOTES_BOX.test(texts[header]!)) return null;
+    header--;
+  }
+  if (header < 0 || !HEADER.test(texts[header]!) || header === questionEnd) return null;
+  const question = texts.slice(header + 1, questionEnd + 1).map((row) => row.trim()).join(" ");
+  const signature = regionSignature(lines, header, end + 1);
   if (signature === "") return null;
 
   return {


### PR DESCRIPTION
Codex questions lose their buttons in Collie when the question or description wraps, or `esc to interrupt` gets its own row. I saw this with Codex 0.153.4 and Collie 1.8.0, with Raw terminal off.

This fixes those three shapes in the question parser. It joins wrapped question and description text and keeps the original rows in the tap signature. The digit keys stay the same. Notes mode, incomplete options, and output below the footer still fall back to the terminal.

The tests modify the existing public fruit capture. All four wrapping cases fail against the old parser and pass with this change. These are synthetic variants of that capture, not new live captures.

Checks:

- Both typechecks, full lint, and version consistency pass.
- Web suite: 5,540 pass, 30 todo, including adapter conformance.
- CLI/script tests: 1,486 pass.
- Bridge tests excluding the crew harness: 3,001 pass, one failure in unchanged `bridge/journal/pi.test.ts`. It compares `/var/...` with `/private/var/...` on macOS.
- The full backend run stalled in the crew TLS tests on Bun 1.3.10. I stopped it and ran the other groups separately.

Leaving this as a draft for maintainer live-verification on a wrapped card. I did not send keys to the work session used for the read-only diagnosis. No version or CHANGELOG files changed.
