### PR TITLE
fix(web): opaque status bar on iOS

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -26,9 +26,11 @@
     />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="mobile-web-app-capable" content="yes" />
+    <!-- Not `black-translucent`: iOS 27 blurs the top edge of a translucent one, into the header.
+         iOS reads this once, at Add to Home Screen, so a change needs a re-add to show. -->
     <meta
       name="apple-mobile-web-app-status-bar-style"
-      content="black-translucent"
+      content="default"
     />
     <meta name="apple-mobile-web-app-title" content="Collie" />
     <title>Collie</title>


### PR DESCRIPTION
iOS 27 draws a progressive blur over the top edge of a Home Screen web app whose status bar style is `black-translucent`. It runs past the safe-area inset and into the header, so the Collie mark and the eyebrow render smeared.

Sets `apple-mobile-web-app-status-bar-style` to `default`, which removes the blur. The sticky header and the body already paint `--background`, and iOS 26 and later colour the status bar from that, so the bar matches the page in both themes. On older iOS the bar is the system's own above the page.

iOS reads the value once, when you add the app to the Home Screen. An existing install stays blurred until you remove it and add it again.

Verified on an iPhone running iOS 27, before and after:

![Before: the mark and the COLLIE eyebrow blurred under the status bar](https://github.com/user-attachments/assets/deb3f4f9-5c6a-4bae-8036-0884bf1a17d2)

![After: the header renders sharp](https://github.com/user-attachments/assets/a12fc580-be21-4549-8e8e-37143a0b0397)

Source: [r/PWA: iOS 27 beta blurs the top edge of installed PWAs](https://www.reddit.com/r/PWA/comments/1w5mqj1/ios_27_beta_blurs_the_top_edge_of_installed_pwas/)

CHANGELOG line, under Fixed:

**The top of the app is no longer blurred on iOS 27.** iOS 27 blurs the top edge of a Home Screen web app whose status bar is translucent, into the header. The status bar is opaque now; the header already paints the page colour under it, and iOS 26 and later colour the bar from that. iOS fixes the style when you add the app to the Home Screen, so an install made before this change stays blurred until you remove it and add it again.
