### PR TITLE
fix(web): skip light omp fills on the inverted mobile mirror

### DIFF
--- a/web/src/components/agent-chat.tsx
+++ b/web/src/components/agent-chat.tsx
@@ -34,7 +34,7 @@ import { Collapse, CollapseSwap } from "@/components/ui/collapse";
 import { RouteHeader } from "@/components/app-header";
 import { HeaderStatus } from "@/components/header-status";
 import { AnsiOutput } from "@/components/ansi-output";
-import { MIRROR_SPACE, MIRROR_INVERT, styleFor } from "@/components/mirror-space";
+import { MIRROR_SPACE, MIRROR_INVERT, segmentStyle } from "@/components/mirror-space";
 import { cn } from "@/lib/utils";
 import { paneTag } from "@/lib/pane-tag";
 import { parseAnsi } from "@/lib/ansi";
@@ -1871,7 +1871,11 @@ export function AgentChat({
                       {row.segments.map((s, si) => (
                         // Text nodes only — colour and weight come from the ANSI parse, never markup.
                         // Same XSS boundary as the mirror.
-                        <span key={si} style={styleFor(s)}>
+                        <span
+                          key={si}
+                          style={segmentStyle(s)}
+                          className={s.mobileTransparentBg ? "terminal-mobile-transparent-bg" : undefined}
+                        >
                           {s.text}
                         </span>
                       ))}

--- a/web/src/components/ansi-output.tsx
+++ b/web/src/components/ansi-output.tsx
@@ -1,8 +1,8 @@
 import { Fragment, memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
-import type { CSSProperties, ReactNode } from "react";
+import type { ReactNode } from "react";
 
 import { cn } from "@/lib/utils";
-import { parseAnsi, type AnsiSegment } from "@/lib/ansi";
+import { parseAnsi } from "@/lib/ansi";
 import { buildBlocks } from "@/lib/harness";
 import {
   dropLeadingLines,
@@ -26,7 +26,7 @@ import {
 } from "@/lib/mirror-images";
 import { t } from "@/lib/i18n";
 import { useLocale } from "@/hooks/use-locale";
-import { MIRROR_SPACE, MIRROR_INVERT, styleFor } from "@/components/mirror-space";
+import { MIRROR_SPACE, MIRROR_INVERT, segmentStyle } from "@/components/mirror-space";
 import { findMatches, splitSegment, type FindMatch } from "@/lib/find";
 import { findLinks } from "@/lib/links";
 import { PromptSelectBlock, type PromptBlockAction } from "@/components/prompt-select-block";
@@ -160,20 +160,7 @@ const NO_BLOCK_RUNS: readonly (readonly TableRun[])[] = Object.freeze([]);
 const LINK_CLASS =
   "underline decoration-1 underline-offset-2 break-all cursor-pointer py-[0.35em]";
 
-// A segment marked `mobileTransparentBg` hands its ANSI fill to a custom property instead of the
-// inline `background-color`, and `.terminal-mobile-transparent-bg` in index.css paints it: on a
-// desktop from the property, on a phone not at all. Inline styles beat a class, so the alternative
-// spelling is `!important` in the stylesheet. Every other segment takes the plain inline style, and
-// the other mirror surface (the statusline strip) calls styleFor directly and is unaffected.
-function segmentStyle(s: AnsiSegment): CSSProperties {
-  const style = styleFor(s);
-  if (!s.mobileTransparentBg) return style;
-  const { backgroundColor, ...rest } = style;
-  // SAFETY: a CSS custom property is a valid style key at runtime; React passes any `--*` key
-  // straight to the CSSOM. CSSProperties has no index signature for it, so the cast is the only
-  // spelling. The value is the backgroundColor just removed from the same object.
-  return { ...rest, "--terminal-seg-bg": backgroundColor } as CSSProperties;
-}
+
 
 function preClass(wrap: boolean, className?: string): string {
   return cn(

--- a/web/src/components/mirror-space.ts
+++ b/web/src/components/mirror-space.ts
@@ -40,3 +40,14 @@ export const MIRROR_INVERT = "[filter:invert(1)_hue-rotate(180deg)] dark:[filter
 export function styleFor(s: AnsiSegment): CSSProperties {
   return s.muted ? { ...s.style, color: "#a1a1a1", fontWeight: 400, opacity: 1 } : s.style;
 }
+
+/** Honor `mobileTransparentBg`: keep the fill in a custom property so phone CSS can drop it. */
+export function segmentStyle(s: AnsiSegment): CSSProperties {
+  const style = styleFor(s);
+  if (!s.mobileTransparentBg) return style;
+  const { backgroundColor, ...rest } = style;
+  // SAFETY: a CSS custom property is a valid style key at runtime; React passes any `--*` key
+  // straight to the CSSOM. CSSProperties has no index signature for it, so the cast is the only
+  // spelling. The value is the backgroundColor just removed from the same object.
+  return { ...rest, "--terminal-seg-bg": backgroundColor } as CSSProperties;
+}

--- a/web/src/lib/harness/omp.test.ts
+++ b/web/src/lib/harness/omp.test.ts
@@ -9,6 +9,7 @@ import { lineText, rstrip } from "./omp/markers";
 import { locateRuleComposer } from "./omp/rule";
 import { describeAdapterConformance } from "./conformance";
 import { parseKeyHintFooter } from "./menu-hints";
+import { decorateOmpDisplay } from "./omp/display";
 
 // The omp adapter's CI gate. This adapter is Tier 1 BY CHOICE — it up-levels nothing, so `ownFixtures`
 // is empty and every one of the 25 captures is a NEUTRAL fixture the adapter must leave raw. That is
@@ -360,3 +361,44 @@ function footerText(name: string, row: number): string {
   const boxed = BOXED_FOOTER.exec(text);
   return (boxed === null ? text : boxed[1]!).trim();
 }
+
+describe("omp mobile display cleanup", () => {
+  it("marks light fills and leaves dark diffs alone", () => {
+    const esc = String.fromCharCode(27);
+    const light = `${esc}[48;2;250;250;250mlight card${esc}[0m`;
+    const dark = `${esc}[48;2;15;18;22mdark body${esc}[0m`;
+    const diff = `${esc}[48;2;33;58;43m+ semantic diff${esc}[0m`;
+    const [lightLine, darkLine, diffLine] = decorateOmpDisplay(
+      splitLines(parseAnsi(`${light}\n${dark}\n${diff}`)),
+    );
+
+    expect(lightLine!.segments[0]!.mobileTransparentBg).toBe(true);
+    expect(darkLine!.segments[0]!.bg).toBe("rgb(15,18,22)");
+    expect(darkLine!.segments[0]!.mobileTransparentBg).toBeUndefined();
+    expect(diffLine!.segments[0]!.bg).toBe("rgb(33,58,43)");
+    expect(diffLine!.segments[0]!.mobileTransparentBg).toBeUndefined();
+  });
+
+  it("does not change visible text", () => {
+    const esc = String.fromCharCode(27);
+    const lines = splitLines(parseAnsi(`${esc}[48;2;250;250;250mcard${esc}[0m`));
+    expect(decorateOmpDisplay(lines).map(lineText)).toEqual(lines.map(lineText));
+  });
+
+  it("returns the same array when nothing is light", () => {
+    const lines = splitLines(parseAnsi("plain text"));
+    expect(decorateOmpDisplay(lines)).toBe(lines);
+  });
+
+  it("ompBuildBlocks marks the fill on the raw block", () => {
+    const esc = String.fromCharCode(27);
+    const [block] = ompAdapter.buildBlocks(
+      splitLines(parseAnsi(`${esc}[48;2;250;250;250mlight card${esc}[0m`)),
+    );
+    expect(block!.kind).toBe("raw");
+    if (block!.kind !== "raw") return;
+    expect(block.lines.some((line) => line.segments.some((segment) => segment.mobileTransparentBg))).toBe(
+      true,
+    );
+  });
+});

--- a/web/src/lib/harness/omp/display.ts
+++ b/web/src/lib/harness/omp/display.ts
@@ -1,0 +1,40 @@
+import type { StyledLine } from "../../blocks";
+
+// Light ANSI fills invert to black bars on a phone (dark-space mirror + CSS invert).
+// Dark fills — diffs, body chrome — stay. Rec. 709 luma on 0–255; 180 separates the two.
+const LIGHT_FILL_LUMA = 180;
+
+function luma(r: number, g: number, b: number): number {
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+
+function isLightFill(bg: string | undefined): boolean {
+  if (!bg) return false;
+  if (bg === "var(--ansi-15)" || bg === "var(--ansi-7)") return true;
+  const rgb = /^rgb\((\d+),(\d+),(\d+)\)$/.exec(bg);
+  if (rgb) return luma(+rgb[1], +rgb[2], +rgb[3]) >= LIGHT_FILL_LUMA;
+  const hex = /^#([0-9a-fA-F]{6})$/.exec(bg);
+  if (!hex) return false;
+  const n = parseInt(hex[1], 16);
+  return luma((n >> 16) & 255, (n >> 8) & 255, n & 255) >= LIGHT_FILL_LUMA;
+}
+
+/** Presentation-only pass over omp's raw lines: mark light fills for mobile transparency.
+ *  Not one byte of visible text changes. The input array is returned as-is when nothing matched. */
+export function decorateOmpDisplay(lines: StyledLine[]): StyledLine[] {
+  let changedLines = false;
+  const decorated = lines.map((line) => {
+    let changedSegments = false;
+    const segments = line.segments.map((segment) => {
+      if (!isLightFill(segment.bg) || segment.mobileTransparentBg) return segment;
+      changedSegments = true;
+      return { ...segment, mobileTransparentBg: true as const };
+    });
+
+    if (!changedSegments) return line;
+    changedLines = true;
+    return { ...line, segments };
+  });
+
+  return changedLines ? decorated : lines;
+}

--- a/web/src/lib/harness/omp/index.ts
+++ b/web/src/lib/harness/omp/index.ts
@@ -85,6 +85,7 @@ import {
   ruleComposerPrompt,
   stripRuleChrome,
 } from "./rule";
+import { decorateOmpDisplay } from "./display";
 
 /**
  * omp's block pipeline: one raw block with the composer chrome stripped off the tail. There is no
@@ -101,14 +102,15 @@ import {
  * Claude's `/model` picker is pinned against. `composerReady` already delivers the safety half.
  */
 export function ompBuildBlocks(lines: StyledLine[]): Block[] {
-  return [{ kind: "raw", lines: stripChrome(lines) }];
+  return [{ kind: "raw", lines: decorateOmpDisplay(stripChrome(lines)) }];
 }
 
 export function extractStatusLines(lines: StyledLine[]): StyledLine[] {
   const pi = locatePiComposer(lines);
-  if (pi) return lines.slice(pi.bottom + 1, pi.suggestEnd);
+  if (pi) return decorateOmpDisplay(lines.slice(pi.bottom + 1, pi.suggestEnd));
   const rule = locateRuleComposer(lines);
-  return rule === null ? extractBoxStatusLines(lines) : extractRuleStatusLines(lines, rule);
+  const status = rule === null ? extractBoxStatusLines(lines) : extractRuleStatusLines(lines, rule);
+  return decorateOmpDisplay(status);
 }
 
 export function extractInputDraft(lines: StyledLine[]): string | null {


### PR DESCRIPTION
## Summary

Light ANSI backgrounds on omp panes invert to black bars on a phone. This marks those fills with the existing `mobileTransparentBg` hint (same mechanism Codex uses). Dark diff colours are unchanged.

Detection is by luminance, not a theme palette.

Fork PR: no version bump.

## Validation

- `bun run typecheck` (root and web)
- `bun run lint`
- `cd web && bun run test src/lib/harness/omp.test.ts src/lib/harness/omp/chrome.test.ts`