### PR TITLE
fix(web): link a URL the terminal wrapped as the one URL it was

### DIFF
--- a/HERDR_API.md
+++ b/HERDR_API.md
@@ -55,6 +55,14 @@ the socket assumptions behind the design in [`ARCHITECTURE.md`](./ARCHITECTURE.m
     visible grid, and its renderer hard-wraps prose at the pane width — there are no soft-wrapped
     rows for the unwrap to merge. It only differs on scrollback-accumulating panes (shells: one
     probe measured 199 → 188 lines with logical lines up to 222 cols re-joined).
+  - **`recent_unwrapped` is how a wrapped URL gets repaired.** The mirror renders the grid, so a URL
+    longer than the pane arrives cut at the column edge and the client can only link the first
+    fragment — with a truncated href (`web/src/lib/links.ts`). The bridge asks for `recent_unwrapped`
+    when the grid it already has shows a URL touching a line end, strips the SGR and sends it as
+    `PaneReadResponse.logicalText`, which the client uses to give every fragment of that URL the href
+    of the whole URL. Same `lines` and same `ansi` format as the mirror read above, deliberately: the
+    observation that keeps this read from harvesting is the one the mirror read rests on too, and the
+    repair is only ever one extra read, on a pane that is showing the split.
   - **A `recent` text read can scroll the pane it reads.** Herdr's agent-automation docs state that
     for an idle, recognized agent at the bottom of its transcript, `recent` / `recent_unwrapped`
     reads "automatically use the agent's mouse-scroll interface" when `lines` asks for more than the

--- a/bridge/beacon/decorate.test.ts
+++ b/bridge/beacon/decorate.test.ts
@@ -5,7 +5,8 @@ import { withAgentHints } from "./hint.ts";
 import { fakeBeaconReader, FAKE_BEACON_NOW, type FakeBeacon } from "./fake.ts";
 import { BEACON_SCHEMA_VERSION, type BeaconMarker, type BeaconStatus } from "./types.ts";
 import { declareCapabilities, type MuxCapability } from "../mux/capabilities.ts";
-import {
+import {type MuxOutcome,
+  
   muxAck,
   muxGone,
   muxOk,
@@ -60,6 +61,9 @@ class StubAdapter implements MuxAdapter {
   readonly mux = "stub";
   /** The adapter's mark, when a case gives it one. Absent by default, like an adapter with none. */
   logo?: string;
+  /** The unwrapped pane read, when a case gives it one. Absent by default, like a multiplexer that
+   *  cannot unwrap at all (tmux) — the decorators must carry it without inventing it. */
+  readLogicalText?: (paneId: string, lines: number) => Promise<MuxOutcome<string>>;
   capabilities = declareCapabilities({
     supports: ["paneGrid", "typeText", "sendKeys"],
     notes: { agentDetection: "the adapter's own note", closePane: "untouched" },
@@ -255,6 +259,7 @@ describe("a decorator preserves the adapter's whole surface", () => {
     snapshot: true,
     refresh: true,
     readGrid: true,
+    readLogicalText: true,
     typeText: true,
     sendKeys: true,
     renamePane: true,
@@ -289,6 +294,7 @@ describe("a decorator preserves the adapter's whole surface", () => {
   function fullAdapter(): MuxAdapter {
     const stub = new StubAdapter();
     stub.logo = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"></svg>`;
+    stub.readLogicalText = (paneId, lines) => Promise.resolve(muxOk(`${paneId}:${lines}`));
     return stub;
   }
 
@@ -312,6 +318,13 @@ describe("a decorator preserves the adapter's whole surface", () => {
     const wrapped = withAgentHints(decorate(raw, []), { hooksInstalled: () => false });
     expect(surfaceOf(wrapped)).toEqual(CONTRACT);
     expect(wrapped.logo).toBe(raw.logo);
+  });
+
+  test("an adapter with no unwrapped read does not gain one from a decorator", () => {
+    // Optional, so `in` is the question that matters: a decorator that defined the key would make
+    // every multiplexer without the read look like it had one.
+    expect("readLogicalText" in decorate(new StubAdapter(), [])).toBe(false);
+    expect("readLogicalText" in withAgentHints(new StubAdapter(), { hooksInstalled: () => false })).toBe(false);
   });
 
   test("an adapter with no mark comes out with the KEY absent, through either decorator", () => {
@@ -363,6 +376,17 @@ describe("everything but capabilities and snapshot is a pass-through", () => {
       { method: "createSpace", args: [{ cwd: "/tmp" }] },
       { method: "watch", args: [watchOptions] },
     ]);
+  });
+
+  test("the unwrapped read passes through with its arguments, through either decorator", async () => {
+    const adapter = new StubAdapter();
+    adapter.readLogicalText = (paneId, lines) => Promise.resolve(muxOk(`${paneId}/${lines}`));
+    expect(await decorate(adapter, []).readLogicalText?.("%1", 20)).toEqual(
+      await adapter.readLogicalText("%1", 20),
+    );
+    expect(
+      await withAgentHints(adapter, { hooksInstalled: () => false }).readLogicalText?.("%1", 20),
+    ).toEqual(await adapter.readLogicalText("%1", 20));
   });
 
   test("a beacon changing synthesises no event — watch is the wrapped adapter's, untouched", () => {

--- a/bridge/beacon/decorate.ts
+++ b/bridge/beacon/decorate.ts
@@ -40,7 +40,13 @@ import { markersIn, readBeacons, type BeaconSweepDeps } from "./reader.ts";
 import type { BeaconReading, BeaconMarker, BeaconStatus } from "./types.ts";
 import type { AgentSessionRef } from "../journal/types.ts";
 import { declareCapabilities, MUX_CAPABILITIES, type MuxCapabilityDeclaration } from "../mux/capabilities.ts";
-import { muxDataFields, type MuxAdapter, type MuxPane, type MuxSnapshot } from "../mux/types.ts";
+import {
+  muxDataFields,
+  muxOptionalMethods,
+  type MuxAdapter,
+  type MuxPane,
+  type MuxSnapshot,
+} from "../mux/types.ts";
 import type { AgentStatus } from "../types.ts";
 
 /**
@@ -281,6 +287,7 @@ export function withAgentBeacons(
     // than listed here, so the next field added to the contract cannot go missing at this seam
     // (bridge/mux/types.ts § muxDataFields).
     ...muxDataFields(adapter),
+    ...muxOptionalMethods(adapter),
     mux: adapter.mux,
     // A getter, so `collie hooks install claude` reaches a RUNNING bridge: the declaration is read
     // per request (`muxConfigBody`), and the seam behind `hooksInstalled` is what decides how often

--- a/bridge/beacon/hint.ts
+++ b/bridge/beacon/hint.ts
@@ -24,7 +24,7 @@
 // it has.
 
 import { KNOWN_HARNESS_NAMES } from "../journal/registry.ts";
-import { muxDataFields } from "../mux/types.ts";
+import { muxDataFields, muxOptionalMethods } from "../mux/types.ts";
 import type {
   MuxAck,
   MuxAdapter,
@@ -139,6 +139,7 @@ export interface AgentHintDeps {
 export function withAgentHints(adapter: MuxAdapter, deps: AgentHintDeps): MuxAdapter {
   return {
     ...muxDataFields(adapter),
+    ...muxOptionalMethods(adapter),
     mux: adapter.mux,
     // A getter, because the wrapped declaration is itself one — the decorator re-reads the emitter's
     // install per request, and freezing the answer here would undo that.

--- a/bridge/mux/herdr/adapter.ts
+++ b/bridge/mux/herdr/adapter.ts
@@ -314,10 +314,27 @@ export class HerdrMux implements MuxAdapter {
     }
   }
 
+  /**
+   * The same scrollback with soft wraps undone (`recent_unwrapped`), for URL repair.
+   *
+   * Read in the same escape-carrying form as `readGrid` on purpose: `ansi` is the format whose read
+   * was never observed to harvest an alt-screen pane, which is the property that keeps the mirror
+   * from scrolling somebody's terminal (HERDR_API.md → `pane.read`). Callers strip the styling;
+   * this read exists only for the URLs in it. On an agent pane the unwrapped rows equal the wrapped
+   * ones — the bridge asks for this only when a URL is actually split.
+   */
+  async readLogicalText(paneId: string, lines: number): Promise<MuxOutcome<string>> {
+    try {
+      const read = await this.client.readPane(paneId, "recent_unwrapped", lines, "ansi");
+      return muxOk(read.text);
+    } catch (err) {
+      return transportRefusal(err);
+    }
+  }
+
   async typeText(paneId: string, text: string): Promise<MuxAck> {
     return this.attempt(() => this.client.sendPaneText(paneId, text));
   }
-
   /**
    * Keys in the contract's spelling, translated and applied in order.
    *

--- a/bridge/mux/types.ts
+++ b/bridge/mux/types.ts
@@ -567,6 +567,19 @@ export interface MuxAdapter {
   /** One pane's rendered screen. Needs `paneGrid`; `recent` past the viewport needs `gridScrollback`. */
   readGrid(paneId: string, request: MuxGridRequest): Promise<MuxOutcome<MuxGrid>>;
 
+  /**
+   * The same rows with soft wraps undone, plain text, when the multiplexer can produce them.
+   *
+   * The mirror renders the grid, so a URL longer than the pane arrives in fragments and the web app
+   * can only make an anchor out of the first one — a truncated href (`web/src/lib/links.ts`). This
+   * read is what says what the whole URL was. OPTIONAL by design: a multiplexer without it (or one
+   * whose panes never soft-wrap) simply yields no repair, exactly as today.
+   *
+   * Text, never styling: this is only ever read for the URLs in it, and `text` is also the format
+   * that cannot harvest an alt-screen pane (HERDR_API.md → `pane.read`).
+   */
+  readLogicalText?(paneId: string, lines: number): Promise<MuxOutcome<string>>;
+
   /** Type literal text into a pane, submitting nothing. Needs `typeText`. */
   typeText(paneId: string, text: string): Promise<MuxAck>;
 
@@ -669,4 +682,15 @@ export interface MuxAdapter {
  */
 export function muxDataFields(adapter: MuxAdapter): Pick<MuxAdapter, "logo"> {
   return adapter.logo === undefined ? {} : { logo: adapter.logo };
+}
+
+/**
+ * The OPTIONAL methods, gathered the way {@link muxDataFields} gathers the optional data fields.
+ *
+ * A decorator spreads this rather than conditionally spreading inline, so a multiplexer that cannot
+ * unwrap (tmux) never comes out of a decorator appearing to offer the read: absent stays absent.
+ */
+export function muxOptionalMethods(adapter: MuxAdapter): Pick<MuxAdapter, "readLogicalText"> {
+  const readLogicalText = adapter.readLogicalText?.bind(adapter);
+  return readLogicalText === undefined ? {} : { readLogicalText };
 }

--- a/bridge/server.test.ts
+++ b/bridge/server.test.ts
@@ -24,7 +24,9 @@ import {
   keysPane,
   launchersRoute,
   normalizeTabLabel,
+  hasSplitUrl,
   paneReadResponse,
+  readPane,
   parsePairRequest,
   parseSnoozeRequest,
   replyPane,
@@ -77,6 +79,7 @@ import {
   type Launcher,
   type LaunchersResponse,
   type MuxConfig,
+  type PaneReadResponse,
   type SnapshotResponse,
 } from "./types.ts";
 import type { StateEngine } from "./state-engine.ts";
@@ -2804,5 +2807,78 @@ describe("update status peers — the legs of a crew-wide run", () => {
     // A peers-only run starts no updater on this machine.
     const peersBranch = handler.slice(handler.indexOf('if (verdict.kind === "peers")'));
     expect(peersBranch.slice(0, peersBranch.indexOf("return json"))).not.toContain("action.start");
+  });
+});
+
+describe("hasSplitUrl — is a URL cut by the pane's column edge?", () => {
+  test("a URL running to the end of a row is a split", () => {
+    expect(
+      hasSplitUrl("$ gcloud auth login --no-launch-browser\n    https://accounts.google.com/o/oauth2/auth?client_id=1&scope=x"),
+    ).toBe(true);
+  });
+
+  test("Herdr's CR row terminator does not hide the split", () => {
+    // A row that ends `…&s\r` is the shape a real read hands over; without the CR the gate would
+    // never fire on the pane this exists for.
+    expect(hasSplitUrl("\u001b[36mhttps://a.dev/x?y=1\u001b[0m\r\nnext")).toBe(true);
+  });
+
+  test("styling does not hide the split, and a padded row still counts", () => {
+    expect(hasSplitUrl("\u001b[34mhttps://a.dev/x?y=1\u001b[0m")).toBe(true);
+    expect(hasSplitUrl("https://a.dev/x?y=1   ")).toBe(true);
+  });
+
+  test("a URL that ends with prose after it is not a split", () => {
+    expect(hasSplitUrl("open https://a.dev/x then")).toBe(false);
+    expect(hasSplitUrl("https://a.dev/x, and more")).toBe(false);
+  });
+
+  test("no URL at all is not a split", () => {
+    expect(hasSplitUrl("$ echo hello\nworld")).toBe(false);
+  });
+});
+
+describe("readPane — the logical read is asked for only when it can repair something", () => {
+  /** A pane read that answers with `grid`, and remembers whether the logical read was reached. */
+  function paneStub(grid: string, logical: string) {
+    let logicalReads = 0;
+    const stub: Partial<MuxAdapter> = {
+      mux: "herdr",
+      readGrid: (paneId: string) => Promise.resolve(muxOk({ paneId, text: grid, truncated: false, revision: 7 })),
+      readLogicalText: () => {
+        logicalReads += 1;
+        return Promise.resolve(muxOk(logical));
+      },
+    };
+    // SAFETY: `readPane` reaches `mux` for its error text and these two reads, all present above.
+    const adapter = stub as MuxAdapter;
+    return { adapter, reads: () => logicalReads };
+  }
+
+  const get = (paneId: string) =>
+    new Request(`http://x/api/pane/${encodeURIComponent(paneId)}`);
+  const url = new URL("http://x/api/pane/w1:p1");
+
+  test("a grid with no split URL is served from the grid alone", async () => {
+    const { adapter, reads } = paneStub("$ echo hi\nhi", "unused");
+    const res = await readPane(adapter, cfg(), "w1:p1", url, get("w1:p1"));
+    // SAFETY: the bridge's own JSON, served by the call above.
+    const body = (await res.json()) as PaneReadResponse;
+    expect(reads()).toBe(0);
+    expect(body.logicalText).toBeUndefined();
+    expect(body.text).toBe("$ echo hi\nhi");
+  });
+
+  test("a split URL brings the logical text in, with its styling stripped", async () => {
+    const grid = "run:\n\u001b[36mhttps://a.dev/auth?client=1&s\u001b[0m\ntate=y then";
+    const logical = "\u001b[36mrun:\nhttps://a.dev/auth?client=1&state=y then\u001b[0m";
+    const { adapter, reads } = paneStub(grid, logical);
+    const res = await readPane(adapter, cfg(), "w1:p1", url, get("w1:p1"));
+    // SAFETY: the bridge's own JSON, served by the call above.
+    const body = (await res.json()) as PaneReadResponse;
+    expect(reads()).toBe(1);
+    expect(body.logicalText).toBe("run:\nhttps://a.dev/auth?client=1&state=y then");
+    // The mirror keeps its own rows, styling and all — only the hrefs are repaired downstream.
+    expect(body.text).toBe(grid);
   });
 });

--- a/bridge/server.ts
+++ b/bridge/server.ts
@@ -1950,7 +1950,62 @@ export function startupWarnings(cfg: Config): string[] {
   return warnings;
 }
 
-async function readPane(
+/** ESC, as a code point: the lint keeps control characters out of regexes, so this is a string. */
+const ESC = "\u001b";
+
+/** CSI final byte — anything from `@` to `~` ends the sequence (ECMA-48 §5.4). */
+const isCsiFinal = (ch: string): boolean => ch >= "@" && ch <= "~";
+
+/**
+ * Drop the escape sequences Herdr's `ansi` read carries — colour and weight only, never cursor moves
+ * (see `MuxGrid`) — leaving the characters the operator sees.
+ *
+ * Written as a scan rather than a regex because a regex for this needs a control character in it,
+ * which this repo's lint forbids outright and which the web's own parser (`web/src/lib/ansi.ts`)
+ * also avoids: an escape is recognised by its code point.
+ */
+export function stripSgr(ansiText: string): string {
+  let visible = "";
+  for (let i = 0; i < ansiText.length; i++) {
+    // SAFETY: `i` is inside the string by the loop's own bound, so this is its character.
+    const ch = ansiText[i] as string;
+    if (ch !== ESC) {
+      visible += ch;
+      continue;
+    }
+    // `ESC [` opens a CSI; skip to its final byte. A lone ESC (or the text ending mid-sequence) is
+    // dropped: it paints nothing either way.
+    let j = i + 1;
+    if (ansiText[j] === "[") {
+      j += 1;
+      // SAFETY: guarded by the bound on `j` in the same condition.
+      while (j < ansiText.length && !isCsiFinal(ansiText[j] as string)) j += 1;
+    }
+    i = j;
+  }
+  return visible;
+}
+
+// A URL that runs to the end of its row, trailing blanks tolerated so a padded row cannot hide the
+// split. The character set is links.ts's stop-set, so the gate and the client's scanner agree on
+// where a URL ends.
+const SPLIT_URL_AT_END = /https?:\/\/[^\s<>"'`\\{}|^[\]]+[ \t]*\r?$/;
+
+/**
+ * Does this grid end a line with an http(s) URL — that is, did the pane's column edge cut one?
+ *
+ * The mirror's autolinker scans one line at a time (`web/src/lib/links.ts`), so a wrapped URL is
+ * only ever linked as its first fragment, with a truncated href. Spotting that shape here is what
+ * keeps the extra `recent_unwrapped` read off every other poll: it is asked for exactly when there
+ * is something to repair. A false positive costs one read and repairs nothing.
+ */
+export function hasSplitUrl(ansiText: string): boolean {
+  return stripSgr(ansiText)
+    .split("\n")
+    .some((line) => SPLIT_URL_AT_END.test(line));
+}
+
+export async function readPane(
   herdr: MuxAdapter,
   cfg: Config,
   paneId: string,
@@ -1971,7 +2026,16 @@ async function readPane(
     // to `strip` would move someone's screen on every revalidate — see the adapter's `readGrid`.
     const read = await herdr.readGrid(paneId, { scope: "recent", lines, styling: "preserve" });
     if (!read.ok) return text(`${herdr.mux} read failed: ${read.detail}`, 502);
-    const data = paneReadResponse(paneId, read.value);
+    // A URL the pane's column edge cut in two is the one thing the mirror cannot repair on its own,
+    // and the repair needs the same rows with soft wraps undone. Ask for them only when the grid
+    // shows such a URL — this is a second round trip, and a multiplexer without the source has
+    // nothing to give. Same `lines` and the same escape-carrying form as the grid read above, so a
+    // read that would move the operator's screen here is the one `readGrid` already refuses.
+    const logical =
+      herdr.readLogicalText !== undefined && hasSplitUrl(read.value.text)
+        ? await herdr.readLogicalText(paneId, lines)
+        : undefined;
+    const data = paneReadResponse(paneId, read.value, logical?.ok ? stripSgr(logical.value) : undefined);
     // ETag is derived from the serialised body — if content hasn't changed the client gets a 304
     // and skips the whole transfer (the big win on a cellular link).
     const bodyStr = JSON.stringify(data);
@@ -2005,8 +2069,17 @@ async function readPane(
  * (the client's prompt-select race guard depends on it) is covered by the bridge unit tests without
  * standing up Bun.serve / a socket.
  */
-export function paneReadResponse(paneId: string, read: MuxGrid): PaneReadResponse {
-  return { paneId, text: read.text, truncated: read.truncated, revision: read.revision };
+export function paneReadResponse(paneId: string, read: MuxGrid, logicalText?: string): PaneReadResponse {
+  const body: PaneReadResponse = {
+    paneId,
+    text: read.text,
+    truncated: read.truncated,
+    revision: read.revision,
+  };
+  // Absent, never empty, when there is nothing to repair: the ETag is computed over this body, so an
+  // always-present key would invalidate every client's cached copy once for no gain.
+  if (logicalText !== undefined) body.logicalText = logicalText;
+  return body;
 }
 
 /**

--- a/bridge/types.ts
+++ b/bridge/types.ts
@@ -563,6 +563,13 @@ export interface PaneReadResponse {
   truncated: boolean;
   /** Herdr's monotonic pane revision — passed through for the client's prompt-select race guard. */
   revision: number;
+  /**
+   * The same rows with soft wraps undone, present only when the grid shows a URL the pane's width
+   * cut in two (`hasSplitUrl`). The mirror keeps rendering `text`; the client uses this to give the
+   * fragments of one URL the href of the whole URL. ABSENT rather than empty when there is nothing
+   * to repair — the payload stays byte-identical to what it was for every other pane.
+   */
+  logicalText?: string;
 }
 
 /**

--- a/web/src/components/agent-chat.tsx
+++ b/web/src/components/agent-chat.tsx
@@ -96,6 +96,9 @@ interface AgentChatProps {
   tabLabel?: string;
   /** Pane output from the route loader (refreshed by polling/revalidation). */
   text: string;
+  /** The same rows with soft wraps undone, present only when {@link text} splits a URL — frozen
+   * alongside it so the autolinker never pairs a stale mirror with a fresh logical read. */
+  logicalText?: string;
   /** The scrollback window `text` was fetched with — tells a grown fetch from a stale in-flight poll. */
   requestedLines?: number;
   /** The pane's `revision` for `text` — the race guard checks a tapped menu against this. */
@@ -179,6 +182,7 @@ export function AgentChat({
   tabs,
   tabLabel,
   text,
+  logicalText,
   requestedLines = 0,
   revision = 0,
   device,
@@ -542,9 +546,9 @@ export function AgentChat({
   // we hold the text steady (no reflow / no re-pin) until you jump back to latest — so a long
   // message stays put long enough to read instead of sliding out of the rolling window.
   //
-  // The frozen snapshot is a {text, revision} PAIR captured at the same instant: the prompt-select
-  // race guard must check a tap against the revision of what the user is LOOKING AT. The live
-  // `revision` prop keeps advancing with background polls while the mirror is frozen — comparing
+  // The frozen snapshot is a {text, revision, logicalText} TRIPLE captured at the same instant: the
+  // prompt-select race guard must check a tap against the revision of what the user is LOOKING AT.
+  // The live `revision` prop keeps advancing with background polls while the mirror is frozen — comparing
   // against it would blind the guard to drift that happened before the freeze (live-vs-live always
   // matches). While following, the frozen pair IS the live pair by definition.
   const [following, setFollowing] = useState(true);
@@ -559,15 +563,15 @@ export function AgentChat({
   // Leaving the pane hands the flag back to its "nothing is open" value. Without this, closing a
   // pane you had scrolled up in would leave the poller believing nobody is following anything.
   useEffect(() => () => publishFollowing(true), []);
-  const [shown, setShown] = useState({ text, revision });
+  const [shown, setShown] = useState({ text, revision, logicalText });
   useEffect(() => {
     if (!following) return;
     // Functional update that returns the previous object when nothing changed keeps React's
     // Object.is bailout — no re-render per poll while the pane is quiet.
     setShown((prev) =>
-      prev.text === text && prev.revision === revision ? prev : { text, revision },
+      prev.text === text && prev.revision === revision ? prev : { text, revision, logicalText },
     );
-  }, [text, revision, following]);
+  }, [text, revision, logicalText, following]);
   const display = shown.text;
   const hasNew = !following && display !== text;
 
@@ -769,8 +773,8 @@ export function AgentChat({
       return;
     }
     pendingRestore.current = true;
-    setShown({ text, revision });
-  }, [requestedLines, text, revision, display]);
+    setShown({ text, revision, logicalText });
+  }, [requestedLines, text, revision, logicalText, display]);
   // After the enlarged display paints, keep the previously-visible content anchored (content grew at
   // the top, so push scrollTop down by the height delta).
   useLayoutEffect(() => {
@@ -1763,6 +1767,7 @@ export function AgentChat({
                   )}
                   <AnsiOutput
                     text={display}
+                    logicalText={shown.logicalText}
                     wrap={prefs.wrap}
                     fontSize={prefs.fontSize}
                     query={findOpen ? findQuery : ""}

--- a/web/src/components/ansi-output.test.tsx
+++ b/web/src/components/ansi-output.test.tsx
@@ -419,6 +419,31 @@ describe("clickable links in the mirror", () => {
     expect(anchors.map((a) => a.textContent).join("")).toBe("https://herdr.dev/docs");
   });
 
+  // The mirror renders the *grid*, so a URL longer than the pane arrives cut at the column edge: one
+  // anchor with a truncated href, and the rest of the URL as inert text. The logical read the bridge
+  // sends for exactly that case is what turns the fragments back into the one URL they were.
+  it("links every fragment of a wrapped URL to the whole URL, when the logical text is there", () => {
+    const pre = mirror({
+      text: "run this:\nhttps://a.dev/auth?client=1&s\ntate=y then\n",
+      logicalText: "run this:\nhttps://a.dev/auth?client=1&state=y then\n",
+    });
+    const anchors = [...pre.querySelectorAll("a")];
+    expect(anchors.map((a) => a.getAttribute("href"))).toEqual([
+      "https://a.dev/auth?client=1&state=y",
+      "https://a.dev/auth?client=1&state=y",
+    ]);
+    expect(anchors.map((a) => a.textContent).join("")).toBe("https://a.dev/auth?client=1&state=y");
+    // Faithfulness is not negotiable: the rows are still exactly what the terminal printed.
+    expect(pre.textContent).toBe("run this:\nhttps://a.dev/auth?client=1&s\ntate=y then\n");
+  });
+
+  it("keeps the fragment truncated when no logical text came with it", () => {
+    const pre = mirror({ text: "https://a.dev/auth?client=1&s\ntate=y then\n" });
+    expect([...pre.querySelectorAll("a")].map((a) => a.getAttribute("href"))).toEqual([
+      "https://a.dev/auth?client=1&s",
+    ]);
+  });
+
   // Find and links split the same coordinate space; the order they nest in is the easy thing to get
   // wrong, and getting it wrong drops one of them.
   it("still highlights a find match inside a link", () => {

--- a/web/src/components/ansi-output.tsx
+++ b/web/src/components/ansi-output.tsx
@@ -55,6 +55,10 @@ type AutoBlock = Extract<Block, { kind: "autocomplete" }>;
 
 export interface AnsiOutputProps {
   text: string;
+  /** The same rows with soft wraps undone, when the bridge sent them: the autolinker uses it to give
+   * the fragments of one wrapped URL the href of the whole URL. Absent for every pane that needs no
+   * repair, and then links behave exactly as they did. */
+  logicalText?: string;
   className?: string;
   /** true = wrap; the block breaks at the viewport width instead of scrolling horizontally. Default
    *  true — the mirror is mostly agent prose, and a phone shows far fewer columns than the desktop
@@ -286,6 +290,7 @@ const renderImageCluster = (
 
 export const AnsiOutput = memo(function AnsiOutput({
   text,
+  logicalText,
   className,
   wrap = true,
   fontSize = 11,
@@ -391,8 +396,9 @@ export const AnsiOutput = memo(function AnsiOutput({
   }, [haystack, query]);
 
   // Autolinked URLs, in the SAME offset space as find matches — both are ranges over `haystack`, so
-  // one running offset serves both splits. Recomputed only when the mirror text changes.
-  const links = useMemo(() => findLinks(haystack), [haystack]);
+  // one running offset serves both splits. Recomputed only when the mirror text changes. `logicalText`
+  // (when the bridge sent it) lets a URL the pane wrapped be linked as the single URL it was.
+  const links = useMemo(() => findLinks(haystack, logicalText), [haystack, logicalText]);
 
   useEffect(() => {
     onMatchCount?.(matches.length);

--- a/web/src/lib/links.test.ts
+++ b/web/src/lib/links.test.ts
@@ -67,3 +67,78 @@ describe("findLinks", () => {
     ]);
   });
 });
+
+describe("findLinks — a URL the terminal hard-wrapped", () => {
+  // What the mirror renders (the grid) and what the pane read with soft wraps undone holds, for
+  // the same output: a shell printed one URL longer than the pane, so the grid cut it in two.
+  const GRID = ["run this:", "https://a.dev/auth?client=1&scope=x&s", "tate=y&end then"].join("\n");
+  const LOGICAL = ["run this:", "https://a.dev/auth?client=1&scope=x&state=y&end then"].join("\n");
+  const WHOLE = "https://a.dev/auth?client=1&scope=x&state=y&end";
+
+  it("repairs the fragment's href and links the continuation, from the logical text", () => {
+    expect(findLinks(GRID, LOGICAL).map((l) => [GRID.slice(l.start, l.end), l.href])).toEqual([
+      ["https://a.dev/auth?client=1&scope=x&s", WHOLE],
+      ["tate=y&end", WHOLE],
+    ]);
+  });
+
+  it("is exactly today's behaviour without a logical text to check against", () => {
+    expect(findLinks(GRID).map((l) => l.href)).toEqual(["https://a.dev/auth?client=1&scope=x&s"]);
+  });
+
+  it("leaves the fragment alone when two logical URLs start with it", () => {
+    const grid = ["go https://a.dev/x", "tail"].join("\n");
+    const logical = ["go https://a.dev/x", "or https://a.dev/xy"].join("\n");
+    expect(findLinks(grid, logical).map((l) => l.href)).toEqual(["https://a.dev/x"]);
+  });
+
+  it("keeps a complete URL complete when the next line does not continue it", () => {
+    const grid = ["see https://a.dev/x", "next step"].join("\n");
+    const logical = ["see https://a.dev/x", "or https://a.dev/xyz"].join("\n");
+    expect(findLinks(grid, logical).map((l) => l.href)).toEqual(["https://a.dev/x"]);
+  });
+
+  it("stops at the last character the continuation really matches", () => {
+    const grid = ["https://a.dev/abc", "defZZZ"].join("\n");
+    const logical = ["https://a.dev/abcdef", "rest"].join("\n");
+    const href = "https://a.dev/abcdef";
+    expect(findLinks(grid, logical).map((l) => [grid.slice(l.start, l.end), l.href])).toEqual([
+      ["https://a.dev/abc", href],
+      ["def", href],
+    ]);
+  });
+
+  // Herdr hands the mirror rows terminated with CR, so a fragment that was cut by the column edge
+  // has the CR — not the LF — right after it. The repair has to see that as the end of the line.
+  it("repairs a split URL in rows terminated with CR, as the pane read hands them over", () => {
+    const grid = "https://a.dev/auth?client=1&s\r\ntate=y then\r\n";
+    const logical = "https://a.dev/auth?client=1&state=y then\r\n";
+    const href = "https://a.dev/auth?client=1&state=y";
+    expect(findLinks(grid, logical).map((l) => [grid.slice(l.start, l.end), l.href])).toEqual([
+      ["https://a.dev/auth?client=1&s", href],
+      ["tate=y", href],
+    ]);
+  });
+
+  it("links a URL that spans more than two rows as one tap target", () => {
+    const grid = ["https://a.dev/one-two", "-three-four", "-five end"].join("\n");
+    const logical = ["https://a.dev/one-two-three-four-five", "end"].join("\n");
+    const links = findLinks(grid, logical);
+    expect(links.map((l) => l.href)).toEqual(Array(3).fill("https://a.dev/one-two-three-four-five"));
+    expect(links.map((l) => grid.slice(l.start, l.end)).join("")).toBe("https://a.dev/one-two-three-four-five");
+  });
+});
+
+describe("findLinks — a URL the pane shows twice", () => {
+  it("adopts the whole URL when the same URL appears more than once in the logical text", () => {
+    // A typed command and its output both carry the URL — that is one URL to adopt, not a tie.
+    const grid = ["echo https://a.dev/auth?client=1&s", "tate=y", "https://a.dev/auth?client=1&s", "tate=y"].join("\n");
+    const logical = ["echo https://a.dev/auth?client=1&state=y", "https://a.dev/auth?client=1&state=y"].join("\n");
+    expect(findLinks(grid, logical).map((l) => l.href)).toEqual([
+      "https://a.dev/auth?client=1&state=y",
+      "https://a.dev/auth?client=1&state=y",
+      "https://a.dev/auth?client=1&state=y",
+      "https://a.dev/auth?client=1&state=y",
+    ]);
+  });
+});

--- a/web/src/lib/links.ts
+++ b/web/src/lib/links.ts
@@ -92,8 +92,18 @@ const HAS_HOST = /^https?:\/\/[a-z0-9]/i;
  * stops at the newline, and stitching wrapped lines back together would mean knowing the pane's
  * column width and guessing which breaks were soft. A half-URL that opens the right host beats a
  * wrong URL assembled from two unrelated lines.
+ *
+ * `logicalText` — the same pane read with soft wraps undone (`herdr`'s `recent_unwrapped`) — turns
+ * that guess into a check, and the caller that has it should pass it. See `repairWrapped`.
  */
-export function findLinks(text: string): LinkMatch[] {
+export function findLinks(text: string, logicalText?: string): LinkMatch[] {
+  const found = scanLinks(text);
+  if (logicalText === undefined || logicalText === "") return found;
+  return repairWrapped(found, text, scanLinks(logicalText));
+}
+
+/** The scan itself: every http(s) URL one string of text carries, per the rules above. */
+function scanLinks(text: string): LinkMatch[] {
   const links: LinkMatch[] = [];
   URL_SCAN.lastIndex = 0;
   for (;;) {
@@ -104,4 +114,78 @@ export function findLinks(text: string): LinkMatch[] {
     links.push({ start: m.index, end: m.index + href.length, href });
   }
   return links;
+}
+
+/**
+ * Does the line this fragment sits on end right here? Herdr's own reads terminate a row with `\r\n`;
+ * a bare `\n` is what a joined-lines fixture looks like anywhere else.
+ */
+function atLineEnd(text: string, at: number): boolean {
+  return text[at] === "\n" || (text[at] === "\r" && text[at + 1] === "\n");
+}
+
+/**
+ * Pair the grid's URL fragments with the URLs the pane's logical text carries.
+ *
+ * The mirror renders the *grid*, so a URL longer than the pane is cut at the column edge and the
+ * scan finds a fragment whose href is a prefix of the real one — an anchor that opens a truncated
+ * URL, with the rest of the URL as inert text. The logical read has the URL whole, which makes the
+ * pairing exact rather than a guess:
+ *
+ *   · a fragment is considered only when it runs to the END OF ITS LINE — nothing but the row
+ *     terminator after it (`\n`, or Herdr's own `\r\n`). A fragment the scan stopped at a delimiter
+ *     for ended there for real, and nothing continues it;
+ *   · the fragment must be a prefix of exactly ONE URL in the logical text (duplicates of the same
+ *     URL — a typed command and its output — count as one), so two DIFFERENT candidates leave the
+ *     link alone instead of picking one;
+ *   · and the URL is adopted only when its remainder is FOUND in the following lines, compared
+ *     character by character from column 0. A complete URL that merely happens to prefix a longer
+ *     one elsewhere in the scrollback has no continuation to show, so it keeps its own href.
+ *
+ * The continuation fragments become ranges of their own with the same href, so the whole URL is one
+ * tap target across however many rows it occupies. Fragments keep their own characters — this
+ * changes hrefs and adds ranges, never the text.
+ */
+function repairWrapped(found: LinkMatch[], text: string, logical: LinkMatch[]): LinkMatch[] {
+  if (logical.length === 0) return found;
+  // A Set, because the same URL is commonly on screen twice (a typed command and its output): that is
+  // one URL to adopt, not an ambiguity to refuse.
+  const candidates = [...new Set(logical.map((l) => l.href))];
+  const repaired: LinkMatch[] = [];
+
+  for (const link of found) {
+    if (!atLineEnd(text, link.end)) {
+      repaired.push(link);
+      continue;
+    }
+    const full = candidates.filter((href) => href.length > link.href.length && href.startsWith(link.href));
+    if (full.length !== 1) {
+      repaired.push(link);
+      continue;
+    }
+    const href = full[0]!;
+
+    const rest: LinkMatch[] = [];
+    let consumed = link.href.length;
+    let cursor = link.end;
+    while (consumed < href.length) {
+      if (text[cursor] === "\r") cursor += 1; // Herdr terminates a row with CR before the LF
+      if (text[cursor] !== "\n") break;
+      const lineStart = cursor + 1;
+      const lineEnd = text.indexOf("\n", lineStart);
+      const line = text.slice(lineStart, lineEnd === -1 ? text.length : lineEnd);
+      const want = href.slice(consumed, consumed + line.length);
+      if (want.length === 0 || !line.startsWith(want)) break;
+      rest.push({ start: lineStart, end: lineStart + want.length, href });
+      consumed += want.length;
+      cursor = lineStart + want.length;
+    }
+    if (rest.length === 0) {
+      repaired.push(link);
+      continue;
+    }
+    repaired.push({ ...link, href }, ...rest);
+  }
+
+  return repaired.toSorted((a, b) => a.start - b.start);
 }

--- a/web/src/lib/loaders.ts
+++ b/web/src/lib/loaders.ts
@@ -156,6 +156,10 @@ export interface PaneData {
   text: string;
   /** True when the buffer was cut off at the requested line count — older scrollback still exists. */
   truncated: boolean;
+  /** The same rows with soft wraps undone, when the bridge found a URL the pane split — the mirror
+   * hands it to the autolinker so a wrapped URL is one whole link instead of a truncated first
+   * fragment. Absent on every pane that needs no repair. */
+  logicalText?: string;
   /** The scrollback window this result was fetched with — lets the UI tell a grown fetch from a
    * stale in-flight poll (a "Load older" tap raises this; see growRequestedLines). */
   requestedLines: number;
@@ -481,6 +485,7 @@ export async function paneLoader({
       scope,
       text,
       truncated: read.truncated,
+      logicalText: read.logicalText,
       requestedLines: lines,
       revision: read.revision,
       error: false,

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -687,6 +687,12 @@ export interface PaneReadResponse {
   truncated: boolean;
   /** Herdr's monotonic pane revision — the prompt-select race guard checks a tapped menu against it. */
   revision: number;
+  /**
+   * The same rows with soft wraps undone, sent only when {@link text} shows a URL the pane's column
+   * edge cut in two. `lib/links.ts` uses it to give every fragment of that URL the href of the whole
+   * URL; absent for every other pane.
+   */
+  logicalText?: string;
   /** Set to true by the client when the server returns 304 Not Modified. Never sent over the wire. */
   notModified?: boolean;
 }

--- a/web/src/routes/detail.tsx
+++ b/web/src/routes/detail.tsx
@@ -91,6 +91,7 @@ export function DetailRoute() {
       tabs={root.tabs}
       tabLabel={tabLabel}
       text={pane.text}
+      logicalText={pane.logicalText}
       requestedLines={pane.requestedLines}
       revision={pane.revision}
       device={root.device}


### PR DESCRIPTION
## The problem

A URL longer than the pane arrives cut at the column edge, because the mirror renders the grid. `web/src/lib/links.ts` scans one line at a time and deliberately does not stitch hard-wrapped fragments, so only the first fragment becomes an anchor — and that anchor's href is truncated mid-URL. The rest of the URL is inert text.

`gcloud auth login --no-launch-browser` is the everyday case: its consent URL is ~300 characters on a 120-column pane, so the one link the operator needs to open is the one link that cannot be opened.

Measured against a live herdr 0.9.0 server (a shell pane, 120 columns, that URL printed into it), same browser, same pane, same request:

| | anchors on the URL | href |
|---|---|---|
| installed 1.8.1 | 2 | 103 and 120 chars — both truncated |
| this branch | 6 | one distinct href, 288 chars — the whole URL |

## The fix

Two halves, because only one of them can know the whole URL.

**Bridge.** herdr can hand over the same rows with soft wraps undone (`recent_unwrapped`). When the grid it already has shows a URL touching a line end (`hasSplitUrl`, so every other pane pays nothing), the bridge asks for that read, strips the SGR (`stripSgr`), and sends it as `PaneReadResponse.logicalText`. One extra read, on the panes that show a split, with the same `lines` and — deliberately — the same `ansi` format as the mirror read: the observation that keeps that read from harvesting is the one the mirror already rests on, and there is nothing else to lean on here.

**Client.** `findLinks(text, logicalText?)` pairs the fragments with the URLs in that text by checking, not guessing:

- a fragment counts only when nothing but the row terminator follows it (`\n`, or herdr's own `\r\n`);
- it must be a prefix of exactly ONE URL there — duplicates of the same URL (a typed command and its output, which is how this was found) count as one;
- the URL is adopted only when its remainder is found character for character in the following rows, so a complete URL that merely prefixes a longer one elsewhere in the scrollback keeps its own href.

Adopted URLs give every fragment the same full href, so the whole URL is one tap target across however many rows it occupies. Fragments keep their own characters — this changes hrefs and adds ranges, never the text. Anything that fails a check keeps today's behaviour exactly, which is what the existing "stops at a newline" case still pins.

Two seams worth pointing at for review:

- `readLogicalText` is the first OPTIONAL method on `MuxAdapter`. Both decorators carry it the way `muxDataFields` carries `logo` (a `muxOptionalMethods` sibling, so an adapter that cannot unwrap never comes out of a decorator appearing to offer it), and `bridge/beacon/decorate.test.ts` names it in its contract fixture with cases for presence, absence and pass-through.
- herdr terminates a row with `\r` — that is why the fragment's href above is 103 rather than 120 — so both the gate and the repair treat `\r\n` as the row terminator.

## Coverage

- `web/src/lib/links.test.ts` — the repair rules: a fragment not at a line end, two different candidates, an unverified continuation, a three-row URL, CR-terminated rows, and the same URL appearing twice.
- `web/src/components/ansi-output.test.tsx` — the rendered mirror: every fragment of the wrapped URL carries the whole href, the rows are still exactly what the terminal printed, and the no-`logicalText` fallback is unchanged.
- `bridge/server.test.ts` — `hasSplitUrl` (styling, padding, CR, trailing prose, no URL), `paneReadResponse` with and without the field, and `readPane` issuing the extra read only when the grid shows a split.
- Checks: `bun run lint`, root and web `typecheck`, `bun test ./cli` (1405 pass, 0 fail), and the bridge files this touches — `bun test ./bridge/server.test.ts ./bridge/beacon/decorate.test.ts` (241 pass, 0 fail) — all pass.

Two things about running these locally, both pre-existing and neither related to the branch, in case CI sees them too: the web suite reports 150 failures here with an identical count before and after (localStorage under this Bun + jsdom combination), and a whole-directory `bun test ./bridge` never terminates on this machine because `bridge/stt/codex.test.ts` hangs — it hangs the same way at the release commit in a clean worktree, which is why the affected files were run directly.

## Changelog

Per CONTRIBUTING (from a fork: no version bumps), a line for `## [Unreleased]`:

> **A URL the pane wrapped is one whole link again.** The mirror renders the grid, so a URL longer than the pane was cut at the column edge — only its first fragment became a link, and that link opened a truncated URL. The bridge now fetches the same rows with soft wraps undone when the grid shows a split, and the mirror gives every fragment of that URL the href of the whole URL.
